### PR TITLE
fix: enables warnings as errors and -Wswitch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,12 @@ target_link_libraries(${PROJECT_NAME}
     -static-libstdc++
 )
 
+target_compile_options(${PROJECT_NAME}
+  PRIVATE
+    "-Werror"
+    "-Wswitch" # Part of -Wall, but that options gives too many warnings at this time
+)
+
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> $<TARGET_FILE_DIR:${PROJECT_NAME}>
   COMMAND_EXPAND_LISTS

--- a/controls/cGameControlsContext.cpp
+++ b/controls/cGameControlsContext.cpp
@@ -136,9 +136,7 @@ void cGameControlsContext::onMouseAt(const s_MouseEvent &event) {
 }
 
 void cGameControlsContext::onNotify(const s_MouseEvent &event) {
-    switch (event.eventType) {
-        case eMouseEventType::MOUSE_MOVED_TO:
-            onMouseAt(event);
-            return;
-    }
+  if (event.eventType == eMouseEventType::MOUSE_MOVED_TO) {
+      onMouseAt(event);
+  }
 }

--- a/drawers/cMiniMapDrawer.cpp
+++ b/drawers/cMiniMapDrawer.cpp
@@ -379,6 +379,8 @@ void cMiniMapDrawer::onNotify(const s_MouseEvent &event) {
         case eMouseEventType::MOUSE_LEFT_BUTTON_PRESSED:
             onMousePressedLeft(event);
             return;
+        default:
+            return;
     }
 
 }

--- a/drawers/cMouseDrawer.cpp
+++ b/drawers/cMouseDrawer.cpp
@@ -248,9 +248,7 @@ void cMouseDrawer::onMouseAt(const s_MouseEvent &event) {
 }
 
 void cMouseDrawer::onNotify(const s_MouseEvent &event) {
-    switch (event.eventType) {
-        case eMouseEventType::MOUSE_MOVED_TO:
-            onMouseAt(event);
-            return;
+    if (event.eventType == eMouseEventType::MOUSE_MOVED_TO) {
+        onMouseAt(event);
     }
 }

--- a/drawers/cOrderDrawer.cpp
+++ b/drawers/cOrderDrawer.cpp
@@ -84,6 +84,8 @@ void cOrderDrawer::onNotify(const s_MouseEvent &event) {
         case eMouseEventType::MOUSE_LEFT_BUTTON_CLICKED:
             onMouseClickedLeft(event);
             return;
+        default:
+            return;
     }
 }
 

--- a/drawers/cPlaceItDrawer.cpp
+++ b/drawers/cPlaceItDrawer.cpp
@@ -231,9 +231,7 @@ void cPlaceItDrawer::onMouseClickedLeft(const s_MouseEvent &event) {
 }
 
 void cPlaceItDrawer::onNotify(const s_MouseEvent &event) {
-    switch (event.eventType) {
-        case eMouseEventType::MOUSE_LEFT_BUTTON_CLICKED:
-            onMouseClickedLeft(event);
-            return;
+    if (event.eventType == eMouseEventType::MOUSE_LEFT_BUTTON_CLICKED) {
+        onMouseClickedLeft(event);
     }
 }

--- a/gameobjects/structures/cHighTech.cpp
+++ b/gameobjects/structures/cHighTech.cpp
@@ -46,6 +46,8 @@ void cHighTech::think_animation_unitDeploy() {
                     setAnimating(false);
                 }
                 break;
+            default:
+                break;
         }
 
         TIMER_flag = 0;

--- a/gameobjects/structures/cRepairFacility.cpp
+++ b/gameobjects/structures/cRepairFacility.cpp
@@ -98,6 +98,8 @@ void cRepairFacility::think_animation_unitDeploy() {
                     setAnimating(false);
                 }
                 break;
+            default:
+                break;
         }
 
         TIMER_flag = 0;

--- a/gameobjects/units/cUnit.cpp
+++ b/gameobjects/units/cUnit.cpp
@@ -4098,19 +4098,19 @@ int UNIT_find_harvest_spot(int id) {
  * @param iStart where to start from
 
  */
-int REINFORCE(int iPlr, int iTpe, int iCll, int iStart) {
-   return REINFORCE(iPlr, iTpe, iCll, iStart, true);
+void REINFORCE(int iPlr, int iTpe, int iCll, int iStart) {
+   REINFORCE(iPlr, iTpe, iCll, iStart, true);
 }
 
-int REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement) {
+void REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement) {
 
     // handle invalid arguments
     if (iPlr < 0 || iTpe < 0)
-        return -1;
+        return;
 
     //if (iCll < 0 || iCll >= MAX_CELLS)
     if (map.isValidCell(iCll) == false)
-        return -1;
+        return;
 
     if (iStart < 0)
         iStart = iCll;
@@ -4127,7 +4127,7 @@ int REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement) {
 
     if (iStartCell < 0) {
         logbook("ERROR (reinforce): Could not figure a startcell");
-        return -1;
+        return;
     }
 
     char msg[255];
@@ -4139,7 +4139,7 @@ int REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement) {
     if (iUnit < 0) {
         // cannot create carry-all!
         logbook("ERROR (reinforce): Cannot create CARRYALL unit.");
-        return -1;
+        return;
     }
 
     // STEP 3: assign order to carryall

--- a/gameobjects/units/cUnit.h
+++ b/gameobjects/units/cUnit.h
@@ -462,7 +462,7 @@ int UNIT_CREATE(int iCll, int unitType, int iPlayer, bool bOnStart, bool isReinf
 
 int CREATE_PATH(int iUnitId, int iPathCountUnits);
 
-int REINFORCE(int iPlr, int iTpe, int iCll, int iStart);
+void REINFORCE(int iPlr, int iTpe, int iCll, int iStart);
 
 /**
  * Allows overriding reinforcement flag, ie used when a unit is reinforced by construction or other way, rather
@@ -473,7 +473,7 @@ int REINFORCE(int iPlr, int iTpe, int iCll, int iStart);
  * @param iStart
  * @param isReinforcement
  */
-int REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement);
+void REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement);
 
 int RETURN_CLOSE_GOAL(int iCll, int iMyCell, int iID);
 

--- a/gamestates/cChooseHouseGameState.cpp
+++ b/gamestates/cChooseHouseGameState.cpp
@@ -84,6 +84,8 @@ void cChooseHouseGameState::onNotifyMouseEvent(const s_MouseEvent &event) {
         case MOUSE_MOVED_TO:
             onMouseMoved(event);
             break;
+        default:
+            break;
     }
 }
 

--- a/gamestates/cSelectYourNextConquestState.cpp
+++ b/gamestates/cSelectYourNextConquestState.cpp
@@ -574,6 +574,9 @@ void cSelectYourNextConquestState::onNotifyMouseEvent(const s_MouseEvent &event)
             break;
         case MOUSE_LEFT_BUTTON_CLICKED:
             onMouseLeftButtonClicked(event);
+            break;
+        default:
+            break;
     }
 }
 

--- a/gamestates/cSetupSkirmishGameState.cpp
+++ b/gamestates/cSetupSkirmishGameState.cpp
@@ -681,6 +681,8 @@ void cSetupSkirmishGameState::onNotifyMouseEvent(const s_MouseEvent &event) {
         case MOUSE_MOVED_TO:
             onMouseMovedTo(event);
             break;
+        default:
+            break;
     }
 
     backButton->onNotifyMouseEvent(event);

--- a/gui/cGuiButton.cpp
+++ b/gui/cGuiButton.cpp
@@ -146,6 +146,8 @@ void cGuiButton::onNotifyMouseEvent(const s_MouseEvent &event) {
         case MOUSE_LEFT_BUTTON_PRESSED:
             onMouseLeftButtonPressed(event);
             break;
+        default:
+            break;
     }
 }
 

--- a/managers/cInteractionManager.cpp
+++ b/managers/cInteractionManager.cpp
@@ -76,6 +76,8 @@ void cInteractionManager::onNotifyMouseEvent(const s_MouseEvent &mouseEvent) {
         case eMouseEventType::MOUSE_RIGHT_BUTTON_CLICKED:
             onMouseClickedRight(mouseEvent);
             break;
+        default:
+            break;
     }
 
     // now call all its other interested listeners

--- a/map/cMap.cpp
+++ b/map/cMap.cpp
@@ -1401,6 +1401,8 @@ void cMap::onNotify(const s_GameEvent &event) {
         case eGameEventType::GAME_EVENT_CREATED:
             onEntityCreated(event);
             break;
+        default:
+            break;
     }
 }
 

--- a/map/cMapCamera.cpp
+++ b/map/cMapCamera.cpp
@@ -227,6 +227,8 @@ void cMapCamera::onNotify(const s_MouseEvent &event) {
         case eMouseEventType::MOUSE_SCROLLED_UP:
             mapCamera->zoomIn();
             return;
+        default:
+            return;
     }
 
 }

--- a/player/brains/cPlayerBrainCampaign.cpp
+++ b/player/brains/cPlayerBrainCampaign.cpp
@@ -126,6 +126,8 @@ namespace brains {
                         onMyStructureDecayed(event);
                         // should repair when under 75%?
                         break;
+                    default:
+                        break;
                 }
             }
         }

--- a/player/brains/cPlayerBrainSkirmish.cpp
+++ b/player/brains/cPlayerBrainSkirmish.cpp
@@ -133,6 +133,8 @@ namespace brains {
                         onMyStructureDecayed(event);
                         // should repair when under 75%?
                         break;
+                    default:
+                        break;
                 }
             }
         }
@@ -1183,44 +1185,49 @@ namespace brains {
 
         // can build it?
         eCantBuildReason reason = player->canBuildStructure(structureIWantToBuild);
-        if (reason != eCantBuildReason::NONE) {
-            // there is a reason why we cannot build it
-            switch (reason) {
-                case REQUIRES_UPGRADE:
-                    // build the upgrade instead
-                    if (structureIWantToBuild == RTURRET) {
-                        // upgrade ...
-                        cBuildingListItem *pItem = player->isUpgradeAvailableToGrantStructure(RTURRET);
-                        if (!pItem) {
-                            // we first need to upgrade to SLAB4 before we can upgrade to RTURRET
-                            pItem = player->isUpgradeAvailableToGrantStructure(SLAB4);
-                        }
-
-                        if (pItem != nullptr) {
-                            // we have something to upgrade
-                            if (!player->startUpgrading(pItem->getBuildId())) {
-                                // failed to build upgrade.
-                            } else {
-                                // we should wait a bit before re-evaluating base building
-                            }
-                        }
-
-                        // in both cases, we should first wait, so return -1 anyways
-                        return -1;
-                    } else if (structureIWantToBuild == SLAB4) {
-
+        switch (reason) {
+            case NONE:
+                // We can build. Carry on.
+                break;
+            case REQUIRES_UPGRADE:
+                // build the upgrade instead
+                if (structureIWantToBuild == RTURRET) {
+                    // upgrade ...
+                    cBuildingListItem *pItem = player->isUpgradeAvailableToGrantStructure(RTURRET);
+                    if (!pItem) {
+                        // we first need to upgrade to SLAB4 before we can upgrade to RTURRET
+                        pItem = player->isUpgradeAvailableToGrantStructure(SLAB4);
                     }
-                    break;
-                case REQUIRES_STRUCTURE:
-                    // update state, we don't have a constyard anymore!
-                    break;
-                case NOT_ENOUGH_MONEY:
-                    // economy is bad? set state for that
-                    break;
-                case ALREADY_BUILDING:
-                    // already building something, so don't return any id to build
+
+                    if (pItem != nullptr) {
+                        // we have something to upgrade
+                        if (!player->startUpgrading(pItem->getBuildId())) {
+                            // failed to build upgrade.
+                        } else {
+                            // we should wait a bit before re-evaluating base building
+                        }
+                    }
+
+                    // in both cases, we should first wait, so return -1 anyways
                     return -1;
-            }
+                } else if (structureIWantToBuild == SLAB4) {
+
+                }
+                break;
+            case REQUIRES_STRUCTURE:
+                // update state, we don't have a constyard anymore!
+                break;
+            case REQUIRES_ADDITIONAL_STRUCTURE:
+                break;
+            case NOT_ENOUGH_MONEY:
+                // economy is bad? set state for that
+                break;
+            case ALREADY_BUILDING:
+                // already building something, so don't return any id to build
+                return -1;
+            case NOT_AVAILABLE:
+                // The building is not available
+                return -1;
         }
 
         return structureIWantToBuild;

--- a/player/brains/missions/cPlayerBrainMission.cpp
+++ b/player/brains/missions/cPlayerBrainMission.cpp
@@ -54,6 +54,12 @@ namespace brains {
             case PLAYERBRAINMISSION_KIND_EXPLORE:
                 missionKind = new cPlayerBrainMissionKindExplore(player, this);
                 break;
+            case PLAYERBRAINMISSION_IMPROVE_ECONOMY:
+            case PLAYERBRAINMISSION_KIND_FIND_SPICE:
+            case PLAYERBRAINMISSION_KIND_AIRSTRIKE:
+            case PLAYERBRAINMISSION_KIND_HARASS:
+                // TODO
+                break;
         }
 
         char msg[255];
@@ -124,6 +130,8 @@ namespace brains {
                 break;
             case GAME_EVENT_DEVIATED:
                 onEventDeviated(event);
+                break;
+            default:
                 break;
         }
 

--- a/player/brains/missions/cPlayerBrainMissionKindAttack.cpp
+++ b/player/brains/missions/cPlayerBrainMissionKindAttack.cpp
@@ -114,6 +114,8 @@ namespace brains {
             case GAME_EVENT_DEVIATED:
                 onEventDeviated(event);
                 break;
+            default:
+                break;
         }
     }
 

--- a/player/brains/missions/cPlayerBrainMissionKindDeathHand.cpp
+++ b/player/brains/missions/cPlayerBrainMissionKindDeathHand.cpp
@@ -84,11 +84,8 @@ namespace brains {
         sprintf(msg, "cPlayerBrainMissionKindDeathHand::onNotify() -> %s", event.toString(event.eventType));
         log(msg);
 
-
-        switch(event.eventType) {
-            case eGameEventType::GAME_EVENT_LIST_ITEM_CANCELLED:
-                onBuildItemCancelled(event);
-                break;
+        if (event.eventType == eGameEventType::GAME_EVENT_LIST_ITEM_CANCELLED) {
+            onBuildItemCancelled(event);
         }
     }
 

--- a/player/brains/missions/cPlayerBrainMissionKindSaboteur.cpp
+++ b/player/brains/missions/cPlayerBrainMissionKindSaboteur.cpp
@@ -63,10 +63,8 @@ namespace brains {
         sprintf(msg, "cPlayerBrainMissionKindSaboteur::onNotify() -> %s", event.toString(event.eventType));
         log(msg);
 
-        switch(event.eventType) {
-            case GAME_EVENT_DESTROYED:
-                onEventDestroyed(event);
-                break;
+        if (event.eventType == GAME_EVENT_DESTROYED) {
+          onEventDestroyed(event);
         }
     }
 

--- a/player/cPlayerNotification.cpp
+++ b/player/cPlayerNotification.cpp
@@ -28,4 +28,5 @@ int cPlayerNotification::getColor() {
         case BAD:
             return justStarted ? game.getColorFadeSelected(badColor) : badColor;
     }
+    return 0;
 }

--- a/sidebar/cBuildingListItem.cpp
+++ b/sidebar/cBuildingListItem.cpp
@@ -325,17 +325,18 @@ const int cBuildingListItem::getListId(eBuildType type, int buildId) {
 //            return sUpgradeInfo[buildId].;
             return LIST_UPGRADES;
             break;
+        default:
+            return -1;
     }
-    return -1;
 }
 
 const bool cBuildingListItem::isAutoBuild(eBuildType type, int buildId) {
     switch (type) {
         case SPECIAL:
             return sSpecialInfo[buildId].autoBuild;
-            break;
+        default:
+            return false;
     }
-    return false;
 }
 
 bool cBuildingListItem::isAutoBuild() {

--- a/sidebar/cSideBar.cpp
+++ b/sidebar/cSideBar.cpp
@@ -265,10 +265,8 @@ void cSideBar::onNotifyMouseEvent(const s_MouseEvent &event) {
 
     if (!pContext->isMouseOnSidebarOrMinimap()) {
         // we're only interested in mouse movement
-        switch (event.eventType) {
-            case eMouseEventType::MOUSE_MOVED_TO:
-                onMouseAt(event);
-                return;
+        if (event.eventType == eMouseEventType::MOUSE_MOVED_TO) {
+            onMouseAt(event);
         }
         return;
     }
@@ -282,6 +280,8 @@ void cSideBar::onNotifyMouseEvent(const s_MouseEvent &event) {
             return;
         case eMouseEventType::MOUSE_RIGHT_BUTTON_CLICKED:
             onMouseClickedRight(event);
+            return;
+        default:
             return;
     }
 }

--- a/utils/cLog.cpp
+++ b/utils/cLog.cpp
@@ -54,6 +54,10 @@ std::string cLogger::getLogComponentString(eLogComponent component) {
 			return std::string("BULLET");
 		case COMP_AI:
 			return std::string("AI");
+    case COMP_UPGRADE_LIST:
+      return std::string("UPGRADE_LIST");
+	  case COMP_BUILDING_LIST_UPDATER:
+      return std::string("BUILDING_LIST_UPDATER");
 		case COMP_MAP:
 			return std::string("MAP");
 		case COMP_SIDEBAR:
@@ -89,8 +93,12 @@ std::string cLogger::getLogOutcomeString(eLogOutcome outcome) {
 			return std::string("FAILED");
 		case OUTC_NONE:
 			return std::string("NONE");
+	  case OUTC_UNKNOWN:
+      break;
+	  case OUTC_IGNOREME:
+      break;
 	}
-	return std::string("UNIDENTIFIED");
+ 	return std::string("UNIDENTIFIED");
 }
 
 std::string cLogger::getLogHouseString(int houseId) {


### PR DESCRIPTION
We can enable additional checks by the compiler and not have the same errors creep back in by enabling more warnings and setting warnings as errors. I tried enabling -Wall (there are even more with -Wextra and -Wpedantic), but the amount of warnings were too great to fix in one PR. So I picked the one that warns for missing switch cases, which seemed useful given the C-style of most of the code. In almost all places, fallthrough was perfectly fine, so adding a default solved that. For the switches with only one case, I just made an if statement out of it.

It did find a bug in the logger, where two components were not printed.