### PR TITLE
fix: initializes members in classes in the same order as they are declared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ target_compile_options(${PROJECT_NAME}
   PRIVATE
     "-Werror"
     "-Wswitch" # Part of -Wall, but that options gives too many warnings at this time
+    "-Wreorder" # Part of -Wall
 )
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD

--- a/gameobjects/cFlag.cpp
+++ b/gameobjects/cFlag.cpp
@@ -1,12 +1,14 @@
 #include "d2tmh.h"
 
 
-cFlag::cFlag(cPlayer *player, cPoint &absCoords, int frames, int animationDelay) :
-        player(player), absCoords(absCoords),
-        frames(frames), animationDelay(animationDelay) {
-    TIMER_animate = 0;
-    frame = 0;
-    big = true;
+cFlag::cFlag(cPlayer *player, cPoint &absCoords, int frames, int animationDelay)
+  : absCoords(absCoords)
+  , player(player)
+  , TIMER_animate(0)
+  , big(true)
+  , animationDelay(animationDelay)
+  , frames(frames)
+  , frame(0) {
 }
 
 void cFlag::draw() {

--- a/gameobjects/cFlag.h
+++ b/gameobjects/cFlag.h
@@ -29,7 +29,6 @@ private:
 
     // move to 'type object' later (ie flag definitions)
     int animationDelay;
-    int frameHeight;
     int frames; // max amount of frames
 
     int frame;  // frame to draw

--- a/gamestates/cOptionsState.cpp
+++ b/gamestates/cOptionsState.cpp
@@ -1,9 +1,10 @@
 #include "d2tmh.h"
 
-cOptionsState::cOptionsState(cGame &theGame, BITMAP *background, int prevState) : cGameState(theGame),
-                                                                                  textDrawer(cTextDrawer(bene_font)),
-                                                                                  prevState(prevState),
-                                                                                  background(background) {
+cOptionsState::cOptionsState(cGame &theGame, BITMAP *background, int prevState)
+  : cGameState(theGame)
+  ,  background(background)
+  ,  prevState(prevState)
+  ,  textDrawer(cTextDrawer(bene_font)) {
     int margin = game.screen_y * 0.3;
     int mainMenuFrameX = margin;
     int mainMenuFrameY = margin;

--- a/gui/cGuiButton.cpp
+++ b/gui/cGuiButton.cpp
@@ -1,34 +1,34 @@
 #include "d2tmh.h"
 
-cGuiButton::cGuiButton(const cTextDrawer &textDrawer, const cRectangle &rect, const std::string & btnText) : textDrawer(
-        textDrawer), rect(rect), btnText(btnText) {
-    gui_colorButton = makecol(176, 176, 196);
-    gui_colorBorderDark = makecol(84, 84, 120);
-    gui_colorBorderLight = makecol(252, 252, 252);
-    focus = false;
-    pressed = false;
-    enabled = true; // by default always enabled
-    renderKind = eGuiButtonRenderKind::OPAQUE_WITHOUT_BORDER;
-    textAlignHorizontal = eGuiTextAlignHorizontal::CENTER;
-    text_color = makecol(255, 255, 255); // default white color
-    text_colorHover = makecol(255, 0, 0);
-    onLeftMouseButtonClicked_action = nullptr;
-}
+cGuiButton::cGuiButton(const cTextDrawer &textDrawer, const cRectangle &rect, const std::string & btnText)
+  : rect(rect)
+  , textDrawer(textDrawer)
+  , btnText(btnText)
+  , renderKind(eGuiButtonRenderKind::OPAQUE_WITHOUT_BORDER)
+  , textAlignHorizontal(eGuiTextAlignHorizontal::CENTER)
+  , onLeftMouseButtonClicked_action(nullptr)
+  , focus(false)
+  , gui_colorButton(makecol(176, 176, 196))
+  , gui_colorBorderLight(makecol(252, 252, 252))
+  , gui_colorBorderDark(makecol(84, 84, 120))
+  , text_color(makecol(255, 255, 255)) // default white color
+  , text_colorHover(makecol(255, 0, 0))
+  , pressed(false)
+  , enabled(true) { // by default always enabled
+ }
 
 cGuiButton::cGuiButton(const cTextDrawer &textDrawer, const cRectangle &rect, const std::string &btnText,
-                       eGuiButtonRenderKind renderKind) : cGuiButton(textDrawer, rect, btnText) {
+                       eGuiButtonRenderKind renderKind)
+  : cGuiButton(textDrawer, rect, btnText) {
     this->renderKind = renderKind;
-    onLeftMouseButtonClicked_action = nullptr;
 }
 
 cGuiButton::cGuiButton(const cTextDrawer &textDrawer, const cRectangle &rect, const std::string &btnText, int gui_colorButton,
-                       int gui_colorBorderLight,
-                       int gui_colorBorderDark) : cGuiButton(textDrawer, rect, btnText) {
-    focus = false;
+                       int gui_colorBorderLight, int gui_colorBorderDark)
+  : cGuiButton(textDrawer, rect, btnText) {
     this->gui_colorButton = gui_colorButton;
     this->gui_colorBorderLight = gui_colorBorderLight;
     this->gui_colorBorderDark = gui_colorBorderDark;
-    onLeftMouseButtonClicked_action = nullptr;
 }
 
 cGuiButton::~cGuiButton() {

--- a/player/brains/missions/cPlayerBrainMission.cpp
+++ b/player/brains/missions/cPlayerBrainMission.cpp
@@ -10,25 +10,23 @@
 #include "cPlayerBrainMissionKindFremen.h"
 #include "cPlayerBrainMission.h"
 
-
 namespace brains {
 
     cPlayerBrainMission::cPlayerBrainMission(cPlayer *player, const ePlayerBrainMissionKind &kind,
                                              cPlayerBrain *brain, std::vector<S_groupKind> group,
-                                             int initialDelay, int uniqueId) :
-                                             player(player),
-                                             kind(kind),
-                                             state(ePlayerBrainMissionState::PLAYERBRAINMISSION_STATE_INITIAL_DELAY),
-                                             brain(brain),
-                                             group(group),
-                                             TIMER_delay(initialDelay),
-                                             uniqueIdentifier(uniqueId) {
-        units = std::vector<int>();
-        TIMER_awaitingGatheringResoures = -1;
-        missionKind = nullptr;
-        specialEventMakesStateSwitchToSelectTarget = false;
-        missionWithUnits = true; // by default, the missions are executed with units
-
+                                             int initialDelay, int uniqueId)
+      : TIMER_delay(initialDelay)
+      , TIMER_awaitingGatheringResoures(-1)
+      , uniqueIdentifier(uniqueId)
+      , player(player)
+      , kind(kind)
+      , missionKind(nullptr)
+      , brain(brain)
+      , state(ePlayerBrainMissionState::PLAYERBRAINMISSION_STATE_INITIAL_DELAY)
+      , specialEventMakesStateSwitchToSelectTarget(false)
+      , missionWithUnits(true) // by default, the missions are executed with units
+      , units()
+      , group(group) {
         switch (kind) {
             case PLAYERBRAINMISSION_KIND_ATTACK:
                 missionKind = new cPlayerBrainMissionKindAttack(player, this);
@@ -593,22 +591,21 @@ namespace brains {
     }
 
     cPlayerBrainMission::cPlayerBrainMission(const cPlayerBrainMission &src) :
-        player(src.player),
-        state(src.state),
-        uniqueIdentifier(src.uniqueIdentifier),
-        units(src.units),
-        group(src.group),
-        brain(src.brain),
-        kind(src.kind),
         TIMER_delay(src.TIMER_delay),
         TIMER_awaitingGatheringResoures(src.TIMER_awaitingGatheringResoures),
+        uniqueIdentifier(src.uniqueIdentifier),
+        player(src.player),
+        kind(src.kind),
+        missionKind(nullptr),
+        brain(src.brain),
+        state(src.state),
+        specialEventMakesStateSwitchToSelectTarget(src.specialEventMakesStateSwitchToSelectTarget),
         missionWithUnits(src.missionWithUnits),
-        specialEventMakesStateSwitchToSelectTarget(src.specialEventMakesStateSwitchToSelectTarget)
+        units(src.units),
+        group(src.group)
     {
         if (src.missionKind) {
             missionKind = src.missionKind->clone(src.player, this);
-        } else {
-            missionKind = nullptr;
         }
     }
 

--- a/utils/cRectangle.cpp
+++ b/utils/cRectangle.cpp
@@ -1,9 +1,5 @@
 #include "cRectangle.h"
 
-cRectangle::~cRectangle() {
-
-}
-
 /**
  * scans each edge of the rectangle if it is within the other rectangle, returns true if so, or false if not.
  * @param other

--- a/utils/cRectangle.h
+++ b/utils/cRectangle.h
@@ -7,13 +7,11 @@ class cRectangle {
 public:
     cRectangle();
 
-    cRectangle(int x, int y, int width, int height) : topLeft(cPoint(x,y)), height(height), width(width) {
+    cRectangle(int x, int y, int width, int height) : topLeft(cPoint(x,y)), width(width), height(height) {
     }
 
-    cRectangle(cPoint &coord, cPoint &dimensions) : topLeft(cPoint(coord.x, coord.y)), height(dimensions.x), width(dimensions.y) {
+    cRectangle(cPoint &coord, cPoint &dimensions) : topLeft(cPoint(coord.x, coord.y)), width(dimensions.y), height(dimensions.x) {
     }
-
-    ~cRectangle();
 
     static bool isWithin(int pointX, int pointY, int x, int y, int width, int height) {
         return (pointX >= x && pointX <= (x + width)) &&


### PR DESCRIPTION
One more step in the direction of -Wall.
Later, we can remove the separate -W<warning> flags and just go for -Wall.
I removed an unused member too.

We still have a different styles in how constructor parameter lists look. I think we can tackle that later using clang-format.