### PR TITLE
build: include what is used in cItemBuilder

### DIFF
--- a/building/cItemBuilder.cpp
+++ b/building/cItemBuilder.cpp
@@ -1,4 +1,24 @@
-#include "../include/d2tmh.h"
+#include "cItemBuilder.h"
+
+#include "data/gfxaudio.h"
+#include "d2tmc.h"
+#include "gameobjects/structures/cAbstractStructure.h"
+#include "gameobjects/units/cUnit.h"
+#include "player/cPlayer.h"
+#include "player/cPlayerDifficultySettings.h"
+#include "sGameEvent.h"
+#include "sidebar/cBuildingList.h"
+#include "sidebar/cBuildingListItem.h"
+#include "sidebar/cBuildingListUpdater.h"
+#include "structs.h"
+#include "utils/cLog.h"
+#include "utils/common.h"
+#include "utils/d2tm_math.h"
+
+#include <allegro/keyboard.h>
+
+#include <cassert>
+#include <string>
 
 cItemBuilder::cItemBuilder(cPlayer * thePlayer, cBuildingListUpdater * buildingListUpdater) {
 	assert(thePlayer);

--- a/building/cItemBuilder.cpp
+++ b/building/cItemBuilder.cpp
@@ -8,12 +8,11 @@
 #include "player/cPlayerDifficultySettings.h"
 #include "sGameEvent.h"
 #include "sidebar/cBuildingList.h"
-#include "sidebar/cBuildingListItem.h"
-#include "sidebar/cBuildingListUpdater.h"
 #include "structs.h"
 #include "utils/cLog.h"
 #include "utils/common.h"
 #include "utils/d2tm_math.h"
+
 
 #include <allegro/keyboard.h>
 

--- a/building/cItemBuilder.h
+++ b/building/cItemBuilder.h
@@ -4,9 +4,10 @@
 #include "definitions.h"
 #include "enums.h"
 
+#include "sidebar/cBuildingListItem.h"
+#include "sidebar/cBuildingListUpdater.h"
+
 class cPlayer;
-class cBuildingListUpdater;
-class cBuildingListItem;
 
 class cItemBuilder {
 

--- a/building/cItemBuilder.h
+++ b/building/cItemBuilder.h
@@ -1,8 +1,12 @@
 #ifndef CITEMBUILDER_H_
 #define CITEMBUILDER_H_
 
-// forward declaration
+#include "definitions.h"
+#include "enums.h"
+
 class cPlayer;
+class cBuildingListUpdater;
+class cBuildingListItem;
 
 class cItemBuilder {
 

--- a/cGame.h
+++ b/cGame.h
@@ -16,13 +16,13 @@
 #include <observers/cScenarioObserver.h>
 #include <data/cAllegroDataRepository.h>
 
-// forward declaration :/ sigh should really look into this
-class cRectangle;
 class cAbstractMentat;
-class cPlayer;
 class cGameControlsContext;
-class cInteractionManager;
 class cGameState;
+class cInteractionManager;
+class cPlayer;
+class cRectangle;
+class cSoundPlayer;
 
 class cGame : public cScenarioObserver, cMouseObserver {
 

--- a/cGame.h
+++ b/cGame.h
@@ -13,16 +13,16 @@
 #define D2TM_GAME_H
 
 #include <controls/cMouse.h>
-#include <observers/cScenarioObserver.h>
 #include <data/cAllegroDataRepository.h>
+#include <observers/cScenarioObserver.h>
+#include <utils/cRectangle.h>
+#include <utils/cSoundPlayer.h>
 
 class cAbstractMentat;
 class cGameControlsContext;
 class cGameState;
 class cInteractionManager;
 class cPlayer;
-class cRectangle;
-class cSoundPlayer;
 
 class cGame : public cScenarioObserver, cMouseObserver {
 

--- a/gameobjects/structures/cAbstractStructure.h
+++ b/gameobjects/structures/cAbstractStructure.h
@@ -18,14 +18,16 @@
 #ifndef CABSTRACTSTRUCTURE_H_
 #define CABSTRACTSTRUCTURE_H_
 
+#include <vector>
+
 #include "structs.h"
+#include "gameobjects/cFlag.h"
+
+#include <allegro/gfx.h>
 
 #include <vector>
 
-class cFlag;
 class cPlayer;
-
-struct BITMAP;
 
 class cAbstractStructure {
 

--- a/gameobjects/structures/cAbstractStructure.h
+++ b/gameobjects/structures/cAbstractStructure.h
@@ -18,6 +18,15 @@
 #ifndef CABSTRACTSTRUCTURE_H_
 #define CABSTRACTSTRUCTURE_H_
 
+#include "structs.h"
+
+#include <vector>
+
+class cFlag;
+class cPlayer;
+
+struct BITMAP;
+
 class cAbstractStructure {
 
 	private:

--- a/gameobjects/units/cUnit.h
+++ b/gameobjects/units/cUnit.h
@@ -13,8 +13,9 @@
 #ifndef D2TM_UNIT_H
 #define D2TM_UNIT_H
 
-#include <player/brains/missions/cPlayerBrainMission.h>
-#include <utils/cRectangle.h>
+#include "player/brains/missions/cPlayerBrainMission.h"
+#include "structs.h"
+#include "utils/cRectangle.h"
 
 // Define TRANSFER stuff for reinforcements
 

--- a/include/d2tmc.h
+++ b/include/d2tmc.h
@@ -18,6 +18,34 @@
 
 #ifndef D2TMC_H
 
+#include "cGame.h"
+#include "definitions.h"
+#include "map/cMap.h"
+#include "structs.h"
+#include "utils/cStructureUtils.h"
+
+#include <allegro/palette.h>
+
+class cAbstractStructure;
+class cAllegroDrawer;
+class cBullet;
+class cDrawManager;
+class cMapCamera;
+class cMapEditor;
+class cRandomMapGenerator;
+class cUnit;
+class cParticle;
+class cPlayer;
+class cRegion;
+class cTimeManager;
+
+struct sReinforcement;
+
+struct ALFONT_FONT;
+struct ALMP3_MP3;
+struct BITMAP;
+struct DATAFILE;
+
 // Process 'extern' stuff, so we can access our classes
 extern bool		bDoDebug;
 extern int		iRest;	// rest value

--- a/include/structs.h
+++ b/include/structs.h
@@ -1,8 +1,11 @@
 #ifndef STRUCTS_H_
 #define STRUCTS_H_
 
-#include <vector>
 #include "enums.h"
+
+#include <vector>
+
+struct BITMAP;
 
 // Unit properties
 // the s_UnitInfo struct is holding all properties for a specific unit type.

--- a/map/cMap.cpp
+++ b/map/cMap.cpp
@@ -1255,6 +1255,64 @@ cAbstractStructure *cMap::findClosestStructureType(int cell, int structureType, 
     return nullptr;
 }
 
+void cMap::cellTakeDamage(int cellNr, int damage) {
+    tCell *pCell = getCell(cellNr);
+    if (pCell) {
+        pCell->health -= damage;
+
+        if (pCell->health < -25) {
+            if (pCell->type == TERRAIN_ROCK) {
+                smudge_increase(SMUDGE_ROCK, cellNr);
+            }
+
+            if (pCell->type == TERRAIN_SAND ||
+                pCell->type == TERRAIN_HILL ||
+                pCell->type == TERRAIN_SPICE ||
+                pCell->type == TERRAIN_SPICEHILL) {
+                smudge_increase(SMUDGE_SAND, cellNr);
+            }
+
+            pCell->health += rnd(35);
+        }
+    }
+}
+
+void cMap::cellChangeType(int cellNr, int type) {
+    tCell *pCell = getCell(cellNr);
+    if (pCell) {
+        if (type > TERRAIN_WALL) {
+            pCell->type = type;
+        } else if (type < TERRAIN_BLOOM) {
+            pCell->type = type;
+        } else {
+            pCell->type = type;
+        }
+    }
+}
+
+void cMap::cellInit(int cellNr) {
+    tCell *pCell = getCell(cellNr);
+    if (!pCell) return; // bail
+
+    pCell->credits = 0;
+    pCell->health = 0;
+    pCell->passable = true;
+    pCell->passableFoot = true;
+    pCell->tile = 0;
+    pCell->type = TERRAIN_SAND;    // refers to gfxdata!
+
+    pCell->smudgetile = -1;
+    pCell->smudgetype = -1;
+
+    // clear out the ID stuff
+    memset(pCell->id, -1, sizeof(pCell->id));
+    memset(pCell->iVisible, 0, sizeof(pCell->iVisible));
+
+    // for (int i = 0; i < MAX_PLAYERS; i++) {
+    //     setVisible(cellNr, i, false);
+    // }
+}
+
 cAbstractStructure *cMap::findClosestAvailableStructureType(int cell, int structureType, cPlayer *pPlayer) {
     assert(pPlayer);
     assert(structureType > -1);

--- a/map/cMap.h
+++ b/map/cMap.h
@@ -15,6 +15,7 @@
 #include "gameobjects/structures/cAbstractStructure.h"
 #include "gameobjects/units/cUnit.h"
 #include "map/cCell.h"
+#include "sGameEvent.h"
 #include "utils/d2tm_math.h"
 
 #include <map>
@@ -22,8 +23,6 @@
 
 #define TILESIZE_WIDTH_PIXELS 32
 #define TILESIZE_HEIGHT_PIXELS 32
-
-struct s_GameEvent;
 
 class cMap : public cScenarioObserver {
 

--- a/map/cMap.h
+++ b/map/cMap.h
@@ -9,17 +9,21 @@
   2001 - 2021 (c) code by Stefan Hendriks
 
   */
+#ifndef CMAP_H
+#define CMAP_H
 
-#include <vector>
+#include "gameobjects/structures/cAbstractStructure.h"
+#include "gameobjects/units/cUnit.h"
+#include "map/cCell.h"
+#include "utils/d2tm_math.h"
+
 #include <map>
-#include <gameobjects/structures/cAbstractStructure.h>
-#include <gameobjects/units/cUnit.h>
+#include <vector>
 
 #define TILESIZE_WIDTH_PIXELS 32
 #define TILESIZE_HEIGHT_PIXELS 32
 
-#ifndef CMAP_H
-#define CMAP_H
+struct s_GameEvent;
 
 class cMap : public cScenarioObserver {
 
@@ -356,27 +360,7 @@ public:
      */
     cAbstractStructure * findClosestStructureType(int cell, int structureType, cPlayer * player);
 
-    void cellTakeDamage(int cellNr, int damage) {
-        tCell *pCell = getCell(cellNr);
-        if (pCell) {
-            pCell->health -= damage;
-
-            if (pCell->health < -25) {
-                if (pCell->type == TERRAIN_ROCK) {
-                    smudge_increase(SMUDGE_ROCK, cellNr);
-                }
-
-                if (pCell->type == TERRAIN_SAND ||
-                    pCell->type == TERRAIN_HILL ||
-                    pCell->type == TERRAIN_SPICE ||
-                    pCell->type == TERRAIN_SPICEHILL) {
-                    smudge_increase(SMUDGE_SAND, cellNr);
-                }
-
-                pCell->health += rnd(35);
-            }
-        }
-    }
+    void cellTakeDamage(int cellNr, int damage);
 
     void cellTakeCredits(int cellNr, int amount) {
         tCell *pCell = getCell(cellNr);
@@ -393,18 +377,7 @@ public:
         if (pCell) pCell->credits += amount;
     }
 
-    void cellChangeType(int cellNr, int type) {
-        tCell *pCell = getCell(cellNr);
-        if (pCell) {
-            if (type > TERRAIN_WALL) {
-                pCell->type = type;
-            } else if (type < TERRAIN_BLOOM) {
-                pCell->type = type;
-            } else {
-                pCell->type = type;
-            }
-        }
-    }
+    void cellChangeType(int cellNr, int type);
 
     void cellChangeHealth(int cellNr, int value) {
         tCell *pCell = getCell(cellNr);
@@ -441,28 +414,7 @@ public:
         if (pCell) pCell->passableFoot = value;
     }
 
-    void cellInit(int cellNr) {
-        tCell *pCell = getCell(cellNr);
-        if (!pCell) return; // bail
-
-        pCell->credits = 0;
-        pCell->health = 0;
-        pCell->passable = true;
-        pCell->passableFoot = true;
-        pCell->tile = 0;
-        pCell->type = TERRAIN_SAND;    // refers to gfxdata!
-
-        pCell->smudgetile = -1;
-        pCell->smudgetype = -1;
-
-        // clear out the ID stuff
-        memset(pCell->id, -1, sizeof(pCell->id));
-        memset(pCell->iVisible, 0, sizeof(pCell->iVisible));
-
-//        for (int i = 0; i < MAX_PLAYERS; i++) {
-//            setVisible(cellNr, i, false);
-//        }
-    }
+    void cellInit(int cellNr);
 
     void remove_id(int iIndex, int iIDType);    // removes ID of IDtype (unit/structure), etc
 

--- a/player/brains/cPlayerBrainCampaign.cpp
+++ b/player/brains/cPlayerBrainCampaign.cpp
@@ -1,7 +1,9 @@
-#include <algorithm>
 #include "include/d2tmh.h"
-#include "cPlayerBrainCampaign.h"
 
+#include "cPlayerBrainCampaign.h"
+#include "enums.h"
+
+#include <algorithm>
 
 namespace brains {
 

--- a/player/brains/cPlayerBrainSkirmish.cpp
+++ b/player/brains/cPlayerBrainSkirmish.cpp
@@ -1,7 +1,9 @@
-#include <algorithm>
 #include "include/d2tmh.h"
-#include "cPlayerBrainSkirmish.h"
 
+#include "cPlayerBrainSkirmish.h"
+#include "enums.h"
+
+#include <algorithm>
 
 namespace brains {
 

--- a/player/cPlayer.cpp
+++ b/player/cPlayer.cpp
@@ -365,6 +365,12 @@ bool cPlayer::hasRadarAndEnoughPower() const {
     return getAmountOfStructuresForType(RADAR) > 0 && bEnoughPower();
 }
 
+std::string cPlayer::asString() const {
+    char msg[512];
+    sprintf(msg, "Player [id=%d, human=%b, sidebar=%d]", this->id, this->m_Human, this->sidebar);
+    return std::string(msg);
+}
+
 /**
  * This function returns the amount for the given structure type. If structureType param is invalid, then it will
  * return -1

--- a/player/cPlayer.h
+++ b/player/cPlayer.h
@@ -20,9 +20,17 @@
 #ifndef PLAYER_H
 #define PLAYER_H
 
-#include <vector>
 #include "cPlayerNotification.h"
 
+#include <set>
+#include <string>
+#include <vector>
+
+class cAbstractStructure;
+class cItemBuilder;
+class cOrderProcesser;
+class cSideBar;
+class cPlayerDifficultySettings;
 
 struct s_PlaceResult {
     bool success = false; // if true, all is ok
@@ -142,11 +150,7 @@ public:
 
     bool hasRadarAndEnoughPower() const;
 
-    std::string asString() const {
-        char msg[512];
-        sprintf(msg, "Player [id=%d, human=%b, sidebar=%d]", this->id, this->m_Human, this->sidebar);
-        return std::string(msg);
-    }
+    std::string asString() const;
 
     BITMAP *getStructureBitmap(int index);
 

--- a/player/cPlayer.h
+++ b/player/cPlayer.h
@@ -21,16 +21,13 @@
 #define PLAYER_H
 
 #include "cPlayerNotification.h"
+#include "gameobjects/structures/cOrderProcesser.h"
+#include "player/cPlayerDifficultySettings.h"
+#include "sidebar/cSideBar.h"
 
 #include <set>
 #include <string>
 #include <vector>
-
-class cAbstractStructure;
-class cItemBuilder;
-class cOrderProcesser;
-class cSideBar;
-class cPlayerDifficultySettings;
 
 struct s_PlaceResult {
     bool success = false; // if true, all is ok

--- a/sidebar/cBuildingList.h
+++ b/sidebar/cBuildingList.h
@@ -16,6 +16,8 @@
 #ifndef CBUILDINGLIST
 #define CBUILDINGLIST
 
+#include "sidebar/cBuildingListItem.h"
+
 // forward declr..
 class cItemBuilder;
 

--- a/sidebar/cBuildingListItem.h
+++ b/sidebar/cBuildingListItem.h
@@ -8,6 +8,12 @@
 #ifndef CBUILDINGLISTITEM
 #define CBUILDINGLISTITEM
 
+#include "structs.h"
+
+#include <string>
+
+class cBuildingList;
+
 class cBuildingListItem {
 
 public:

--- a/sidebar/cBuildingListUpdater.h
+++ b/sidebar/cBuildingListUpdater.h
@@ -1,6 +1,8 @@
 #ifndef CBUILDINGLISTUPDATER_H_
 #define CBUILDINGLISTUPDATER_H_
 
+class cPlayer;
+
 class cBuildingListUpdater {
 	public:
 		cBuildingListUpdater(cPlayer * thePlayer);

--- a/sidebar/cSideBar.h
+++ b/sidebar/cSideBar.h
@@ -15,11 +15,6 @@
 #define CSIDEBAR_H_
 
 class cPlayer;
-class cBuildingList;
-class cBuildingListItem;
-
-struct s_MouseEvent;
-struct s_GameEvent;
 
 //// List ID's corresponding buttons
 //#define LIST_NONE        0

--- a/sidebar/cSideBar.h
+++ b/sidebar/cSideBar.h
@@ -14,8 +14,12 @@
 #ifndef CSIDEBAR_H_
 #define CSIDEBAR_H_
 
-// forward declaration
 class cPlayer;
+class cBuildingList;
+class cBuildingListItem;
+
+struct s_MouseEvent;
+struct s_GameEvent;
 
 //// List ID's corresponding buttons
 //#define LIST_NONE        0

--- a/utils/cStructureUtils.h
+++ b/utils/cStructureUtils.h
@@ -8,6 +8,10 @@
 #ifndef CSTRUCTUREUTILS_H_
 #define CSTRUCTUREUTILS_H_
 
+class cAbstractStructure;
+class cBuildingListItem;
+class cPlayer;
+
 class cStructureUtils {
 public:
     cStructureUtils();
@@ -41,10 +45,6 @@ public:
     int getTotalSpiceCapacityForPlayer(cPlayer *pPlayer);
 
     int getStructureTypeByUnitBuildId(int unitBuildId) const;
-
-protected:
-
-private:
 };
 
 #endif /* CSTRUCTUREUTILS_H_ */

--- a/utils/cStructureUtils.h
+++ b/utils/cStructureUtils.h
@@ -8,10 +8,6 @@
 #ifndef CSTRUCTUREUTILS_H_
 #define CSTRUCTUREUTILS_H_
 
-class cAbstractStructure;
-class cBuildingListItem;
-class cPlayer;
-
 class cStructureUtils {
 public:
     cStructureUtils();

--- a/utils/d2tm_math.h
+++ b/utils/d2tm_math.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef D2TM_MATH_H_
+#define D2TM_MATH_H_
 
 // Angle stuff for unit facing
 float fDegrees(int x1, int y1, int x2, int y2);
@@ -29,3 +30,5 @@ int CELL_L_LEFT(int c);
 int CELL_L_RIGHT(int c);
 
 bool CELL_BORDERS(int iOrigin, int iCell);
+
+#endif

--- a/utils/d2tm_math.h
+++ b/utils/d2tm_math.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Angle stuff for unit facing
 float fDegrees(int x1, int y1, int x2, int y2);
 float fRadians(int x1, int y1, int x2, int y2);


### PR DESCRIPTION
We need to get rid of the "uber" header file, IMHO. If we include what is used, then incremental builds are faster as not the entire program needs to be rebuilt.
- Moved some code to .cpp files to hide it from other components. This to reduce the number of includes from header files.
- Introduced forward declarations for private pieces of components that are not needed to interpret the header file. This is also to reduce the number of includes that are needed in header files.
- Found a missing header guard. I put #pragma once there. This is non-standard C++, but all available compilers support it.
Stopped after handling the first .cpp file in the project. Otherwise, the PR would be way too big.