### PR TITLE
Bugfix: Make sure not to hang when starting second skirmish game

### DIFF
--- a/cGame.h
+++ b/cGame.h
@@ -296,6 +296,8 @@ private:
     void setState(int newState);
 
     void onCombatMouseEventMovedTo(const s_MouseEvent &event);
+
+    void initPlayers(bool rememberHouse) const;
 };
 
 #endif

--- a/cGame_logic.cpp
+++ b/cGame_logic.cpp
@@ -79,9 +79,7 @@ void cGame::init() {
 
 	map.init(64, 64);
 
-	for (int i=0; i < MAX_PLAYERS; i++) {
-		players[i].init(i, nullptr);
-    }
+    initPlayers(false);
 
 	for (int i=0; i < MAX_UNITS; i++) {
 	    unit[i].init(i);
@@ -127,55 +125,57 @@ void cGame::mission_init() {
 
     map.init(64, 64);
 
-    int maxThinkingAIs = MAX_PLAYERS;
-    if (bOneAi) {
-        maxThinkingAIs = 1;
-    }
-    // clear out players but not entirely
-    for (int i=0; i < MAX_PLAYERS; i++) {
-        cPlayer &pPlayer = players[i];
-        int h = pPlayer.getHouse();
-
-        if (i == HUMAN) {
-            pPlayer.init(i, nullptr);
-        } else if (i < AI_CPU5) {
-            // TODO: playing attribute? (from ai player class?)
-            if (game.bDisableAI) {
-                pPlayer.init(i, nullptr);
-            } else {
-                if (game.bSkirmish) {
-                    if (maxThinkingAIs > 0) {
-                        pPlayer.init(i, new brains::cPlayerBrainSkirmish(&pPlayer));
-                    } else {
-                        pPlayer.init(i, nullptr);
-                    }
-                } else {
-                    if (maxThinkingAIs > 0) {
-                        pPlayer.init(i, new brains::cPlayerBrainCampaign(&pPlayer));
-                    } else {
-                        pPlayer.init(i, nullptr);
-                    }
-                    pPlayer.setAutoSlabStructures(true); // campaign based AI's autoslab structures...
-                }
-            }
-            maxThinkingAIs--;
-        } else if (i == AI_CPU5) {
-            pPlayer.init(i, new brains::cPlayerBrainFremenSuperWeapon(&pPlayer));
-        } else if (i == AI_CPU6) {
-            pPlayer.init(i, new brains::cPlayerBrainSandworm(&pPlayer));
-        }
-        pPlayer.setHouse(h);
-
-        if (bSkirmish) {
-            pPlayer.setCredits(2500);
-        }
-    }
+    initPlayers(true);
 
     // instantiate the creditDrawer with the appropriate player. Only
     // possible once game has been initialized and player has been created.
     assert(drawManager);
     assert(drawManager->getCreditsDrawer());
     drawManager->getCreditsDrawer()->setCredits();
+}
+
+void cGame::initPlayers(bool rememberHouse) const {
+    int maxThinkingAIs = MAX_PLAYERS;
+    if (bOneAi) {
+        maxThinkingAIs = 1;
+    }
+
+    for (int i=0; i < MAX_PLAYERS; i++) {
+        cPlayer &pPlayer = players[i];
+        int h = pPlayer.getHouse();
+
+        brains::cPlayerBrain *brain = nullptr;
+        bool autoSlabStructures = false;
+
+        if (i > HUMAN && i < AI_CPU5) {
+            // TODO: playing attribute? (from ai player class?)
+            if (!game.bDisableAI) {
+                if (maxThinkingAIs > 0) {
+                    if (game.bSkirmish) {
+                        brain = new brains::cPlayerBrainSkirmish(&pPlayer);
+                    } else {
+                        brain = new brains::cPlayerBrainCampaign(&pPlayer);
+                        autoSlabStructures = true;  // campaign based AI's autoslab structures...
+                    }
+                }
+            }
+            maxThinkingAIs--;
+        } else if (i == AI_CPU5) {
+            brain = new brains::cPlayerBrainFremenSuperWeapon(&pPlayer);
+        } else if (i == AI_CPU6) {
+            brain = new brains::cPlayerBrainSandworm(&pPlayer);
+        }
+
+        pPlayer.init(i, brain);
+        pPlayer.setAutoSlabStructures(autoSlabStructures);
+        if (rememberHouse) {
+            pPlayer.setHouse(h);
+        }
+
+        if (bSkirmish) {
+            pPlayer.setCredits(2500);
+        }
+    }
 }
 
 /**
@@ -1307,6 +1307,7 @@ void cGame::setState(int newState) {
 
                 newStatePtr = pState;
             } else if (newState == GAME_SETUPSKIRMISH) {
+                initPlayers(false);
                 newStatePtr = new cSetupSkirmishGameState(*this);
             } else if (newState == GAME_MENU) {
                 newStatePtr = new cMainMenuGameState(*this);

--- a/cGame_logic.cpp
+++ b/cGame_logic.cpp
@@ -127,10 +127,6 @@ void cGame::mission_init() {
 
     initPlayers(true);
 
-    // instantiate the creditDrawer with the appropriate player. Only
-    // possible once game has been initialized and player has been created.
-    assert(drawManager);
-    assert(drawManager->getCreditsDrawer());
     drawManager->getCreditsDrawer()->setCredits();
 }
 


### PR DESCRIPTION
- fixes #366 

to test:
- start skirmish game, with 4 players (random house is fine).
- make sure to have selected a known map (not random map)
- then win game (press TAB-F2)
- then again, choose map and try to play.  (with *random* houses)
- the game should play the next map

Previously, it would hang at the 2nd time. 

Reason being that finding a 'free' house to play with when you specified a random house, is depending on the `players` state. Which was not correctly cleared (due to the new 'state' changing logic in 0.6.5). 