### PR TITLE
refactor: eliminate a double query of mouse coordinates

### DIFF
--- a/sidebar/cBuildingList.cpp
+++ b/sidebar/cBuildingList.cpp
@@ -246,7 +246,7 @@ bool cBuildingList::removeItemFromList(int position) {
  * @return
  */
 bool cBuildingList::isOverButton(int x, int y) {
-    return game.getMouse()->isOverRectangle(getButtonDrawX(), getButtonDrawY(), 33, 27);
+    return cRectangle::isWithin(x, y, getButtonDrawX(), getButtonDrawY(), 33, 27);
 }
 
 /**


### PR DESCRIPTION
Found this when fixing "unused-parameter" warnings. Playtested it and this works.