### PR TITLE
fix designated and structured initializers to conform to C++20

### DIFF
--- a/player/brains/cPlayerBrainCampaign.cpp
+++ b/player/brains/cPlayerBrainCampaign.cpp
@@ -186,12 +186,12 @@ namespace brains {
                 // this structure got destroyed, so mark it as destroyed in my base plan
                 structurePosition.isDestroyed = true;
                 // and add order to rebuild it
-                addBuildOrder((S_buildOrder) {
-                        buildType : STRUCTURE,
-                        priority : 1,
-                        buildId : structurePosition.type,
-                        placeAt : structurePosition.cell,
-                        state : buildOrder::PROCESSME,
+                addBuildOrder(S_buildOrder{
+                        .buildType = STRUCTURE,
+                        .priority = 1,
+                        .buildId = structurePosition.type,
+                        .placeAt = structurePosition.cell,
+                        .state = buildOrder::PROCESSME,
                 });
             }
         }
@@ -249,12 +249,12 @@ namespace brains {
             if (!hasMission(99)) {
                 // add scouting mission
                 std::vector<S_groupKind> group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : player->getScoutingUnitType(),
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = player->getScoutingUnitType(),
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
 
                 cPlayerBrainMission someMission(player, ePlayerBrainMissionKind::PLAYERBRAINMISSION_KIND_EXPLORE, this, group, rnd(5), 99);
@@ -355,27 +355,27 @@ namespace brains {
         std::vector<S_groupKind> group = std::vector<S_groupKind>();
         if (!hasMission(0)) {
             if (player->getHouse() != HARKONNEN && player->getHouse() != SARDAUKAR) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : trikeKind,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = trikeKind,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1 + rnd(2),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1 + rnd(2),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             } else {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1 + rnd(3),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1 + rnd(3),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
@@ -384,38 +384,38 @@ namespace brains {
         if (!hasMission(1)) {
             group = std::vector<S_groupKind>();
             if (rnd(100) < 50) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             if (player->getHouse() != ORDOS) {
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : LAUNCHER,
-                            required: 1 + rnd(2),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = LAUNCHER,
+                            .required = 1 + rnd(2),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : TANK,
-                        required: 1 + rnd(4),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = TANK,
+                        .required = 1 + rnd(4),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             } else {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : TANK,
-                        required: 4 + rnd(2),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = TANK,
+                        .required = 4 + rnd(2),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 1);
@@ -425,21 +425,21 @@ namespace brains {
             // 25% chance we want another different attack force
             if (rnd(100) < 25) {
                 group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : TANK,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = TANK,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 if (player->getHouse() != ORDOS) {
                     if (rnd(100) < 75) {
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : LAUNCHER,
-                                required: 1 + rnd(2),
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = LAUNCHER,
+                                .required = 1 + rnd(2),
+                                .ordered = 0,
+                                .produced = 0,
                         });
                     }
                 }
@@ -449,12 +449,12 @@ namespace brains {
         if (!hasMission(3)) {
             group = std::vector<S_groupKind>();
             if (rnd(100) < 50) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : infantryKind,
-                        required: 2 + rnd(4),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = infantryKind,
+                        .required = 2 + rnd(4),
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 3);
             }
@@ -464,12 +464,12 @@ namespace brains {
         if (harvesters < 2) {
             if (!hasMission(4)) {
                 group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : HARVESTER,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = HARVESTER,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 4);
             } else {
@@ -479,12 +479,12 @@ namespace brains {
                 if (!hasMission(5)) {
                     if (harvesters > 0) {
                         group = std::vector<S_groupKind>();
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : HARVESTER,
-                                required: 1,
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = HARVESTER,
+                                .required = 1,
+                                .ordered = 0,
+                                .produced = 0,
                         });
                         // different mission ID
                         addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 5);
@@ -498,27 +498,27 @@ namespace brains {
         std::vector<S_groupKind> group = std::vector<S_groupKind>();
         if (!hasMission(0)) {
             if (player->getHouse() != HARKONNEN && player->getHouse() != SARDAUKAR) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : trikeKind,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = trikeKind,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1 + rnd(2),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1 + rnd(2),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             } else {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1 + rnd(3),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1 + rnd(3),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
@@ -527,56 +527,56 @@ namespace brains {
         if (!hasMission(1)) {
             group = std::vector<S_groupKind>();
             if (rnd(100) < 50) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             if (player->getHouse() != ORDOS) {
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : LAUNCHER,
-                            required: 1 + rnd(3),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = LAUNCHER,
+                            .required = 1 + rnd(3),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : TANK,
-                            required: 2 + rnd(4),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = TANK,
+                            .required = 2 + rnd(4),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : SIEGETANK,
-                            required: 3 + rnd(4),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = SIEGETANK,
+                            .required = 3 + rnd(4),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
             } else {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : TANK,
-                        required: 2 + rnd(4),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = TANK,
+                        .required = 2 + rnd(4),
+                        .ordered = 0,
+                        .produced = 0,
                 });
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : SIEGETANK,
-                        required: 3 + rnd(3),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = SIEGETANK,
+                        .required = 3 + rnd(3),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 1);
@@ -586,30 +586,30 @@ namespace brains {
             // 25% chance we want another different attack force
             if (rnd(100) < 25) {
                 group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : TANK,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = TANK,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : SIEGETANK,
-                            required: 1 + rnd(2),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = SIEGETANK,
+                            .required = 1 + rnd(2),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
                 if (player->getHouse() != ORDOS) {
                     if (rnd(100) < 75) {
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : LAUNCHER,
-                                required: 1 + rnd(2),
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = LAUNCHER,
+                                .required = 1 + rnd(2),
+                                .ordered = 0,
+                                .produced = 0,
                         });
                     }
                 }
@@ -619,12 +619,12 @@ namespace brains {
         if (!hasMission(3)) {
             group = std::vector<S_groupKind>();
             if (rnd(100) < 50) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : infantryKind,
-                        required: 1 + rnd(2),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = infantryKind,
+                        .required = 1 + rnd(2),
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 3);
             }
@@ -634,12 +634,12 @@ namespace brains {
         if (harvesters < 4) {
             if (!hasMission(4)) {
                 group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : HARVESTER,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = HARVESTER,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 4);
             } else {
@@ -650,12 +650,12 @@ namespace brains {
                 if (!hasMission(5)) {
                     if (harvesters > 0) {
                         group = std::vector<S_groupKind>();
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : HARVESTER,
-                                required: 2,
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = HARVESTER,
+                                .required = 2,
+                                .ordered = 0,
+                                .produced = 0,
                         });
                         // different mission ID
                         addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 5);
@@ -669,27 +669,27 @@ namespace brains {
         std::vector<S_groupKind> group = std::vector<S_groupKind>();
         if (!hasMission(0)) {
             if (player->getHouse() != HARKONNEN && player->getHouse() != SARDAUKAR) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : trikeKind,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = trikeKind,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1 + rnd(2),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1 + rnd(2),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             } else {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1 + rnd(3),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1 + rnd(3),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
@@ -698,56 +698,56 @@ namespace brains {
         if (!hasMission(1)) {
             group = std::vector<S_groupKind>();
             if (rnd(100) < 50) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             if (player->getHouse() != ORDOS) {
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : LAUNCHER,
-                            required: 1 + rnd(3),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = LAUNCHER,
+                            .required = 1 + rnd(3),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : TANK,
-                            required: 2 + rnd(4),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = TANK,
+                            .required = 2 + rnd(4),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : SIEGETANK,
-                            required: 3 + rnd(4),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = SIEGETANK,
+                            .required = 3 + rnd(4),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
             } else {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : TANK,
-                        required: 2 + rnd(4),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = TANK,
+                        .required = 2 + rnd(4),
+                        .ordered = 0,
+                        .produced = 0,
                 });
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : SIEGETANK,
-                        required: 3 + rnd(3),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = SIEGETANK,
+                        .required = 3 + rnd(3),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 1);
@@ -757,30 +757,30 @@ namespace brains {
             // 25% chance we want another different attack force
             if (rnd(100) < 25) {
                 group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : TANK,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = TANK,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : SIEGETANK,
-                            required: 1 + rnd(2),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = SIEGETANK,
+                            .required = 1 + rnd(2),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
                 if (player->getHouse() != ORDOS) {
                     if (rnd(100) < 75) {
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : LAUNCHER,
-                                required: 1 + rnd(2),
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = LAUNCHER,
+                                .required = 1 + rnd(2),
+                                .ordered = 0,
+                                .produced = 0,
                         });
                     }
                 }
@@ -790,12 +790,12 @@ namespace brains {
         if (!hasMission(3)) {
             group = std::vector<S_groupKind>();
             if (rnd(100) < 50) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : infantryKind,
-                        required: 1 + rnd(2),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = infantryKind,
+                        .required = 1 + rnd(2),
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 3);
             }
@@ -805,12 +805,12 @@ namespace brains {
         if (harvesters < 4) {
             if (!hasMission(4)) {
                 group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : HARVESTER,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = HARVESTER,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 4);
             } else {
@@ -821,12 +821,12 @@ namespace brains {
                 if (!hasMission(5)) {
                     if (harvesters > 0) {
                         group = std::vector<S_groupKind>();
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : HARVESTER,
-                                required: 2,
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = HARVESTER,
+                                .required = 2,
+                                .ordered = 0,
+                                .produced = 0,
                         });
                         // different mission ID
                         addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 5);
@@ -840,12 +840,12 @@ namespace brains {
                 if (!hasMission(6)) {
                     group = std::vector<S_groupKind>();
                     if (rnd(100) < 10) {
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : ORNITHOPTER,
-                                required: 1 + rnd(2),
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = ORNITHOPTER,
+                                .required = 1 + rnd(2),
+                                .ordered = 0,
+                                .produced = 0,
                         });
                         addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 6);
                     }
@@ -857,12 +857,12 @@ namespace brains {
             if (!hasMission(7)) {
                 group = std::vector<S_groupKind>();
                 if (rnd(100) < 10) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : CARRYALL,
-                            required: 2,
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = CARRYALL,
+                            .required = 2,
+                            .ordered = 0,
+                            .produced = 0,
                     });
                     addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(10), 7);
                 }
@@ -874,27 +874,27 @@ namespace brains {
         std::vector<S_groupKind> group = std::vector<S_groupKind>();
         if (!hasMission(0)) {
             if (player->getHouse() != HARKONNEN && player->getHouse() != SARDAUKAR) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : trikeKind,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = trikeKind,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1 + rnd(2),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1 + rnd(2),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             } else {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1 + rnd(3),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1 + rnd(3),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
@@ -903,56 +903,56 @@ namespace brains {
         if (!hasMission(1)) {
             group = std::vector<S_groupKind>();
             if (rnd(100) < 50) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             if (player->getHouse() != ORDOS) {
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : LAUNCHER,
-                            required: 1 + rnd(3),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = LAUNCHER,
+                            .required = 1 + rnd(3),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : TANK,
-                            required: 2 + rnd(4),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = TANK,
+                            .required = 2 + rnd(4),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : SIEGETANK,
-                            required: 3 + rnd(4),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = SIEGETANK,
+                            .required = 3 + rnd(4),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
             } else {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : TANK,
-                        required: 2 + rnd(4),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = TANK,
+                        .required = 2 + rnd(4),
+                        .ordered = 0,
+                        .produced = 0,
                 });
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : SIEGETANK,
-                        required: 3 + rnd(3),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = SIEGETANK,
+                        .required = 3 + rnd(3),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 1);
@@ -962,30 +962,30 @@ namespace brains {
             // 25% chance we want another different attack force
             if (rnd(100) < 25) {
                 group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : TANK,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = TANK,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : SIEGETANK,
-                            required: 1 + rnd(2),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = SIEGETANK,
+                            .required = 1 + rnd(2),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
                 if (player->getHouse() != ORDOS) {
                     if (rnd(100) < 75) {
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : LAUNCHER,
-                                required: 1 + rnd(2),
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = LAUNCHER,
+                                .required = 1 + rnd(2),
+                                .ordered = 0,
+                                .produced = 0,
                         });
                     }
                 }
@@ -995,12 +995,12 @@ namespace brains {
         if (!hasMission(3)) {
             group = std::vector<S_groupKind>();
             if (rnd(100) < 50) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : infantryKind,
-                        required: 1 + rnd(2),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = infantryKind,
+                        .required = 1 + rnd(2),
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 3);
             }
@@ -1010,12 +1010,12 @@ namespace brains {
         if (harvesters < 4) {
             if (!hasMission(4)) {
                 group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : HARVESTER,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = HARVESTER,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 4);
             } else {
@@ -1026,12 +1026,12 @@ namespace brains {
                 if (!hasMission(5)) {
                     if (harvesters > 0) {
                         group = std::vector<S_groupKind>();
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : HARVESTER,
-                                required: 2,
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = HARVESTER,
+                                .required = 2,
+                                .ordered = 0,
+                                .produced = 0,
                         });
                         // different mission ID
                         addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 5);
@@ -1045,12 +1045,12 @@ namespace brains {
                 if (!hasMission(6)) {
                     group = std::vector<S_groupKind>();
                     if (rnd(100) < 10) {
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : ORNITHOPTER,
-                                required: 1 + rnd(2),
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = ORNITHOPTER,
+                                .required = 1 + rnd(2),
+                                .ordered = 0,
+                                .produced = 0,
                         });
                         addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 6);
                     }
@@ -1062,12 +1062,12 @@ namespace brains {
             if (!hasMission(7)) {
                 group = std::vector<S_groupKind>();
                 if (rnd(100) < 10) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : CARRYALL,
-                            required: 2,
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = CARRYALL,
+                            .required = 2,
+                            .ordered = 0,
+                            .produced = 0,
                     });
                     addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(10), 7);
                 }
@@ -1079,27 +1079,27 @@ namespace brains {
         std::vector<S_groupKind> group = std::vector<S_groupKind>();
         if (!hasMission(0)) {
             if (player->getHouse() != HARKONNEN && player->getHouse() != SARDAUKAR) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : trikeKind,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = trikeKind,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
             } else {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
@@ -1108,77 +1108,77 @@ namespace brains {
         if (!hasMission(1)) {
             group = std::vector<S_groupKind>();
             if (rnd(100) < 50) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             if (player->getHouse() != ORDOS) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : LAUNCHER,
-                        required: 1 + rnd(3),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = LAUNCHER,
+                        .required = 1 + rnd(3),
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 if (rnd(100) < 35) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : TANK,
-                            required: 2 + rnd(4),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = TANK,
+                            .required = 2 + rnd(4),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : SIEGETANK,
-                        required: 3 + rnd(4),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = SIEGETANK,
+                        .required = 3 + rnd(4),
+                        .ordered = 0,
+                        .produced = 0,
                 });
 
                 if (player->getHouse() == ATREIDES) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : SONICTANK,
-                            required: 2,
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = SONICTANK,
+                            .required = 2,
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 } else if (player->getHouse() == HARKONNEN || player->getHouse() == SARDAUKAR) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : DEVASTATOR,
-                            required: 2,
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = DEVASTATOR,
+                            .required = 2,
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
             } else {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : TANK,
-                        required: 2 + rnd(4),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = TANK,
+                        .required = 2 + rnd(4),
+                        .ordered = 0,
+                        .produced = 0,
                 });
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : SIEGETANK,
-                        required: 3 + rnd(3),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = SIEGETANK,
+                        .required = 3 + rnd(3),
+                        .ordered = 0,
+                        .produced = 0,
                 });
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : DEVIATOR,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = DEVIATOR,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 1);
@@ -1188,29 +1188,29 @@ namespace brains {
             // 25% chance we want another different attack force
             if (rnd(100) < 25) {
                 group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : TANK,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = TANK,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 if (rnd(100) < 75) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : SIEGETANK,
-                            required: 1 + rnd(2),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = SIEGETANK,
+                            .required = 1 + rnd(2),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
                 if (player->getHouse() != ORDOS) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : LAUNCHER,
-                            required: 1 + rnd(2),
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = LAUNCHER,
+                            .required = 1 + rnd(2),
+                            .ordered = 0,
+                            .produced = 0,
                     });
                 }
                 addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + rnd(10), 2);
@@ -1219,12 +1219,12 @@ namespace brains {
         if (!hasMission(3)) {
             group = std::vector<S_groupKind>();
             if (rnd(100) < 5) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : infantryKind,
-                        required: 1 + rnd(2),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = infantryKind,
+                        .required = 1 + rnd(2),
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 3);
             }
@@ -1234,12 +1234,12 @@ namespace brains {
         if (harvesters < 4) {
             if (!hasMission(4)) {
                 group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : HARVESTER,
-                        required: 2,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = HARVESTER,
+                        .required = 2,
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 4);
             } else {
@@ -1250,12 +1250,12 @@ namespace brains {
                 if (!hasMission(5)) {
                     if (harvesters > 0) {
                         group = std::vector<S_groupKind>();
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : HARVESTER,
-                                required: 2,
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = HARVESTER,
+                                .required = 2,
+                                .ordered = 0,
+                                .produced = 0,
                         });
                         // different mission ID
                         addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 5);
@@ -1269,12 +1269,12 @@ namespace brains {
                 if (!hasMission(6)) {
                     group = std::vector<S_groupKind>();
                     if (rnd(100) < 10) {
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : ORNITHOPTER,
-                                required: 1 + rnd(2),
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = ORNITHOPTER,
+                                .required = 1 + rnd(2),
+                                .ordered = 0,
+                                .produced = 0,
                         });
                         addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 6);
                     }
@@ -1286,12 +1286,12 @@ namespace brains {
             if (!hasMission(7)) {
                 group = std::vector<S_groupKind>();
                 if (rnd(100) < 10) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : CARRYALL,
-                            required: 2,
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = CARRYALL,
+                            .required = 2,
+                            .ordered = 0,
+                            .produced = 0,
                     });
                     addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(10), 7);
                 }
@@ -1303,12 +1303,12 @@ namespace brains {
                 if (!hasMission(6)) {
                     group = std::vector<S_groupKind>();
                     if (rnd(100) < 10) {
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : ORNITHOPTER,
-                                required: 1 + rnd(2),
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = ORNITHOPTER,
+                                .required = 1 + rnd(2),
+                                .ordered = 0,
+                                .produced = 0,
                         });
                         addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 6);
                     }
@@ -1320,12 +1320,12 @@ namespace brains {
             if (!hasMission(7)) {
                 group = std::vector<S_groupKind>();
                 if (rnd(100) < 10) {
-                    group.push_back((S_groupKind) {
-                            buildType: eBuildType::UNIT,
-                            type : CARRYALL,
-                            required: 2,
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = eBuildType::UNIT,
+                            .type = CARRYALL,
+                            .required = 2,
+                            .ordered = 0,
+                            .produced = 0,
                     });
                     addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(10), 7);
                 }
@@ -1337,58 +1337,58 @@ namespace brains {
         std::vector<S_groupKind> group = std::vector<S_groupKind>();
         if (!hasMission(0)) {
             if (player->getHouse() != HARKONNEN && player->getHouse() != SARDAUKAR) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : trikeKind,
-                        required: 1 + rnd(1),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = trikeKind,
+                        .required = 1 + rnd(1),
+                        .ordered = 0,
+                        .produced = 0,
                 });
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1 + rnd(3),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1 + rnd(3),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             } else {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 2 + rnd(2),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 2 + rnd(2),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
         }
         if (!hasMission(1)) {
             group = std::vector<S_groupKind>();
-            group.push_back((S_groupKind) {
-                    buildType: eBuildType::UNIT,
-                    type : TANK,
-                    required: 1 + rnd(3),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = eBuildType::UNIT,
+                    .type = TANK,
+                    .required = 1 + rnd(3),
+                    .ordered = 0,
+                    .produced = 0,
             });
-            group.push_back((S_groupKind) {
-                    buildType: eBuildType::UNIT,
-                    type : QUAD,
-                    required: 1,
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = eBuildType::UNIT,
+                    .type = QUAD,
+                    .required = 1,
+                    .ordered = 0,
+                    .produced = 0,
             });
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + rnd(10), 1);
         }
         if (!hasMission(2)) {
             group = std::vector<S_groupKind>();
             if (rnd(100) < 50) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : infantryKind,
-                        required: 2 + rnd(4),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = infantryKind,
+                        .required = 2 + rnd(4),
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 2);
             }
@@ -1399,12 +1399,12 @@ namespace brains {
         if (harvesters < 2) {
             if (!hasMission(3)) {
                 group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : HARVESTER,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = HARVESTER,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 3);
             } else {
@@ -1414,12 +1414,12 @@ namespace brains {
                 if (!hasMission(4)) {
                     if (harvesters > 0) {
                         group = std::vector<S_groupKind>();
-                        group.push_back((S_groupKind) {
-                                buildType: eBuildType::UNIT,
-                                type : HARVESTER,
-                                required: 1,
-                                ordered: 0,
-                                produced: 0,
+                        group.push_back(S_groupKind{
+                                .buildType = eBuildType::UNIT,
+                                .type = HARVESTER,
+                                .required = 1,
+                                .ordered = 0,
+                                .produced = 0,
                         });
                         // different mission ID
                         addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 4);
@@ -1433,27 +1433,27 @@ namespace brains {
         std::vector<S_groupKind> group = std::vector<S_groupKind>();
         if (!hasMission(0)) {
             if (player->getHouse() != HARKONNEN && player->getHouse() != SARDAUKAR) {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 1 + rnd(2),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 1 + rnd(2),
+                        .ordered = 0,
+                        .produced = 0,
                 });
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : trikeKind,
-                        required: 1 + rnd(1),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = trikeKind,
+                        .required = 1 + rnd(1),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             } else {
-                group.push_back((S_groupKind) {
-                        buildType: eBuildType::UNIT,
-                        type : QUAD,
-                        required: 2 + rnd(3),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = eBuildType::UNIT,
+                        .type = QUAD,
+                        .required = 2 + rnd(3),
+                        .ordered = 0,
+                        .produced = 0,
                 });
             }
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
@@ -1461,19 +1461,19 @@ namespace brains {
         if (!hasMission(1)) {
             group = std::vector<S_groupKind>();
 
-            group.push_back((S_groupKind) {
-                    buildType: eBuildType::UNIT,
-                    type : soldierKind,
-                    required: 1 + rnd(3),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = eBuildType::UNIT,
+                    .type = soldierKind,
+                    .required = 1 + rnd(3),
+                    .ordered = 0,
+                    .produced = 0,
             });
-            group.push_back((S_groupKind) {
-                    buildType: eBuildType::UNIT,
-                    type : infantryKind,
-                    required: 1 + rnd(2),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = eBuildType::UNIT,
+                    .type = infantryKind,
+                    .required = 1 + rnd(2),
+                    .ordered = 0,
+                    .produced = 0,
             });
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 1);
         }
@@ -1482,19 +1482,19 @@ namespace brains {
     void cPlayerBrainCampaign::produceLevel2Missions(int soldierKind, int infantryKind) {
         if (!hasMission(0)) {
             std::vector<S_groupKind> group = std::vector<S_groupKind>();
-            group.push_back((S_groupKind) {
-                    buildType: eBuildType::UNIT,
-                    type : soldierKind,
-                    required: 2 + rnd(1),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = eBuildType::UNIT,
+                    .type = soldierKind,
+                    .required = 2 + rnd(1),
+                    .ordered = 0,
+                    .produced = 0,
             });
-            group.push_back((S_groupKind) {
-                    buildType: eBuildType::UNIT,
-                    type : infantryKind,
-                    required: 1 + rnd(1),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = eBuildType::UNIT,
+                    .type = infantryKind,
+                    .required = 1 + rnd(1),
+                    .ordered = 0,
+                    .produced = 0,
             });
             addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 0);
         }

--- a/player/brains/cPlayerBrainSkirmish.cpp
+++ b/player/brains/cPlayerBrainSkirmish.cpp
@@ -205,12 +205,12 @@ namespace brains {
                 // this structure got destroyed, so mark it as destroyed in my base plan
                 structurePosition.isDestroyed = true;
                 // and add order to rebuild it
-                addBuildOrder((S_buildOrder) {
-                        buildType : STRUCTURE,
-                        priority : 1,
-                        buildId : structurePosition.type,
-                        placeAt : structurePosition.cell,
-                        state : buildOrder::PROCESSME,
+                addBuildOrder(S_buildOrder{
+                        .buildType = STRUCTURE,
+                        .priority = 1,
+                        .buildId = structurePosition.type,
+                        .placeAt = structurePosition.cell,
+                        .state = buildOrder::PROCESSME,
                 });
             }
         }
@@ -290,12 +290,12 @@ namespace brains {
                 // add it to the build queue
 
                 if (result.structureType > -1 && result.cell > -1) {
-                    addBuildOrder((S_buildOrder) {
-                            buildType : STRUCTURE,
-                            priority : 1,
-                            buildId : result.structureType,
-                            placeAt : result.cell,
-                            state : buildOrder::PROCESSME,
+                    addBuildOrder(S_buildOrder{
+                            .buildType = STRUCTURE,
+                            .priority = 1,
+                            .buildId = result.structureType,
+                            .placeAt = result.cell,
+                            .state = buildOrder::PROCESSME,
                     });
                 }
             }
@@ -408,12 +408,12 @@ namespace brains {
     }
 
     void cPlayerBrainSkirmish::addBuildOrderForUnit(int type) {
-        addBuildOrder((S_buildOrder) {
-            buildType : UNIT,
-            priority : 0,
-            buildId : type,
-            placeAt : -1,
-            state : buildOrder::PROCESSME,
+        addBuildOrder(S_buildOrder{
+            .buildType = UNIT,
+            .priority = 0,
+            .buildId = type,
+            .placeAt = -1,
+            .state = buildOrder::PROCESSME,
         });
     }
 
@@ -456,12 +456,12 @@ namespace brains {
             if (amountOfHarvesters < idealAmountHarvesters) {
                 if (!hasMission(MISSION_IMPROVE_ECONOMY_BUILD_ADDITIONAL_HARVESTER)) {
                     std::vector<S_groupKind> group = std::vector<S_groupKind>();
-                    group.push_back((S_groupKind) {
-                            buildType: UNIT,
-                            type : HARVESTER,
-                            required: 1,
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = UNIT,
+                            .type = HARVESTER,
+                            .required = 1,
+                            .ordered = 0,
+                            .produced = 0,
                     });
                     addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(15), MISSION_IMPROVE_ECONOMY_BUILD_ADDITIONAL_HARVESTER);
                 }
@@ -474,12 +474,12 @@ namespace brains {
             if (player->getAmountOfUnitsForType(CARRYALL) < idealAmountOfCarryAlls) {
                 if (!hasMission(MISSION_IMPROVE_ECONOMY_BUILD_ADDITIONAL_CARRYALL)) {
                     std::vector<S_groupKind> group = std::vector<S_groupKind>();
-                    group.push_back((S_groupKind) {
-                            buildType: UNIT,
-                            type : CARRYALL,
-                            required: 1,
-                            ordered: 0,
-                            produced: 0,
+                    group.push_back(S_groupKind{
+                            .buildType = UNIT,
+                            .type = CARRYALL,
+                            .required = 1,
+                            .ordered = 0,
+                            .produced = 0,
                     });
                     addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(15), MISSION_IMPROVE_ECONOMY_BUILD_ADDITIONAL_CARRYALL);
                 }
@@ -526,12 +526,12 @@ namespace brains {
         if (!hasMission(MISSION_ATTACK5)) {
             if (player->canBuildUnitBool(ORNITHOPTER)) {
                 std::vector<S_groupKind> group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: UNIT,
-                        type : ORNITHOPTER,
-                        required: 1 + rnd(3),
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = UNIT,
+                        .type = ORNITHOPTER,
+                        .required = 1 + rnd(3),
+                        .ordered = 0,
+                        .produced = 0,
                 });
                 addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15),
                            MISSION_ATTACK5);
@@ -544,12 +544,12 @@ namespace brains {
             if (!hasMission(MISSION_SCOUT1)) {
                 // add scouting mission
                 std::vector<S_groupKind> group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: UNIT,
-                        type : scoutingUnitType,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = UNIT,
+                        .type = scoutingUnitType,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
 
                 addMission(PLAYERBRAINMISSION_KIND_EXPLORE, group, rnd(15),
@@ -557,12 +557,12 @@ namespace brains {
             } else if (!hasMission(MISSION_SCOUT2)) {
                 // add scouting mission
                 std::vector<S_groupKind> group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: UNIT,
-                        type : scoutingUnitType,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = UNIT,
+                        .type = scoutingUnitType,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
 
                 addMission(PLAYERBRAINMISSION_KIND_EXPLORE, group, rnd(15),
@@ -570,12 +570,12 @@ namespace brains {
             } else if (!hasMission(MISSION_SCOUT3)) {
                 // add scouting mission
                 std::vector<S_groupKind> group = std::vector<S_groupKind>();
-                group.push_back((S_groupKind) {
-                        buildType: UNIT,
-                        type : scoutingUnitType,
-                        required: 1,
-                        ordered: 0,
-                        produced: 0,
+                group.push_back(S_groupKind{
+                        .buildType = UNIT,
+                        .type = scoutingUnitType,
+                        .required = 1,
+                        .ordered = 0,
+                        .produced = 0,
                 });
 
                 addMission(PLAYERBRAINMISSION_KIND_EXPLORE, group, rnd(15), MISSION_SCOUT3);
@@ -585,19 +585,19 @@ namespace brains {
         if (!hasMission(MISSION_GUARDFORCE) && player->canBuildUnitBool(QUAD) && player->canBuildUnitBool(TANK)) {
             // add defending force
             std::vector<S_groupKind> group = std::vector<S_groupKind>();
-            group.push_back((S_groupKind) {
-                    buildType: UNIT,
-                    type : QUAD,
-                    required: 1,
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = UNIT,
+                    .type = QUAD,
+                    .required = 1,
+                    .ordered = 0,
+                    .produced = 0,
             });
-            group.push_back((S_groupKind) {
-                    buildType: UNIT,
-                    type : TANK,
-                    required: 2,
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = UNIT,
+                    .type = TANK,
+                    .required = 2,
+                    .ordered = 0,
+                    .produced = 0,
             });
             addMission(PLAYERBRAINMISSION_KIND_DEFEND, group, rnd(15), MISSION_GUARDFORCE);
         }
@@ -625,12 +625,12 @@ namespace brains {
         }
 
         if (rnd(100) < normalChance && player->canBuildUnitBool(SIEGETANK)) {
-            group.push_back((S_groupKind) {
-                    buildType: UNIT,
-                    type : SIEGETANK,
-                    required: 1+rnd(4),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = UNIT,
+                    .type = SIEGETANK,
+                    .required = 1+rnd(4),
+                    .ordered = 0,
+                    .produced = 0,
             });
         }
 
@@ -639,12 +639,12 @@ namespace brains {
             if (player->canBuildUnitBool(TROOPERS)) {
                 trooperUnit = TROOPERS;
             }
-            group.push_back((S_groupKind) {
-                    buildType: UNIT,
-                    type : trooperUnit,
-                    required: 1 + rnd(2),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = UNIT,
+                    .type = trooperUnit,
+                    .required = 1 + rnd(2),
+                    .ordered = 0,
+                    .produced = 0,
             });
         }
 
@@ -653,64 +653,64 @@ namespace brains {
             if (player->canBuildUnitBool(INFANTRY)) {
                 infantryUnit = INFANTRY;
             }
-            group.push_back((S_groupKind) {
-                    buildType: UNIT,
-                    type : infantryUnit,
-                    required: 1 + rnd(2),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = UNIT,
+                    .type = infantryUnit,
+                    .required = 1 + rnd(2),
+                    .ordered = 0,
+                    .produced = 0,
             });
         }
 
         if (rnd(100) < bigChance && player->canBuildUnitBool(LAUNCHER)) {
-            group.push_back((S_groupKind) {
-                    buildType: UNIT,
-                    type : LAUNCHER,
-                    required: 1+rnd(3),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = UNIT,
+                    .type = LAUNCHER,
+                    .required = 1+rnd(3),
+                    .ordered = 0,
+                    .produced = 0,
             });
         }
 
         if (rnd(100) < bigChance && player->canBuildUnitBool(TANK)) {
-            group.push_back((S_groupKind) {
-                    buildType: UNIT,
-                    type : TANK,
-                    required: 1+rnd(4),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = UNIT,
+                    .type = TANK,
+                    .required = 1+rnd(4),
+                    .ordered = 0,
+                    .produced = 0,
             });
         }
 
         int scoutingUnitType = player->getScoutingUnitType();
         if (rnd(100) < smallChance && player->canBuildUnitBool(scoutingUnitType)) {
-            group.push_back((S_groupKind) {
-                    buildType: UNIT,
-                    type : scoutingUnitType,
-                    required: 1+rnd(2),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = UNIT,
+                    .type = scoutingUnitType,
+                    .required = 1+rnd(2),
+                    .ordered = 0,
+                    .produced = 0,
             });
         }
 
         if (QUAD != scoutingUnitType && player->canBuildUnitBool(QUAD) && rnd(100) < normalChance) {
-            group.push_back((S_groupKind) {
-                    buildType: UNIT,
-                    type : QUAD,
-                    required: 1+rnd(3),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = UNIT,
+                    .type = QUAD,
+                    .required = 1+rnd(3),
+                    .ordered = 0,
+                    .produced = 0,
             });
         }
 
         int specialType = player->getSpecialUnitType();
         if (rnd(100) < normalChance && player->canBuildUnitBool(specialType)) {
-            group.push_back((S_groupKind) {
-                    buildType: UNIT,
-                    type : specialType,
-                    required: 1+rnd(2),
-                    ordered: 0,
-                    produced: 0,
+            group.push_back(S_groupKind{
+                    .buildType = UNIT,
+                    .type = specialType,
+                    .required = 1+rnd(2),
+                    .ordered = 0,
+                    .produced = 0,
             });
         }
 

--- a/player/brains/missions/cPlayerBrainMission.cpp
+++ b/player/brains/missions/cPlayerBrainMission.cpp
@@ -314,12 +314,12 @@ namespace brains {
 
                     // else, we order stuff, if we didn't already?
                     while (thingIWant.ordered < thingIWant.required) {
-                        brain->addBuildOrder((S_buildOrder) {
-                                buildType : thingIWant.buildType,
-                                priority : 0,
-                                buildId : thingIWant.type,
-                                placeAt : -1,
-                                state : buildOrder::eBuildOrderState::PROCESSME,
+                        brain->addBuildOrder(S_buildOrder{
+                                .buildType = thingIWant.buildType,
+                                .priority = 0,
+                                .buildId = thingIWant.type,
+                                .placeAt = -1,
+                                .state = buildOrder::eBuildOrderState::PROCESSME,
                         });
 //                        // amount of 'think' iterations to wait before we bail the mission
 //                        // brains 'normal thinking' is 100ms every tick. The missions have much faster thinking (5ms).

--- a/rebuildwin.bat
+++ b/rebuildwin.bat
@@ -1,0 +1,7 @@
+rm -rf build
+mkdir build
+cd build
+cmake .. -G "MinGW Makefiles"
+cmake --build . --target all -- -j 6
+cd ..
+

--- a/utils/common.cpp
+++ b/utils/common.cpp
@@ -1357,7 +1357,7 @@ void install_structures() {
     sStructureInfo[WINDTRAP].fademax = 134;
     sStructureInfo[WINDTRAP].icon = ICON_STR_WINDTRAP;
     sStructureInfo[WINDTRAP].configured = true;
-    sStructureInfo[WINDTRAP].flags.push_back((s_FlagInfo) {
+    sStructureInfo[WINDTRAP].flags.push_back(s_FlagInfo{
             .big = true,
             .relX = 53,
             .relY = 37
@@ -1374,7 +1374,7 @@ void install_structures() {
     sStructureInfo[HEAVYFACTORY].fadecol = -1;
     sStructureInfo[HEAVYFACTORY].icon = ICON_STR_HEAVYFACTORY;
     sStructureInfo[HEAVYFACTORY].configured = true;
-    sStructureInfo[HEAVYFACTORY].flags.push_back((s_FlagInfo) {
+    sStructureInfo[HEAVYFACTORY].flags.push_back(s_FlagInfo{
             .big = false,
             .relX = 25,
             .relY = 3
@@ -1390,7 +1390,7 @@ void install_structures() {
     sStructureInfo[HIGHTECH].fadecol = -1;
     sStructureInfo[HIGHTECH].icon = ICON_STR_HIGHTECH;
     sStructureInfo[HIGHTECH].configured = true;
-    sStructureInfo[HIGHTECH].flags.push_back((s_FlagInfo) {
+    sStructureInfo[HIGHTECH].flags.push_back(s_FlagInfo{
             .big = true,
             .relX = 19,
             .relY = 36
@@ -1406,7 +1406,7 @@ void install_structures() {
     sStructureInfo[REPAIR].fadecol = -1;
     sStructureInfo[REPAIR].icon = ICON_STR_REPAIR;
     sStructureInfo[REPAIR].configured = true;
-    sStructureInfo[REPAIR].flags.push_back((s_FlagInfo) {
+    sStructureInfo[REPAIR].flags.push_back(s_FlagInfo{
             .big = true,
             .relX = 41,
             .relY = 3
@@ -1421,7 +1421,7 @@ void install_structures() {
     sStructureInfo[PALACE].shadow = (BITMAP *) gfxdata[BUILD_PALACE_SHADOW].dat;
     sStructureInfo[PALACE].icon = ICON_STR_PALACE;
     sStructureInfo[PALACE].configured = true;
-    sStructureInfo[PALACE].flags.push_back((s_FlagInfo) {
+    sStructureInfo[PALACE].flags.push_back(s_FlagInfo{
             .big = true,
             .relX = 28,
             .relY = 14
@@ -1438,7 +1438,7 @@ void install_structures() {
     sStructureInfo[LIGHTFACTORY].fadecol = -1;
     sStructureInfo[LIGHTFACTORY].icon = ICON_STR_LIGHTFACTORY;
     sStructureInfo[LIGHTFACTORY].configured = true;
-    sStructureInfo[LIGHTFACTORY].flags.push_back((s_FlagInfo) {
+    sStructureInfo[LIGHTFACTORY].flags.push_back(s_FlagInfo{
             .big = true,
             .relX = 41,
             .relY = 2
@@ -1456,12 +1456,12 @@ void install_structures() {
     sStructureInfo[RADAR].icon = ICON_STR_RADAR;
     sStructureInfo[RADAR].configured = true;
     // outpost has 2 flags
-    sStructureInfo[RADAR].flags.push_back((s_FlagInfo) {
+    sStructureInfo[RADAR].flags.push_back(s_FlagInfo{
             .big = true,
             .relX = 17,
             .relY = 38
     });
-    sStructureInfo[RADAR].flags.push_back((s_FlagInfo) {
+    sStructureInfo[RADAR].flags.push_back(s_FlagInfo{
             .big = false,
             .relX = 12,
             .relY = 46
@@ -1477,12 +1477,12 @@ void install_structures() {
     sStructureInfo[BARRACKS].fadecol = -1;
     sStructureInfo[BARRACKS].icon = ICON_STR_BARRACKS;
     sStructureInfo[BARRACKS].configured = true;
-    sStructureInfo[BARRACKS].flags.push_back((s_FlagInfo) {
+    sStructureInfo[BARRACKS].flags.push_back(s_FlagInfo{
             .big = false,
             .relX = 60,
             .relY = 47
     });
-    sStructureInfo[BARRACKS].flags.push_back((s_FlagInfo) {
+    sStructureInfo[BARRACKS].flags.push_back(s_FlagInfo{
             .big = false,
             .relX = 51,
             .relY = 50
@@ -1498,7 +1498,7 @@ void install_structures() {
     sStructureInfo[WOR].fadecol = -1;
     sStructureInfo[WOR].icon = ICON_STR_WOR;
     sStructureInfo[WOR].configured = true;
-    sStructureInfo[WOR].flags.push_back((s_FlagInfo) {
+    sStructureInfo[WOR].flags.push_back(s_FlagInfo{
             .big = true,
             .relX = 21,
             .relY = 31
@@ -1516,7 +1516,7 @@ void install_structures() {
     sStructureInfo[SILO].icon = ICON_STR_SILO;
     sStructureInfo[SILO].configured = true;
     sStructureInfo[SILO].queuable = true;
-    sStructureInfo[SILO].flags.push_back((s_FlagInfo) {
+    sStructureInfo[SILO].flags.push_back(s_FlagInfo{
             .big = true,
             .relX = 43,
             .relY = 20
@@ -1532,7 +1532,7 @@ void install_structures() {
     sStructureInfo[REFINERY].fadecol = -1;
     sStructureInfo[REFINERY].icon = ICON_STR_REFINERY;
     sStructureInfo[REFINERY].configured = true;
-    sStructureInfo[REFINERY].flags.push_back((s_FlagInfo) {
+    sStructureInfo[REFINERY].flags.push_back(s_FlagInfo{
             .big = true,
             .relX = 45,
             .relY = 12
@@ -1546,7 +1546,7 @@ void install_structures() {
     sStructureInfo[CONSTYARD].sight = 4;
     sStructureInfo[CONSTYARD].bmp = (BITMAP *) gfxdata[BUILD_CONSTYARD].dat;
     sStructureInfo[CONSTYARD].shadow = (BITMAP *) gfxdata[BUILD_CONSTYARD_SHADOW].dat;
-    sStructureInfo[CONSTYARD].flags.push_back((s_FlagInfo) {
+    sStructureInfo[CONSTYARD].flags.push_back(s_FlagInfo{
             .big = true,
             .relX = 14,
             .relY = 14
@@ -1565,7 +1565,7 @@ void install_structures() {
     sStructureInfo[STARPORT].fadecol = -1;
     sStructureInfo[STARPORT].icon = ICON_STR_STARPORT;
     sStructureInfo[STARPORT].configured = true;
-    sStructureInfo[STARPORT].flags.push_back((s_FlagInfo) {
+    sStructureInfo[STARPORT].flags.push_back(s_FlagInfo{
             .big = true,
             .relX = 16,
             .relY = 3
@@ -1581,7 +1581,7 @@ void install_structures() {
     sStructureInfo[IX].fadecol = -1;
     sStructureInfo[IX].icon = ICON_STR_IX;
     sStructureInfo[IX].configured = true;
-    sStructureInfo[IX].flags.push_back((s_FlagInfo) {
+    sStructureInfo[IX].flags.push_back(s_FlagInfo{
             .big = true,
             .relX = 60, // 60
             .relY = 40  // 40


### PR DESCRIPTION
A mechanical change.
`(type) { a: something, b: something)` turns out to be nonstandard.
The standard form is: `type{ a = something, b = something }`
This is needed to enable C++20 officially, which we are already using with these initializers.