### PR TITLE
sets the C++ standard to 20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 project(d2tm)
 

--- a/cGame_logic.cpp
+++ b/cGame_logic.cpp
@@ -841,8 +841,8 @@ bool cGame::setupGame() {
 
 	// Install timers
 	install_int(allegro_timerunits, 100); // 100 milliseconds
-    install_int(allegro_timergametime, 5); // 5 milliseconds / hence, in 1 second the gametime has passed 1000/5 = 200 times
-    install_int(allegro_timerseconds, 1000); // 1000 milliseconds (seconds)
+  install_int(allegro_timergametime, 5); // 5 milliseconds / hence, in 1 second the gametime has passed 1000/5 = 200 times
+  install_int(allegro_timerseconds, 1000); // 1000 milliseconds (seconds)
 
 	logger->log(LOG_INFO, COMP_ALLEGRO, "Set up timer related variables", "LOCK_VARIABLE/LOCK_FUNCTION", OUTC_SUCCESS);
 

--- a/timers.cpp
+++ b/timers.cpp
@@ -1,27 +1,24 @@
-#include "include/d2tmh.h"
+#include "timers.h"
 
+#include <allegro.h>
 /**
 	Timers lib specific implementations
 **/
 
-#ifdef ALLEGRO_H
-	/** FPS timer **/
-	void allegro_timerseconds() {
-		allegro_timerSecond++;
-	}
-	END_OF_FUNCTION(allegro_timerseconds);
+/** FPS timer **/
+void allegro_timerseconds() {
+  allegro_timerSecond = allegro_timerSecond + 1;
+}
+END_OF_FUNCTION(allegro_timerseconds);
 
-	/** Global timer **/
-	void allegro_timergametime() {
-		allegro_timerGlobal++;
-	}
-	END_OF_FUNCTION(allegro_timergametime);
+/** Global timer **/
+void allegro_timergametime() {
+  allegro_timerGlobal = allegro_timerGlobal + 1;
+}
+END_OF_FUNCTION(allegro_timergametime);
 
-	/** Unit timer **/
-	void allegro_timerunits() {
-		allegro_timerUnits++;
-	}
-	END_OF_FUNCTION(allegro_timerunits);
-#else
-	// Theoretically some other library could be used and have timer specific code here...
-#endif
+/** Unit timer **/
+void allegro_timerunits() {
+  allegro_timerUnits = allegro_timerUnits + 1;
+}
+END_OF_FUNCTION(allegro_timerunits);

--- a/timers.h
+++ b/timers.h
@@ -9,13 +9,12 @@
   2001 - 2021 (c) code by Stefan Hendriks
 
   */
+#pragma once
 
-#ifndef TIMERS_H
-	void allegro_timerseconds();	/** FPS timer **/
-	void allegro_timergametime(); /** Global timer **/
-	void allegro_timerunits();	/** Unit timer **/
+void allegro_timerseconds();	/** FPS timer **/
+void allegro_timergametime(); /** Global timer **/
+void allegro_timerunits();	/** Unit timer **/
 
-	extern volatile int allegro_timerSecond;
-	extern volatile int allegro_timerGlobal;
-	extern volatile int allegro_timerUnits;
-#endif
+extern volatile int allegro_timerSecond;
+extern volatile int allegro_timerGlobal;
+extern volatile int allegro_timerUnits;


### PR DESCRIPTION
Using ++ (or +=) operators on volatile ints is no longer allowed with C++20, because it doesn't work properly. There is more information to be found on this, but the replacement is pretty simple: a = a + 1.