### PR TITLE
Refactor logger to be a self-sufficient singleton

### DIFF
--- a/cGame_logic.cpp
+++ b/cGame_logic.cpp
@@ -666,8 +666,6 @@ void cGame::shutdown() {
 
     logbook("Allegro shut down.");
     logbook("Thanks for playing.");
-
-    cLogger::destroy();
 }
 
 bool cGame::isResolutionInGameINIFoundAndSet() {
@@ -699,8 +697,6 @@ bool cGame::setupGame() {
     cLogger *logger = cLogger::getInstance();
 
     game.init(); // Must be first!
-
-    logger->clearLogFile();
 
     logger->logHeader("Dune II - The Maker");
     logger->logCommentLine(""); // whitespace

--- a/cGame_logic.cpp
+++ b/cGame_logic.cpp
@@ -15,6 +15,7 @@
 #include <random>
 #include "include/d2tmh.h"
 #include "cGame.h"
+#include "utils/cLog.h"
 
 #include <fmt/core.h>
 

--- a/gameobjects/structures/cStructureFactory.cpp
+++ b/gameobjects/structures/cStructureFactory.cpp
@@ -1,6 +1,7 @@
 #include "../../include/d2tmh.h"
 #include "cStructureFactory.h"
 
+#include "utils/cLog.h"
 
 cStructureFactory *cStructureFactory::instance = NULL;
 

--- a/gamestates/cSetupSkirmishGameState.cpp
+++ b/gamestates/cSetupSkirmishGameState.cpp
@@ -2,6 +2,7 @@
 #include "d2tmh.h"
 #include "cSetupSkirmishGameState.h"
 
+#include "utils/cLog.h"
 
 cSetupSkirmishGameState::cSetupSkirmishGameState(cGame &theGame) : cGameState(theGame) {
     for (int i = 0; i < MAX_PLAYERS; i++) {

--- a/include/enums.h
+++ b/include/enums.h
@@ -47,45 +47,6 @@ enum eCantBuildReason {
 	NONE
 };
 
-enum eLogComponent {
-	COMP_UNITS,
-	COMP_STRUCTURES,
-	COMP_GAMEINI,
-	COMP_SCENARIOINI,
-	COMP_PARTICLE,
-	COMP_BULLET,
-	COMP_AI,
-	COMP_UPGRADE_LIST,
-	COMP_BUILDING_LIST_UPDATER,
-	COMP_SIDEBAR,
-	COMP_MAP,
-	COMP_NONE,
-	COMP_INIT,
-	COMP_ALLEGRO,		/** Use for allegro specific calls **/
-	COMP_SETUP,
-	COMP_VERSION,		/** version specific loggin messages **/
-	COMP_SKIRMISHSETUP, /** When skirmish game is being set up **/
-	COMP_ALFONT, 		/** ALFONT library specific **/
-	COMP_SOUND, 		/** Sound related **/
-	COMP_REGIONINI		/** Used for regions **/
-};
-
-enum eLogOutcome {
-	OUTC_SUCCESS,
-	OUTC_FAILED,
-	OUTC_NONE,
-	OUTC_UNKNOWN,
-	OUTC_IGNOREME /** will not be printed **/
-};
-
-enum eLogLevel {
-	LOG_INFO,
-	LOG_TRACE,
-	LOG_WARN,
-	LOG_ERROR,
-	LOG_FATAL
-};
-
 // what is the intent of the action given to the unit?
 enum eUnitActionIntent {
     INTENT_NONE, // none

--- a/include/global.h
+++ b/include/global.h
@@ -2,7 +2,6 @@
 #define GLOBAL_H_
 
 #include "enums.h"
-#include "../utils/cLog.h"							// logger
 #include "../timers.h"							/** declare correct functions at compile time here **/
 
 #include "../utils/d2tm_math.h"

--- a/ini.cpp
+++ b/ini.cpp
@@ -12,6 +12,8 @@
 
 #include "include/d2tmh.h"
 
+#include "utils/cLog.h"
+
 #include <fmt/core.h>
 
 bool INI_Scenario_Section_Units(int iHumanID, bool bSetUpPlayers, const int *iPl_credits, const int *iPl_house,

--- a/sidebar/cBuildingListUpdater.cpp
+++ b/sidebar/cBuildingListUpdater.cpp
@@ -1,6 +1,7 @@
 #include "include/d2tmh.h"
 #include "cBuildingListUpdater.h"
 
+#include "utils/cLog.h"
 
 cBuildingListUpdater::cBuildingListUpdater(cPlayer *thePlayer) {
 	assert(thePlayer);

--- a/sidebar/cSideBar.cpp
+++ b/sidebar/cSideBar.cpp
@@ -1,6 +1,7 @@
 #include "../include/d2tmh.h"
 #include "cSideBar.h"
 
+#include "utils/cLog.h"
 
 cSideBar::cSideBar(cPlayer * thePlayer) : player(thePlayer) {
     assert(thePlayer != nullptr && "Expected player to be not null!");

--- a/utils/cLog.cpp
+++ b/utils/cLog.cpp
@@ -44,10 +44,10 @@ std::string getLogComponentString(eLogComponent component) {
             return std::string("BULLET");
         case COMP_AI:
             return std::string("AI");
-    case COMP_UPGRADE_LIST:
-      return std::string("UPGRADE_LIST");
-      case COMP_BUILDING_LIST_UPDATER:
-      return std::string("BUILDING_LIST_UPDATER");
+        case COMP_UPGRADE_LIST:
+            return std::string("UPGRADE_LIST");
+        case COMP_BUILDING_LIST_UPDATER:
+            return std::string("BUILDING_LIST_UPDATER");
         case COMP_MAP:
             return std::string("MAP");
         case COMP_SIDEBAR:
@@ -83,12 +83,13 @@ std::string getLogOutcomeString(eLogOutcome outcome) {
             return std::string("FAILED");
         case OUTC_NONE:
             return std::string("NONE");
-      case OUTC_UNKNOWN:
-      break;
-      case OUTC_IGNOREME:
-      break;
+        case OUTC_UNKNOWN:
+            break;
+        case OUTC_IGNOREME:
+            break;
     }
-     return std::string("UNIDENTIFIED");
+
+    return std::string("UNIDENTIFIED");
 }
 
 std::string getLogHouseString(int houseId) {
@@ -114,9 +115,9 @@ std::string getLogHouseString(int houseId) {
 }
 
 cLogger* cLogger::getInstance() {
-  // The logger is initialized once as soon as this function is called for the first time.
-  static cLogger theLogger;
-  return &theLogger;
+    // The logger is initialized once as soon as this function is called for the first time.
+    static cLogger theLogger;
+    return &theLogger;
 }
 
 void cLogger::log(eLogLevel level, eLogComponent component, const std::string& event, const std::string& message) {
@@ -149,8 +150,8 @@ void cLogger::log(eLogLevel level, eLogComponent component, const std::string& e
     logline += "|";
 
     if (playerId >= GENERALHOUSE) {
-            logline += getLogHouseString(houseId);
-            logline += "|";
+        logline += getLogHouseString(houseId);
+        logline += "|";
     }
 
     if (playerId >= HUMAN) {
@@ -168,7 +169,7 @@ void cLogger::log(eLogLevel level, eLogComponent component, const std::string& e
 
     logline += event;
 
-  fprintf(file, "%s\n", logline.c_str()); // print the text into the file
+    fprintf(file, "%s\n", logline.c_str()); // print the text into the file
 }
 
 void cLogger::logCommentLine(const std::string& txt) {
@@ -176,7 +177,7 @@ void cLogger::logCommentLine(const std::string& txt) {
 }
 
 void cLogger::logHeader(const std::string& txt) {
-  auto str = txt.substr(0, 79);
+    auto str = txt.substr(0, 79);
     auto line = std::string(str.length(), '-');
 
     logCommentLine(str);
@@ -186,14 +187,14 @@ void cLogger::logHeader(const std::string& txt) {
 
 
 cLogger::cLogger() : file(std::fopen("log.txt", "wt")), startTime(std::clock()) {
-  if (file == nullptr) {
-    // This translates the POSIX error number into a C++ exception
-    throw std::system_error(errno, std::generic_category());
-  }
+    if (file == nullptr) {
+        // This translates the POSIX error number into a C++ exception
+        throw std::system_error(errno, std::generic_category());
+    }
 }
 
 cLogger::~cLogger() {
-  fclose(file);
+    fclose(file);
 }
 
 /* From 1970-01-01T00:00:00 */

--- a/utils/cLog.cpp
+++ b/utils/cLog.cpp
@@ -180,9 +180,9 @@ void cLogger::logHeader(const std::string& txt) {
     auto str = txt.substr(0, 79);
     auto line = std::string(str.length(), '-');
 
+    logCommentLine(line);
     logCommentLine(str);
-    logCommentLine(txt);
-    logCommentLine(str);
+    logCommentLine(line);
 }
 
 

--- a/utils/cLog.cpp
+++ b/utils/cLog.cpp
@@ -1,262 +1,203 @@
-#include "../include/d2tmh.h"
 #include "cLog.h"
 
+#include "definitions.h"
 
-cLogger *cLogger::instance = NULL;
+#include <cstdio>
+#include <ctime>
+#include <system_error>
 
-cLogger::cLogger() {
-	startTime = clock();
+extern bool	bDoDebug;
+
+namespace {
+
+std::string getLogLevelString(eLogLevel level) {
+    // LOG_TRACE, LOG_WARN, LOG_ERROR, LOG_FATAL
+    switch (level) {
+        case LOG_FATAL:
+            return std::string("FATAL");
+        case LOG_WARN:
+            return std::string("WARN");
+        case LOG_ERROR:
+            return std::string("ERROR");
+        case LOG_TRACE:
+            return std::string("TRACE");
+        case LOG_INFO:
+            return std::string("INFO");
+    }
+
+    return std::string("UNIDENTIFIED");
 }
 
-cLogger::~cLogger() {
-}
-
-cLogger *cLogger::getInstance() {
-	if (instance == NULL) {
-		instance = new cLogger();
-		logbook("New instance of Logger created");
-	}
-
-	return instance;
-}
-
-std::string cLogger::getLogLevelString(eLogLevel level) {
-	// LOG_TRACE, LOG_WARN, LOG_ERROR, LOG_FATAL
-	switch (level) {
-		case LOG_FATAL:
-			return std::string("FATAL");
-		case LOG_WARN:
-			return std::string("WARN");
-		case LOG_ERROR:
-			return std::string("ERROR");
-		case LOG_TRACE:
-			return std::string("TRACE");
-		case LOG_INFO:
-			return std::string("INFO");
-	}
-
-	return std::string("UNIDENTIFIED");
-}
-
-std::string cLogger::getLogComponentString(eLogComponent component) {
-	switch(component) {
-		case COMP_UNITS:
-			return std::string("UNITS");
-		case COMP_STRUCTURES:
-			return std::string("STRUCTURES");
-		case COMP_GAMEINI:
-			return std::string("GAMEINI");
-		case COMP_SCENARIOINI:
-			return std::string("SCENARIOINI");
-		case COMP_PARTICLE:
-			return std::string("PARTICLE");
-		case COMP_BULLET:
-			return std::string("BULLET");
-		case COMP_AI:
-			return std::string("AI");
+std::string getLogComponentString(eLogComponent component) {
+    switch(component) {
+        case COMP_UNITS:
+            return std::string("UNITS");
+        case COMP_STRUCTURES:
+            return std::string("STRUCTURES");
+        case COMP_GAMEINI:
+            return std::string("GAMEINI");
+        case COMP_SCENARIOINI:
+            return std::string("SCENARIOINI");
+        case COMP_PARTICLE:
+            return std::string("PARTICLE");
+        case COMP_BULLET:
+            return std::string("BULLET");
+        case COMP_AI:
+            return std::string("AI");
     case COMP_UPGRADE_LIST:
       return std::string("UPGRADE_LIST");
-	  case COMP_BUILDING_LIST_UPDATER:
+      case COMP_BUILDING_LIST_UPDATER:
       return std::string("BUILDING_LIST_UPDATER");
-		case COMP_MAP:
-			return std::string("MAP");
-		case COMP_SIDEBAR:
-			return std::string("SIDEBAR");
-		case COMP_NONE:
-			return std::string("NONE");
-		case COMP_SETUP:
-			return std::string("SETUP");
-		case COMP_INIT:
-			return std::string("INIT");
-		case COMP_ALLEGRO:
-			return std::string("ALLEGRO");
-		case COMP_VERSION:
-			return std::string("VERSION");
-		case COMP_SKIRMISHSETUP:
-			return std::string("SKIRMISHSETUP");
-		case COMP_ALFONT:
-			return std::string("ALFONT");
-		case COMP_SOUND:
-			return std::string("SOUND");
-		case COMP_REGIONINI:
-			return std::string("REGIONINI");
-	}
+        case COMP_MAP:
+            return std::string("MAP");
+        case COMP_SIDEBAR:
+            return std::string("SIDEBAR");
+        case COMP_NONE:
+            return std::string("NONE");
+        case COMP_SETUP:
+            return std::string("SETUP");
+        case COMP_INIT:
+            return std::string("INIT");
+        case COMP_ALLEGRO:
+            return std::string("ALLEGRO");
+        case COMP_VERSION:
+            return std::string("VERSION");
+        case COMP_SKIRMISHSETUP:
+            return std::string("SKIRMISHSETUP");
+        case COMP_ALFONT:
+            return std::string("ALFONT");
+        case COMP_SOUND:
+            return std::string("SOUND");
+        case COMP_REGIONINI:
+            return std::string("REGIONINI");
+    }
 
-	return std::string("UNIDENTIFIED");
+    return std::string("UNIDENTIFIED");
 }
 
-std::string cLogger::getLogOutcomeString(eLogOutcome outcome) {
-	switch (outcome) {
-		case OUTC_SUCCESS:
-			return std::string("SUCCESS");
-		case OUTC_FAILED:
-			return std::string("FAILED");
-		case OUTC_NONE:
-			return std::string("NONE");
-	  case OUTC_UNKNOWN:
+std::string getLogOutcomeString(eLogOutcome outcome) {
+    switch (outcome) {
+        case OUTC_SUCCESS:
+            return std::string("SUCCESS");
+        case OUTC_FAILED:
+            return std::string("FAILED");
+        case OUTC_NONE:
+            return std::string("NONE");
+      case OUTC_UNKNOWN:
       break;
-	  case OUTC_IGNOREME:
+      case OUTC_IGNOREME:
       break;
-	}
- 	return std::string("UNIDENTIFIED");
+    }
+     return std::string("UNIDENTIFIED");
 }
 
-std::string cLogger::getLogHouseString(int houseId) {
-	switch (houseId) {
-		case ATREIDES:
-			return std::string("ATREIDES");
-		case HARKONNEN:
-			return std::string("HARKONNEN");
-		case ORDOS:
-			return std::string("ORDOS");
-		case FREMEN:
-			return std::string("FREMEN");
-		case SARDAUKAR:
-			return std::string("SARDAUKAR");
-		case MERCENARY:
-			return std::string("MERCENARY");
-		default:
-			return std::string("UNKNOWN HOUSE");
-	}
-	return std::string("UNIDENTIFIED");
+std::string getLogHouseString(int houseId) {
+    switch (houseId) {
+        case ATREIDES:
+            return std::string("ATREIDES");
+        case HARKONNEN:
+            return std::string("HARKONNEN");
+        case ORDOS:
+            return std::string("ORDOS");
+        case FREMEN:
+            return std::string("FREMEN");
+        case SARDAUKAR:
+            return std::string("SARDAUKAR");
+        case MERCENARY:
+            return std::string("MERCENARY");
+        default:
+            return std::string("UNKNOWN HOUSE");
+    }
+    return std::string("UNIDENTIFIED");
 }
 
-
-// courtesy from : http://www.codeguru.com/forum/showthread.php?t=477894
-std::string cLogger::getCurrentFormattedTime() {
-	char szBuffer[80];
-
-	auto ts = localtime(&current_time);
-
-	// Format the time
-	strftime(szBuffer, sizeof(szBuffer), "%H:%M:%S", ts);
-
-	return szBuffer;
 }
 
-void cLogger::updateTime() {
-	current_time = time (NULL);
-}
-
-void cLogger::logHeader(const char *txt) {
-	int length = strlen(txt);
-	if (length > 79) length = 79;
-	std::string line(length, '-');
-
-	char *str = new char[line.length() + 1];
-	strcpy(str, line.c_str());
-
-	logCommentLine(str);
-	logCommentLine(txt);
-	logCommentLine(str);
-
-	delete[] str;
+cLogger* cLogger::getInstance() {
+  // The logger is initialized once as soon as this function is called for the first time.
+  static cLogger theLogger;
+  return &theLogger;
 }
 
 void cLogger::log(eLogLevel level, eLogComponent component, const std::string& event, const std::string& message) {
-	log(level, component, event, message.c_str(), OUTC_IGNOREME, -1, -1);
+    log(level, component, event, message.c_str(), OUTC_IGNOREME, -1, -1);
 }
 
 void cLogger::log(eLogLevel level, eLogComponent component, const std::string& event, const std::string& message, eLogOutcome outcome) {
-	log(level, component, event, message.c_str(), outcome, -1, -1);
+    log(level, component, event, message.c_str(), outcome, -1, -1);
 }
 
 //	Timestamp | Level | Component | House (if component requires) | ID (if component requires) | Message | Outcome | Event | Event fields...
 void cLogger::log(eLogLevel level, eLogComponent component, const std::string& event, const std::string& message, eLogOutcome outcome, int playerId, int houseId) {
-	updateTime();
+    if (level == LOG_TRACE) {
+        if (!DEBUGGING) {
+            // trace level is only in debug mode
+            return;
+        }
+    }
 
-	if (level == LOG_TRACE) {
-	    if (!DEBUGGING) {
-	        // trace level is only in debug mode
-	        return;
-	    }
-	}
+    auto diffTime = getTimeInMilisDifference();
 
-	int diffTime = getTimeInMilisDifference();
+    // log line starts with time
+    std::string logline = std::to_string(diffTime);
+    logline += "|";
 
-	// log line starts with time
-	std::string logline = getLongAsString(diffTime);
-	//= getCurrentFormattedTime();
+    logline += getLogLevelString(level);
+    logline += "|";
 
-	logline += "|"; // add first pipe
+    logline += getLogComponentString(component);
+    logline += "|";
 
-	std::string sLevel = getLogLevelString(level);
-	std::string sComponent = getLogComponentString(component);
+    if (playerId >= GENERALHOUSE) {
+            logline += getLogHouseString(houseId);
+            logline += "|";
+    }
 
-	logline += sLevel;
-	logline += "|";
-	logline += sComponent;
+    if (playerId >= HUMAN) {
+        logline += std::to_string(playerId);
+        logline += "|";
+    }
 
-	if (playerId >= GENERALHOUSE) {
-			logline += "|";
-			logline += getLogHouseString(houseId);
-	}
+    logline += message;
+        logline += "|";
 
-	if (playerId >= HUMAN) {
-		logline += "|";
-		logline += getIntegerAsString(playerId);
-	}
+    if (outcome != OUTC_IGNOREME) {
+        logline += getLogOutcomeString(outcome);
+        logline += "|";
+    }
 
-	logline += "|";
-	logline += message;
+    logline += event;
 
-	if (outcome != OUTC_IGNOREME) {
-		std::string sOutcome = getLogOutcomeString(outcome);
-		logline += "|";
-		logline += sOutcome;
-	}
-
-	logline += "|";
-	logline += event;
-
-	// TODO: here could come other fields later
-
-	file = fopen("log.txt", "at");
-	if (file) {
-		fprintf(file, "%s\n", logline.c_str()); // print the text into the file
-		fclose(file);
-	}
+  fprintf(file, "%s\n", logline.c_str()); // print the text into the file
 }
 
-std::string cLogger::getIntegerAsString(int value) {
-	char numberChar[32];
-	sprintf(numberChar, "%d", value);
-	return std::string(numberChar);
+void cLogger::logCommentLine(const std::string& txt) {
+    fprintf(file, "\\\\%s\n", txt.c_str()); // print the text into the file
 }
 
-std::string cLogger::getLongAsString(long value) {
-	char numberChar[256];
-	sprintf(numberChar, "%ld", value);
-	return std::string(numberChar);
+void cLogger::logHeader(const std::string& txt) {
+  auto str = txt.substr(0, 79);
+    auto line = std::string(str.length(), '-');
+
+    logCommentLine(str);
+    logCommentLine(txt);
+    logCommentLine(str);
 }
 
-void cLogger::logCommentLine(const char *txt) {
-	file = fopen("log.txt", "at");
-	if (file) {
-		fprintf(file, "\\\\%s\n", txt); // print the text into the file
-		fclose(file);
-	}
+
+cLogger::cLogger() : file(std::fopen("log.txt", "wt")), startTime(std::clock()) {
+  if (file == nullptr) {
+    // This translates the POSIX error number into a C++ exception
+    throw std::system_error(errno, std::generic_category());
+  }
+}
+
+cLogger::~cLogger() {
+  fclose(file);
 }
 
 /* From 1970-01-01T00:00:00 */
-long cLogger::getTimeInMilisDifference() {
-	long time_taken_millis;
-	time_taken_millis = (long)((clock()-startTime)*1E3/CLOCKS_PER_SEC);
-	return time_taken_millis;
-}
-
-void cLogger::destroy() {
-    if (instance) {
-        delete instance;
-    }
-}
-
-void cLogger::clearLogFile() {
-    // Each time we run the game, we clear out the logfile
-    FILE *fp = fopen("log.txt", "wt");
-
-    // this will empty the log file (create a new one)
-    if (fp)	{
-        fclose(fp);
-    }
+long cLogger::getTimeInMilisDifference() const {
+    long time_taken_millis = (std::clock() - startTime) * 1E3 / CLOCKS_PER_SEC;
+    return time_taken_millis;
 }

--- a/utils/cLog.cpp
+++ b/utils/cLog.cpp
@@ -14,62 +14,62 @@ std::string getLogLevelString(eLogLevel level) {
     // LOG_TRACE, LOG_WARN, LOG_ERROR, LOG_FATAL
     switch (level) {
         case LOG_FATAL:
-            return std::string("FATAL");
+            return "FATAL";
         case LOG_WARN:
-            return std::string("WARN");
+            return "WARN";
         case LOG_ERROR:
-            return std::string("ERROR");
+            return "ERROR";
         case LOG_TRACE:
-            return std::string("TRACE");
+            return "TRACE";
         case LOG_INFO:
-            return std::string("INFO");
+            return "INFO";
     }
 
-    return std::string("UNIDENTIFIED");
+    return "UNIDENTIFIED";
 }
 
 std::string getLogComponentString(eLogComponent component) {
     switch(component) {
         case COMP_UNITS:
-            return std::string("UNITS");
+            return "UNITS";
         case COMP_STRUCTURES:
-            return std::string("STRUCTURES");
+            return "STRUCTURES";
         case COMP_GAMEINI:
-            return std::string("GAMEINI");
+            return "GAMEINI";
         case COMP_SCENARIOINI:
-            return std::string("SCENARIOINI");
+            return "SCENARIOINI";
         case COMP_PARTICLE:
-            return std::string("PARTICLE");
+            return "PARTICLE";
         case COMP_BULLET:
-            return std::string("BULLET");
+            return "BULLET";
         case COMP_AI:
-            return std::string("AI");
+            return "AI";
         case COMP_UPGRADE_LIST:
-            return std::string("UPGRADE_LIST");
+            return "UPGRADE_LIST";
         case COMP_BUILDING_LIST_UPDATER:
-            return std::string("BUILDING_LIST_UPDATER");
+            return "BUILDING_LIST_UPDATER";
         case COMP_MAP:
-            return std::string("MAP");
+            return "MAP";
         case COMP_SIDEBAR:
-            return std::string("SIDEBAR");
+            return "SIDEBAR";
         case COMP_NONE:
-            return std::string("NONE");
+            return "NONE";
         case COMP_SETUP:
-            return std::string("SETUP");
+            return "SETUP";
         case COMP_INIT:
-            return std::string("INIT");
+            return "INIT";
         case COMP_ALLEGRO:
-            return std::string("ALLEGRO");
+            return "ALLEGRO";
         case COMP_VERSION:
-            return std::string("VERSION");
+            return "VERSION";
         case COMP_SKIRMISHSETUP:
-            return std::string("SKIRMISHSETUP");
+            return "SKIRMISHSETUP";
         case COMP_ALFONT:
-            return std::string("ALFONT");
+            return "ALFONT";
         case COMP_SOUND:
-            return std::string("SOUND");
+            return "SOUND";
         case COMP_REGIONINI:
-            return std::string("REGIONINI");
+            return "REGIONINI";
     }
 
     return std::string("UNIDENTIFIED");
@@ -78,38 +78,38 @@ std::string getLogComponentString(eLogComponent component) {
 std::string getLogOutcomeString(eLogOutcome outcome) {
     switch (outcome) {
         case OUTC_SUCCESS:
-            return std::string("SUCCESS");
+            return "SUCCESS";
         case OUTC_FAILED:
-            return std::string("FAILED");
+            return "FAILED";
         case OUTC_NONE:
-            return std::string("NONE");
+            return "NONE";
         case OUTC_UNKNOWN:
-            break;
+            return "UNKNOWN";
         case OUTC_IGNOREME:
-            break;
+            return "IGNOREME";
     }
 
-    return std::string("UNIDENTIFIED");
+    return "UNIDENTIFIED";
 }
 
 std::string getLogHouseString(int houseId) {
     switch (houseId) {
         case ATREIDES:
-            return std::string("ATREIDES");
+            return "ATREIDES";
         case HARKONNEN:
-            return std::string("HARKONNEN");
+            return "HARKONNEN";
         case ORDOS:
-            return std::string("ORDOS");
+            return "ORDOS";
         case FREMEN:
-            return std::string("FREMEN");
+            return "FREMEN";
         case SARDAUKAR:
-            return std::string("SARDAUKAR");
+            return "SARDAUKAR";
         case MERCENARY:
-            return std::string("MERCENARY");
+            return "MERCENARY";
         default:
-            return std::string("UNKNOWN HOUSE");
+            return "UNKNOWN HOUSE";
     }
-    return std::string("UNIDENTIFIED");
+    return "UNIDENTIFIED";
 }
 
 }

--- a/utils/cLog.h
+++ b/utils/cLog.h
@@ -1,48 +1,66 @@
-#ifndef D2TM_CLOG_H_
-#define D2TM_CLOG_H_
+#pragma once
 
-class cLogger {
+#include <cstdio>
+#include <string>
 
-public:
-	void log(eLogLevel level, eLogComponent component, const std::string& event, const std::string& message);
-	void log(eLogLevel level, eLogComponent component, const std::string& event, const std::string& message, eLogOutcome outcome, int playerId, int houseId);
-	void log(eLogLevel level, eLogComponent component, const std::string& event, const std::string& message, eLogOutcome outcome);
-
-	void logCommentLine(const char *txt);
-
-	void logHeader(const char *txt);
-
-	static cLogger *getInstance();
-	static void destroy();
-
-    void clearLogFile();
-
-private:
-	FILE *file;
-
-	time_t current_time;
-
-	std::string getLogLevelString(eLogLevel level);
-	std::string getLogComponentString(eLogComponent component);
-	std::string getLogOutcomeString(eLogOutcome outcome);
-
-	std::string getCurrentFormattedTime();
-	std::string getLogHouseString(int houseId);
-
-	void updateTime();
-
-	static cLogger *instance;
-
-	std::string getIntegerAsString(int value);
-	std::string getLongAsString(long value);
-
-	long startTime; // start time of logging in miliseconds
-
-	long getTimeInMilisDifference();
-protected:
-	cLogger();
-	~cLogger();
-
+enum eLogLevel {
+    LOG_INFO,
+    LOG_TRACE,
+    LOG_WARN,
+    LOG_ERROR,
+    LOG_FATAL
 };
 
-#endif
+enum eLogComponent {
+    COMP_UNITS,
+    COMP_STRUCTURES,
+    COMP_GAMEINI,
+    COMP_SCENARIOINI,
+    COMP_PARTICLE,
+    COMP_BULLET,
+    COMP_AI,
+    COMP_UPGRADE_LIST,
+    COMP_BUILDING_LIST_UPDATER,
+    COMP_SIDEBAR,
+    COMP_MAP,
+    COMP_NONE,
+    COMP_INIT,
+    COMP_ALLEGRO,		/** Use for allegro specific calls **/
+    COMP_SETUP,
+    COMP_VERSION,		/** version specific loggin messages **/
+    COMP_SKIRMISHSETUP, /** When skirmish game is being set up **/
+    COMP_ALFONT, 		/** ALFONT library specific **/
+    COMP_SOUND, 		/** Sound related **/
+    COMP_REGIONINI		/** Used for regions **/
+};
+
+enum eLogOutcome {
+    OUTC_SUCCESS,
+    OUTC_FAILED,
+    OUTC_NONE,
+    OUTC_UNKNOWN,
+    OUTC_IGNOREME /** will not be printed **/
+};
+
+class cLogger {
+  public:
+      static cLogger* getInstance();
+
+      void log(eLogLevel level, eLogComponent component, const std::string& event, const std::string& message);
+      void log(eLogLevel level, eLogComponent component, const std::string& event, const std::string& message, eLogOutcome outcome, int playerId, int houseId);
+      void log(eLogLevel level, eLogComponent component, const std::string& event, const std::string& message, eLogOutcome outcome);
+
+      void logCommentLine(const std::string& txt);
+
+      void logHeader(const std::string& txt);
+
+  private:
+      cLogger();
+      ~cLogger();
+
+      std::FILE* file;
+
+      long startTime; // start time of logging in miliseconds
+
+      long getTimeInMilisDifference() const;
+};

--- a/utils/common.cpp
+++ b/utils/common.cpp
@@ -12,6 +12,8 @@
 
 #include "../include/d2tmh.h"
 
+#include "utils/cLog.h"
+
 #include <math.h>
 
 namespace


### PR DESCRIPTION
Now it can be used from other singletons too. This is useful if we turn cSoundPlayer into a singleton, for example.
The logger initializes itself now and clears the logfile.
