### PR TITLE
enable pedantic and zero-as-null-pointer-constant warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,9 +90,11 @@ target_compile_options(${PROJECT_NAME}
     "-Werror"
     "-Wall"
     "-Wextra"
+    "-Wpedantic"
     "-Wnon-virtual-dtor"
     "-Wuseless-cast"
     "-Wredundant-tags"
+    "-Wzero-as-null-pointer-constant"
 )
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD

--- a/cGame_logic.cpp
+++ b/cGame_logic.cpp
@@ -1052,10 +1052,8 @@ bool cGame::setupGame() {
     allegroDrawer = new cAllegroDrawer(m_dataRepository);
 
     // randomize timer
-    unsigned int t = (unsigned int) time(0);
-    char seedtxt[80];
-    sprintf(seedtxt, "Seed is %u", t);
-    logbook(seedtxt);
+    auto t = static_cast<unsigned int>(time(nullptr));
+    logbook(fmt::format("Seed is {}", t));
     srand(t);
 
     game.bPlaying = true;


### PR DESCRIPTION
More warnings. Pedantic is to make sure we keep writing standard C++. That will help us if we ever want to build with MSVC or Clang.
