### PR TITLE
encapsulate all sound and music in cSoundPlayer

### DIFF
--- a/building/cItemBuilder.cpp
+++ b/building/cItemBuilder.cpp
@@ -1,6 +1,5 @@
 #include "cItemBuilder.h"
 
-#include "data/gfxaudio.h"
 #include "d2tmc.h"
 #include "gameobjects/structures/cAbstractStructure.h"
 #include "gameobjects/units/cUnit.h"
@@ -11,8 +10,8 @@
 #include "structs.h"
 #include "utils/cLog.h"
 #include "utils/common.h"
+#include "utils/cSoundPlayer.h"
 #include "utils/d2tm_math.h"
-
 
 #include <allegro/keyboard.h>
 
@@ -194,7 +193,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item) {
         // play voice when placeIt is false`
         if (!item->shouldPlaceIt()) {
             if (player->isHuman()) {
-                play_voice(SOUND_VOICE_01_ATR); // "Construction Complete"
+                game.getSoundPlayer().playVoice(SOUND_VOICE_01_ATR, player->getHouse()); // "Construction Complete"
             }
             item->setPlaceIt(true);
 

--- a/building/cItemBuilder.cpp
+++ b/building/cItemBuilder.cpp
@@ -193,7 +193,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item) {
         // play voice when placeIt is false`
         if (!item->shouldPlaceIt()) {
             if (player->isHuman()) {
-                game.getSoundPlayer().playVoice(SOUND_VOICE_01_ATR, player->getHouse()); // "Construction Complete"
+                game.playVoice(SOUND_VOICE_01_ATR, player->getHouse()); // "Construction Complete"
             }
             item->setPlaceIt(true);
 

--- a/building/cItemBuilder.cpp
+++ b/building/cItemBuilder.cpp
@@ -433,7 +433,7 @@ void cItemBuilder::deployUnit(cBuildingListItem *item, int buildId) const {
  */
 int cItemBuilder::getFreeSlot() {
 	for (int i = 0; i < MAX_ITEMS; i++) {
-		if (items[i] == NULL) {
+		if (items[i] == nullptr) {
 			return i; // return free slot
 		}
 	}
@@ -517,7 +517,7 @@ cBuildingListItem *cItemBuilder::findBuildingListItemOfSameListAs(cBuildingListI
             return listItem;
         }
 	}
-	return NULL;
+	return nullptr;
 }
 
 /**

--- a/cGame.h
+++ b/cGame.h
@@ -87,7 +87,7 @@ public:
 
 	void setup_players();
 
-    void think_music();
+    void think_audio();
 
 	void think_mentat();
 
@@ -103,9 +103,14 @@ public:
     // Use this instead
 	void setNextStateToTransitionTo(int newState);
 
-	cSoundPlayer& getSoundPlayer() {
-	    return *_soundplayer;
-	}
+    // Game acts as a facade, delegates to sound player
+    void playSound(int sampleId); // Maximum volume
+    void playSound(int sampleId, int vol);
+
+    void playVoice(int sampleId, int house);
+    void playMusic(int sampleId);
+
+    int getMaxVolume();
 
     int getColorFadeSelected(int r, int g, int b) {
         // Fade with all rgb

--- a/cGame.h
+++ b/cGame.h
@@ -17,7 +17,6 @@
 #include "definitions.h"
 #include "observers/cScenarioObserver.h"
 #include "utils/cRectangle.h"
-#include "utils/cSoundPlayer.h"
 
 #include <memory>
 #include <string>
@@ -28,6 +27,7 @@ class cGameState;
 class cInteractionManager;
 class cPlatformLayerInit;
 class cPlayer;
+class cSoundPlayer;
 
 class cGame : public cScenarioObserver, cInputObserver {
 
@@ -103,10 +103,8 @@ public:
     // Use this instead
 	void setNextStateToTransitionTo(int newState);
 
-	int getMaxVolume() { return iMaxVolume; }
-
-	cSoundPlayer * getSoundPlayer() {
-	    return soundPlayer;
+	cSoundPlayer& getSoundPlayer() {
+	    return *_soundplayer;
 	}
 
     int getColorFadeSelected(int r, int g, int b) {
@@ -219,15 +217,14 @@ private:
     cInteractionManager *_interactionManager;
     cAllegroDataRepository *m_dataRepository;
 
-    cSoundPlayer *soundPlayer;
+    std::unique_ptr<cSoundPlayer> _soundplayer;
+
     cMouse *mouse;
     cKeyboard *keyboard;
 
     bool missionWasWon; // hack: used for state transitioning :/
 
 	int state;
-
-	int iMaxVolume;
 
 	cAbstractMentat *pMentat; // TODO: Move this into a currentState class (as field)?
 

--- a/cGame_logic.cpp
+++ b/cGame_logic.cpp
@@ -109,7 +109,7 @@ void cGame::init() {
     // Load properties
     INI_Install_Game(game_filename);
 
-    mp3_music = NULL;
+    mp3_music = nullptr;
 }
 
 // TODO: Bad smell (duplicate code)
@@ -382,8 +382,10 @@ void cGame::think_mentat() {
     }
 }
 
-// TODO: Move to music related class (MusicPlayer?)
-void cGame::think_music() {
+// think function belongs to combat state (tbd)
+void cGame::think_audio() {
+    _soundplayer->think();
+
     if (!game.bPlayMusic) // no music enabled, so no need to think
         return;
 
@@ -833,7 +835,7 @@ bool cGame::setupGame() {
 
     game_font = alfont_load_font("data/arakeen.fon");
 
-    if (game_font != NULL) {
+    if (game_font != nullptr) {
         logger->log(LOG_INFO, COMP_ALFONT, "Loading font", "loaded arakeen.fon", OUTC_SUCCESS);
         alfont_set_font_size(game_font, GAME_FONTSIZE); // set size
     } else {
@@ -845,7 +847,7 @@ bool cGame::setupGame() {
 
     bene_font = alfont_load_font("data/benegess.fon");
 
-    if (bene_font != NULL) {
+    if (bene_font != nullptr) {
         logger->log(LOG_INFO, COMP_ALFONT, "Loading font", "loaded benegess.fon", OUTC_SUCCESS);
         alfont_set_font_size(bene_font, 10); // set size
     } else {
@@ -856,7 +858,7 @@ bool cGame::setupGame() {
 
     small_font = alfont_load_font("data/small.ttf");
 
-    if (small_font != NULL) {
+    if (small_font != nullptr) {
         logger->log(LOG_INFO, COMP_ALFONT, "Loading font", "loaded small.ttf", OUTC_SUCCESS);
         alfont_set_font_size(small_font, 10); // set size
     } else {
@@ -890,7 +892,7 @@ bool cGame::setupGame() {
 
     bmp_screen = create_bitmap(game.screen_x, game.screen_y);
 
-    if (bmp_screen == NULL) {
+    if (bmp_screen == nullptr) {
         allegro_message("Failed to create a memory bitmap");
         logbook("ERROR: Could not create bitmap: bmp_screen");
         return false;
@@ -901,7 +903,7 @@ bool cGame::setupGame() {
 
     bmp_backgroundMentat = create_bitmap(game.screen_x, game.screen_y);
 
-    if (bmp_backgroundMentat == NULL) {
+    if (bmp_backgroundMentat == nullptr) {
         allegro_message("Failed to create a memory bitmap");
         logbook("ERROR: Could not create bitmap: bmp_backgroundMentat");
         return false;
@@ -943,7 +945,7 @@ bool cGame::setupGame() {
 
     bmp_throttle = create_bitmap(game.screen_x, game.screen_y);
 
-    if (bmp_throttle == NULL) {
+    if (bmp_throttle == nullptr) {
         allegro_message("Failed to create a memory bitmap");
         logbook("ERROR: Could not create bitmap: bmp_throttle");
         return false;
@@ -953,7 +955,7 @@ bool cGame::setupGame() {
 
     bmp_winlose = create_bitmap(game.screen_x, game.screen_y);
 
-    if (bmp_winlose == NULL) {
+    if (bmp_winlose == nullptr) {
         allegro_message("Failed to create a memory bitmap");
         logbook("ERROR: Could not create bitmap: bmp_winlose");
         return false;
@@ -963,7 +965,7 @@ bool cGame::setupGame() {
 
     bmp_fadeout = create_bitmap(game.screen_x, game.screen_y);
 
-    if (bmp_fadeout == NULL) {
+    if (bmp_fadeout == nullptr) {
         allegro_message("Failed to create a memory bitmap");
         logbook("ERROR: Could not create bitmap: bmp_fadeout");
         return false;
@@ -1682,3 +1684,22 @@ void cGame::onKeyPressedGamePlaying(const cKeyboardEvent &event) {
     }
 }
 
+void cGame::playSound(int sampleId) {
+    _soundplayer->playSound(sampleId);
+}
+
+void cGame::playSound(int sampleId, int vol) {
+    _soundplayer->playSound(sampleId, vol);
+}
+
+void cGame::playVoice(int sampleId, int house) {
+    _soundplayer->playVoice(sampleId, house);
+}
+
+void cGame::playMusic(int sampleId) {
+    _soundplayer->playMusic(sampleId);
+}
+
+int cGame::getMaxVolume() {
+    return _soundplayer->getMaxVolume();
+}

--- a/controls/mousestates/cMouseNormalState.cpp
+++ b/controls/mousestates/cMouseNormalState.cpp
@@ -3,14 +3,13 @@
 #include "controls/cGameControlsContext.h"
 
 #include "utils/cRectangle.h"
+#include "utils/cSoundPlayer.h"
 #include "gameobjects/units/cUnit.h"
 #include "gameobjects/structures/cAbstractStructure.h"
 #include "player/cPlayer.h"
-//#include "sidebar/cSideBar.h"
 
 #include "d2tmc.h"
 
-#include "data/gfxaudio.h"
 #include "data/gfxdata.h"
 
 #include <algorithm>
@@ -103,11 +102,11 @@ void cMouseNormalState::onMouseLeftButtonClicked() {
         }
 
         if (unitSelected) {
-            play_sound_id(SOUND_REPORTING);
+            game.getSoundPlayer().playSound(SOUND_REPORTING);
         }
 
         if (infantrySelected) {
-            play_sound_id(SOUND_YESSIR);
+            game.getSoundPlayer().playSound(SOUND_YESSIR);
         }
 
         selectedUnits = unitSelected || infantrySelected;

--- a/controls/mousestates/cMouseNormalState.cpp
+++ b/controls/mousestates/cMouseNormalState.cpp
@@ -102,11 +102,11 @@ void cMouseNormalState::onMouseLeftButtonClicked() {
         }
 
         if (unitSelected) {
-            game.getSoundPlayer().playSound(SOUND_REPORTING);
+            game.playSound(SOUND_REPORTING);
         }
 
         if (infantrySelected) {
-            game.getSoundPlayer().playSound(SOUND_YESSIR);
+            game.playSound(SOUND_YESSIR);
         }
 
         selectedUnits = unitSelected || infantrySelected;

--- a/controls/mousestates/cMousePlaceState.cpp
+++ b/controls/mousestates/cMousePlaceState.cpp
@@ -49,7 +49,7 @@ void cMousePlaceState::onMouseLeftButtonClicked() {
     }
 
     if (mayPlaceIt(itemToPlace, context->getMouseCell())) {
-        game.getSoundPlayer().playSound(SOUND_PLACE);
+        game.playSound(SOUND_PLACE);
         player->placeItem(mouseCell, itemToPlace);
         context->toPreviousState();
     }

--- a/controls/mousestates/cMousePlaceState.cpp
+++ b/controls/mousestates/cMousePlaceState.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include "d2tmh.h"
 
+#include "utils/cSoundPlayer.h"
+
 cMousePlaceState::cMousePlaceState(cPlayer *player, cGameControlsContext *context, cMouse *mouse) :
         cMouseState(player, context, mouse) {
 
@@ -47,7 +49,7 @@ void cMousePlaceState::onMouseLeftButtonClicked() {
     }
 
     if (mayPlaceIt(itemToPlace, context->getMouseCell())) {
-        play_sound_id(SOUND_PLACE);
+        game.getSoundPlayer().playSound(SOUND_PLACE);
         player->placeItem(mouseCell, itemToPlace);
         context->toPreviousState();
     }

--- a/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -120,11 +120,11 @@ void cMouseUnitsSelectedState::onMouseLeftButtonClicked() {
         }
 
         if (infantryAcknowledged) {
-            game.getSoundPlayer().playSound(SOUND_MOVINGOUT + rnd(2));
+            game.playSound(SOUND_MOVINGOUT + rnd(2));
         }
 
         if (unitAcknowledged) {
-            game.getSoundPlayer().playSound(SOUND_ACKNOWLEDGED + rnd(3));
+            game.playSound(SOUND_ACKNOWLEDGED + rnd(3));
         }
     }
 

--- a/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include "d2tmh.h"
 
+#include "utils/cSoundPlayer.h"
+
 cMouseUnitsSelectedState::cMouseUnitsSelectedState(cPlayer *player, cGameControlsContext *context, cMouse *mouse) :
         cMouseState(player, context, mouse),
         selectedUnits(),
@@ -118,11 +120,11 @@ void cMouseUnitsSelectedState::onMouseLeftButtonClicked() {
         }
 
         if (infantryAcknowledged) {
-            play_sound_id(SOUND_MOVINGOUT + rnd(2));
+            game.getSoundPlayer().playSound(SOUND_MOVINGOUT + rnd(2));
         }
 
         if (unitAcknowledged) {
-            play_sound_id(SOUND_ACKNOWLEDGED + rnd(3));
+            game.getSoundPlayer().playSound(SOUND_ACKNOWLEDGED + rnd(3));
         }
     }
 

--- a/drawers/CreditsDrawer.cpp
+++ b/drawers/CreditsDrawer.cpp
@@ -1,6 +1,7 @@
 #include "../include/d2tmh.h"
 #include "CreditsDrawer.h"
 
+#include "utils/cSoundPlayer.h"
 
 CreditsDrawer::CreditsDrawer(cPlayer * thePlayer) : player(thePlayer){
 	assert(thePlayer);
@@ -135,7 +136,7 @@ void CreditsDrawer::thinkAboutIndividualCreditOffsets() {
 			//offset_credit[i] = 18.1F; // so we do not keep matching our IF :)
 			offset_credit[i] = 0.0F; // so we do not keep matching our IF :)
 			if (soundsMade < 7) {
-                play_sound_id(soundType, 32);
+                game.getSoundPlayer().playSound(soundType, 32);
 				soundsMade++;
 			}
 			// it is fully 'moved'. Now update the array.

--- a/drawers/CreditsDrawer.cpp
+++ b/drawers/CreditsDrawer.cpp
@@ -136,7 +136,7 @@ void CreditsDrawer::thinkAboutIndividualCreditOffsets() {
 			//offset_credit[i] = 18.1F; // so we do not keep matching our IF :)
 			offset_credit[i] = 0.0F; // so we do not keep matching our IF :)
 			if (soundsMade < 7) {
-                game.getSoundPlayer().playSound(soundType, 32);
+                game.playSound(soundType, 32);
 				soundsMade++;
 			}
 			// it is fully 'moved'. Now update the array.

--- a/drawers/cMiniMapDrawer.cpp
+++ b/drawers/cMiniMapDrawer.cpp
@@ -308,7 +308,7 @@ void cMiniMapDrawer::think() {
             // go to state power down (not enough power)
             status = eMinimapStatus::POWERDOWN;
             // "Radar de-activated""
-            game.getSoundPlayer().playVoice(SOUND_VOICE_04_ATR, player->getHouse());
+            game.playVoice(SOUND_VOICE_04_ATR, player->getHouse());
         }
     }
 
@@ -317,9 +317,9 @@ void cMiniMapDrawer::think() {
         if (hasRadarAndEnoughPower) {
             // go to state power up (enough power)
             status = eMinimapStatus::POWERUP;
-            game.getSoundPlayer().playSound(SOUND_RADAR);
+            game.playSound(SOUND_RADAR);
             // "Radar activated"
-            game.getSoundPlayer().playVoice(SOUND_VOICE_03_ATR, player->getHouse());
+            game.playVoice(SOUND_VOICE_03_ATR, player->getHouse());
         }
     }
 

--- a/drawers/cMiniMapDrawer.cpp
+++ b/drawers/cMiniMapDrawer.cpp
@@ -1,6 +1,7 @@
 #include "../include/d2tmh.h"
 #include "cMiniMapDrawer.h"
 
+#include "utils/cSoundPlayer.h"
 
 cMiniMapDrawer::cMiniMapDrawer(cMap *theMap, cPlayer *thePlayer, cMapCamera *theMapCamera) :
         m_isMouseOver(false),
@@ -306,7 +307,8 @@ void cMiniMapDrawer::think() {
         if (!hasRadarAndEnoughPower) {
             // go to state power down (not enough power)
             status = eMinimapStatus::POWERDOWN;
-            play_voice(SOUND_VOICE_04_ATR); // radar de-activated!
+            // "Radar de-activated""
+            game.getSoundPlayer().playVoice(SOUND_VOICE_04_ATR, player->getHouse());
         }
     }
 
@@ -315,8 +317,9 @@ void cMiniMapDrawer::think() {
         if (hasRadarAndEnoughPower) {
             // go to state power up (enough power)
             status = eMinimapStatus::POWERUP;
-            play_sound_id(SOUND_RADAR);
-            play_voice(SOUND_VOICE_03_ATR); // radar activated!
+            game.getSoundPlayer().playSound(SOUND_RADAR);
+            // "Radar activated"
+            game.getSoundPlayer().playVoice(SOUND_VOICE_03_ATR, player->getHouse());
         }
     }
 

--- a/gameobjects/projectiles/bullet.cpp
+++ b/gameobjects/projectiles/bullet.cpp
@@ -12,6 +12,8 @@
 
 #include "../../include/d2tmh.h"
 
+#include "utils/cSoundPlayer.h"
+
 #include <math.h>
 
 void cBullet::init() {

--- a/gameobjects/structures/cAbstractStructure.cpp
+++ b/gameobjects/structures/cAbstractStructure.cpp
@@ -13,6 +13,7 @@
 #include "../../include/d2tmh.h"
 #include "cAbstractStructure.h"
 
+#include "utils/cSoundPlayer.h"
 
 // "default" Constructor
 cAbstractStructure::cAbstractStructure() {

--- a/gameobjects/structures/cOrderProcesser.cpp
+++ b/gameobjects/structures/cOrderProcesser.cpp
@@ -78,7 +78,7 @@ void cOrderProcesser::playTMinusSound(int seconds) {
 	}
 
 	if (soundIdToPlay > -1) {
-        game.getSoundPlayer().playSound(soundIdToPlay);
+        game.playSound(soundIdToPlay);
 	}
 }
 

--- a/gameobjects/structures/cOrderProcesser.cpp
+++ b/gameobjects/structures/cOrderProcesser.cpp
@@ -6,6 +6,8 @@
  */
 #include "../../include/d2tmh.h"
 
+#include "utils/cSoundPlayer.h"
+
 cOrderProcesser::cOrderProcesser(cPlayer *thePlayer) {
 	assert(thePlayer);
     player = thePlayer;
@@ -76,7 +78,7 @@ void cOrderProcesser::playTMinusSound(int seconds) {
 	}
 
 	if (soundIdToPlay > -1) {
-        play_sound_id(soundIdToPlay);
+        game.getSoundPlayer().playSound(soundIdToPlay);
 	}
 }
 

--- a/gameobjects/structures/cOrderProcesser.cpp
+++ b/gameobjects/structures/cOrderProcesser.cpp
@@ -23,16 +23,16 @@ cOrderProcesser::cOrderProcesser(cPlayer *thePlayer) {
 
 cOrderProcesser::~cOrderProcesser() {
 	removeAllItems();
-    player = NULL;
+    player = nullptr;
 }
 
 cBuildingListItem * cOrderProcesser::getItemToDeploy() {
 	for (int i = 0; i < MAX_ITEMS_TO_ORDER; i++) {
-		if (orderedItems[i] != NULL) {
+		if (orderedItems[i] != nullptr) {
 			return orderedItems[i];
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 bool cOrderProcesser::hasOrderedAnything() {
@@ -46,7 +46,7 @@ void cOrderProcesser::markOrderAsDeployed(cBuildingListItem * item) {
 	int slot = getSlotForItem(item);
 	assert(slot > -1);
 	// remove item from the ordered items
-	orderedItems[slot] = NULL;
+	orderedItems[slot] = nullptr;
 	pricePaidForItem[slot] = -1;
 }
 
@@ -146,7 +146,7 @@ void cOrderProcesser::removeOrder(cBuildingListItem *item) {
 
 int cOrderProcesser::getFreeSlot() {
 	for (int i = 0; i < MAX_ITEMS_TO_ORDER; i++) {
-		if (orderedItems[i] == NULL) {
+		if (orderedItems[i] == nullptr) {
 			return i;
 		}
 	}
@@ -171,7 +171,7 @@ void cOrderProcesser::removeAllItems() {
 void cOrderProcesser::removeItem(int slot) {
 	assert(slot >= 0);
 	assert(slot < MAX_ITEMS_TO_ORDER);
-	orderedItems[slot] = NULL;
+	orderedItems[slot] = nullptr;
 	// give money back to player
 	if (pricePaidForItem[slot] > 0) {
         player->giveCredits(pricePaidForItem[slot]);

--- a/gameobjects/structures/cRefinery.cpp
+++ b/gameobjects/structures/cRefinery.cpp
@@ -1,5 +1,7 @@
 #include "../../include/d2tmh.h"
 
+#include "utils/cSoundPlayer.h"
+
 // Constructor
 cRefinery::cRefinery() {
 
@@ -74,7 +76,7 @@ void cRefinery::think_unit_occupation() {
 
     // let player know...
     if (pPlayer->isHuman()) {
-        play_voice(SOUND_VOICE_02_ATR);
+        game.getSoundPlayer().playSound(SOUND_VOICE_02_ATR, pPlayer->getHouse());
     }
 
     // perhaps we can find a carryall to help us out

--- a/gameobjects/structures/cRefinery.cpp
+++ b/gameobjects/structures/cRefinery.cpp
@@ -76,7 +76,7 @@ void cRefinery::think_unit_occupation() {
 
     // let player know...
     if (pPlayer->isHuman()) {
-        game.getSoundPlayer().playSound(SOUND_VOICE_02_ATR, pPlayer->getHouse());
+        game.playSound(SOUND_VOICE_02_ATR, pPlayer->getHouse());
     }
 
     // perhaps we can find a carryall to help us out

--- a/gameobjects/structures/cStarPort.cpp
+++ b/gameobjects/structures/cStarPort.cpp
@@ -1,5 +1,7 @@
 #include "../../include/d2tmh.h"
 
+#include "utils/cSoundPlayer.h"
+
 // Constructor
 cStarPort::cStarPort() {
     // other variables (class specific)
@@ -72,7 +74,8 @@ void cStarPort::think_deploy() {
                     if (rallyPoint > -1) {
                         unit[id].move_to(rallyPoint, -1, -1);
                     }
-                    play_voice(SOUND_VOICE_05_ATR); // unit deployed
+                    const int house = players[iPlayer].getHouse();
+                    game.getSoundPlayer().playVoice(SOUND_VOICE_05_ATR, house); // unit deployed
                 } else {
                     // could not find cell to deploy to, reinforce it
                     if (rallyPoint > -1) {

--- a/gameobjects/structures/cStarPort.cpp
+++ b/gameobjects/structures/cStarPort.cpp
@@ -75,7 +75,7 @@ void cStarPort::think_deploy() {
                         unit[id].move_to(rallyPoint, -1, -1);
                     }
                     const int house = players[iPlayer].getHouse();
-                    game.getSoundPlayer().playVoice(SOUND_VOICE_05_ATR, house); // unit deployed
+                    game.playVoice(SOUND_VOICE_05_ATR, house); // unit deployed
                 } else {
                     // could not find cell to deploy to, reinforce it
                     if (rallyPoint > -1) {

--- a/gameobjects/units/cUnit.cpp
+++ b/gameobjects/units/cUnit.cpp
@@ -13,6 +13,8 @@
 #include "d2tmh.h"
 #include "cUnit.h"
 
+#include "utils/cSoundPlayer.h"
+
 #include <fmt/core.h>
 
 #include <cmath>

--- a/gamestates/cChooseHouseGameState.cpp
+++ b/gamestates/cChooseHouseGameState.cpp
@@ -2,6 +2,7 @@
 #include "d2tmh.h"
 #include "cChooseHouseGameState.h"
 
+#include "utils/cSoundPlayer.h"
 
 cChooseHouseGameState::cChooseHouseGameState(cGame &theGame) : cGameState(theGame) {
     textDrawer = cTextDrawer(bene_font);
@@ -92,17 +93,17 @@ void cChooseHouseGameState::onMouseLeftButtonClicked(const s_MouseEvent &event) 
 
     if (event.coords.isWithinRectangle(&houseAtreides)) {
         game.prepareMentatToTellAboutHouse(ATREIDES);
-        play_sound_id(SOUND_ATREIDES);
+        game.getSoundPlayer().playSound(SOUND_ATREIDES);
         game.setNextStateToTransitionTo(GAME_TELLHOUSE);
         game.START_FADING_OUT();
     } else if (event.coords.isWithinRectangle(&houseOrdos)) {
         game.prepareMentatToTellAboutHouse(ORDOS);
-        play_sound_id(SOUND_ORDOS);
+        game.getSoundPlayer().playSound(SOUND_ORDOS);
         game.setNextStateToTransitionTo(GAME_TELLHOUSE);
         game.START_FADING_OUT();
     } else if (event.coords.isWithinRectangle(&houseHarkonnen)) {
         game.prepareMentatToTellAboutHouse(HARKONNEN);
-        play_sound_id(SOUND_HARKONNEN);
+        game.getSoundPlayer().playSound(SOUND_HARKONNEN);
         game.setNextStateToTransitionTo(GAME_TELLHOUSE);
         game.START_FADING_OUT();
     } else if (event.coords.isWithinRectangle(backButtonRect)) {

--- a/gamestates/cChooseHouseGameState.cpp
+++ b/gamestates/cChooseHouseGameState.cpp
@@ -4,8 +4,9 @@
 
 #include "utils/cSoundPlayer.h"
 
-cChooseHouseGameState::cChooseHouseGameState(cGame &theGame) : cGameState(theGame) {
-    textDrawer = cTextDrawer(bene_font);
+cChooseHouseGameState::cChooseHouseGameState(cGame &theGame) :
+    cGameState(theGame),
+    textDrawer(cTextDrawer(bene_font)) {
     backButtonRect = textDrawer.getAsRectangle(0, game.screen_y - textDrawer.getFontHeight(), " BACK");
 
     bmp_Dune = (BITMAP *) gfxinter[BMP_GAME_DUNE].dat;
@@ -93,17 +94,17 @@ void cChooseHouseGameState::onMouseLeftButtonClicked(const s_MouseEvent &event) 
 
     if (event.coords.isWithinRectangle(&houseAtreides)) {
         game.prepareMentatToTellAboutHouse(ATREIDES);
-        game.getSoundPlayer().playSound(SOUND_ATREIDES);
+        game.playSound(SOUND_ATREIDES);
         game.setNextStateToTransitionTo(GAME_TELLHOUSE);
         game.START_FADING_OUT();
     } else if (event.coords.isWithinRectangle(&houseOrdos)) {
         game.prepareMentatToTellAboutHouse(ORDOS);
-        game.getSoundPlayer().playSound(SOUND_ORDOS);
+        game.playSound(SOUND_ORDOS);
         game.setNextStateToTransitionTo(GAME_TELLHOUSE);
         game.START_FADING_OUT();
     } else if (event.coords.isWithinRectangle(&houseHarkonnen)) {
         game.prepareMentatToTellAboutHouse(HARKONNEN);
-        game.getSoundPlayer().playSound(SOUND_HARKONNEN);
+        game.playSound(SOUND_HARKONNEN);
         game.setNextStateToTransitionTo(GAME_TELLHOUSE);
         game.START_FADING_OUT();
     } else if (event.coords.isWithinRectangle(backButtonRect)) {

--- a/include/d2tmc.h
+++ b/include/d2tmc.h
@@ -93,7 +93,6 @@ extern ALFONT_FONT *small_font;
 
 // DATAFILES
 extern DATAFILE *gfxdata;
-extern DATAFILE *gfxaudio;
 extern DATAFILE *gfxinter;
 extern DATAFILE *gfxworld;
 extern DATAFILE *gfxmentat;

--- a/include/data.h
+++ b/include/data.h
@@ -15,7 +15,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // data file header(s)                          - THIS
 #include "../data/gfxdata.h"						// general gfx
-#include "../data/gfxaudio.h"                     	// audio (sounds and music , midi)
 #include "../data/gfxinter.h"                  	// sidebar/downbar gfx
 #include "../data/gfxworld.h"                  	// world / regions gfx
 #include "../data/gfxmentat.h"                  	// mentat gfx

--- a/include/definitions.h
+++ b/include/definitions.h
@@ -162,11 +162,6 @@
 #define SANDHOUSE 9
 #define GREYHOUSE	10
 
-#define ATREIDES_TALK	20
-#define HARKONNEN_TALK	21
-#define ORDOS_TALK		22
-// .. add another id for another house
-
 // Structure types
 #define PALACE            0         // cPalace
 #define WINDTRAP          1         // cWindTrap

--- a/main.cpp
+++ b/main.cpp
@@ -12,8 +12,6 @@
 
 #include "include/d2tmh.h"
 
-#include "utils/cLog.h"
-
 bool bDoDebug = false;
 int	iRest = 1;	// default rest value
 
@@ -60,7 +58,6 @@ BITMAP *bmp_fadeout;
 
 // datafile(s)
 DATAFILE *gfxdata;		// graphics (terrain, units, structures)
-DATAFILE *gfxaudio;		// audio
 DATAFILE *gfxinter;		// interface graphics
 DATAFILE *gfxworld;		// world/pieces graphics
 DATAFILE *gfxmentat;	// mentat graphics

--- a/player/cPlayer.cpp
+++ b/player/cPlayer.cpp
@@ -3,6 +3,7 @@
 #include "cPlayer.h"
 
 #include "utils/common.h"
+#include "utils/cSoundPlayer.h"
 
 #include <fmt/format.h>
 
@@ -1773,7 +1774,7 @@ void cPlayer::onEntityDiscovered(const s_GameEvent &event) {
     }
 
     if (voiceId > -1) {
-        play_voice(voiceId);
+        game.getSoundPlayer().playVoice(voiceId, getHouse());
     }
 }
 
@@ -2051,11 +2052,11 @@ bool cPlayer::selectUnits(const std::vector<int> &ids) const {
     }
 
     if (unitSelected) {
-        play_sound_id(SOUND_REPORTING);
+        game.getSoundPlayer().playSound(SOUND_REPORTING);
     }
 
     if (infantrySelected) {
-        play_sound_id(SOUND_YESSIR);
+        game.getSoundPlayer().playSound(SOUND_YESSIR);
     }
 
     // return true if we selected any unit

--- a/player/cPlayer.cpp
+++ b/player/cPlayer.cpp
@@ -213,7 +213,7 @@ void cPlayer::init(int id, brains::cPlayerBrain *brain) {
 void cPlayer::setHouse(int iHouse) {
     int currentHouse = house;
     // not yet set up house properly.. so use logbook instead of log()
-    logbook(fmt::format("cPlayer[{}]::setHouse - Current house is [{}/{}], setting house to [{}/{}]", 
+    logbook(fmt::format("cPlayer[{}]::setHouse - Current house is [{}/{}], setting house to [{}/{}]",
                         this->id, currentHouse, getHouseNameForId(currentHouse), iHouse, getHouseNameForId(iHouse)));
     house = iHouse; // use rules of this house
 
@@ -1713,7 +1713,7 @@ bool cPlayer::startBuilding(cBuildingListItem *pItem) {
         log("startBuilding: Cannot start building null item!");
         return false;
     }
-    
+
     return startBuilding(pItem->getBuildType(), pItem->getBuildId());
 }
 
@@ -1774,7 +1774,7 @@ void cPlayer::onEntityDiscovered(const s_GameEvent &event) {
     }
 
     if (voiceId > -1) {
-        game.getSoundPlayer().playVoice(voiceId, getHouse());
+        game.playVoice(voiceId, getHouse());
     }
 }
 
@@ -2052,11 +2052,11 @@ bool cPlayer::selectUnits(const std::vector<int> &ids) const {
     }
 
     if (unitSelected) {
-        game.getSoundPlayer().playSound(SOUND_REPORTING);
+        game.playSound(SOUND_REPORTING);
     }
 
     if (infantrySelected) {
-        game.getSoundPlayer().playSound(SOUND_YESSIR);
+        game.playSound(SOUND_YESSIR);
     }
 
     // return true if we selected any unit

--- a/sidebar/cSideBar.cpp
+++ b/sidebar/cSideBar.cpp
@@ -143,7 +143,7 @@ void cSideBar::onMouseClickedLeft(const s_MouseEvent &event) {
         if (list->isOverButton(event.coords.x, event.coords.y)) {
             // clicked on it. Set focus on this one
             setSelectedListId(eListTypeFromInt(i));
-            game.getSoundPlayer().playSound(SOUND_BUTTON, 64); // click sound
+            game.playSound(SOUND_BUTTON, 64); // click sound
             break;
         }
     }

--- a/sidebar/cSideBar.cpp
+++ b/sidebar/cSideBar.cpp
@@ -2,6 +2,7 @@
 #include "cSideBar.h"
 
 #include "utils/cLog.h"
+#include "utils/cSoundPlayer.h"
 
 cSideBar::cSideBar(cPlayer * thePlayer) : player(thePlayer) {
     assert(thePlayer != nullptr && "Expected player to be not null!");
@@ -142,7 +143,7 @@ void cSideBar::onMouseClickedLeft(const s_MouseEvent &event) {
         if (list->isOverButton(event.coords.x, event.coords.y)) {
             // clicked on it. Set focus on this one
             setSelectedListId(eListTypeFromInt(i));
-            play_sound_id(SOUND_BUTTON, 64); // click sound
+            game.getSoundPlayer().playSound(SOUND_BUTTON, 64); // click sound
             break;
         }
     }

--- a/utils/cSoundPlayer.cpp
+++ b/utils/cSoundPlayer.cpp
@@ -114,6 +114,7 @@ cSoundPlayer::~cSoundPlayer() {
 }
 
 int cSoundPlayer::getMaxVolume() {
+    // TODO: This will become configurable (so you can set your own max volume for sounds, etc)
     return kAllegroMaxVolume;
 }
 

--- a/utils/cSoundPlayer.cpp
+++ b/utils/cSoundPlayer.cpp
@@ -5,91 +5,170 @@
  *      Author: Stefan
  */
 
-#include "../include/d2tmh.h"
+#include "cSoundPlayer.h"
 
-cSoundPlayer::cSoundPlayer(int maxVoices) {
-	maximumVoices = maxVoices;
-	memset(voices, -1, sizeof(voices));
+#include "allegroh.h"
+#include "definitions.h"
+#include "utils/cLog.h"
+
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <cassert>
+#include <memory>
+
+namespace {
+
+constexpr int kAllegroMaxNrVoices = 256; // From the Allegro 4 documentation
+constexpr int kAllegroMaxVolume = 255;
+constexpr int kAllegroPanCenter = 128;
+
+constexpr int kFinishedPLaying = -1;
+constexpr int kNoVoiceAvailable = -1;
+constexpr int kNoVoice = -1;
+constexpr int kNoLoop = 0;
+
+constexpr int kMinNrVoices = 4;
+constexpr int kMaxVolume = 220;
+
+}
+
+class cSoundData {
+  public:
+    cSoundData() {
+        auto logger = cLogger::getInstance();
+
+        gfxaudio = load_datafile("data/gfxaudio.dat");
+        if (gfxaudio == nullptr) {
+            logger->log(LOG_ERROR, COMP_SOUND, "Initialization", "Could not hook/load datafile: gfxaudio.dat.", OUTC_FAILED);
+            throw 1; // FIXME: real exception
+        } else {
+            logger->log(LOG_INFO, COMP_SOUND, "Initialization", "Hooked datafile: gfxaudio.dat.", OUTC_SUCCESS);
+        }
+    }
+
+    const SAMPLE* getSample(int sampleId) const {
+        return static_cast<const SAMPLE*>(gfxaudio[sampleId].dat);
+    }
+
+    MIDI* getMusic(int musicId) const {
+        return static_cast<MIDI*>(gfxaudio[musicId].dat);
+    }
+
+    const DATAFILE* gfxaudio;
+};
+
+cSoundPlayer::cSoundPlayer(const cPlatformLayerInit& init) : cSoundPlayer(init, kAllegroMaxNrVoices) {
+}
+
+cSoundPlayer::cSoundPlayer(const cPlatformLayerInit&, int maxNrVoices)
+        : soundData(std::make_unique<cSoundData>()) {
+    // The platform layer init object is not used here, but since it needs to be passed, it tells
+    // the caller that the initialization needs to be performed first.
+
+    auto logger = cLogger::getInstance();
+
+    if (maxNrVoices < kMinNrVoices) {
+        logger->log(LOG_WARN, COMP_SOUND, "Initialization", "Muting all sound.", OUTC_SUCCESS);
+        return;
+    }
+
+    int nr_voices = maxNrVoices;
+    while (true) {
+        if (nr_voices < kMinNrVoices) {
+            logger->log(LOG_WARN, COMP_SOUND, "Initialization", "Failed installing sound.", OUTC_FAILED);
+            return;
+        }
+
+        reserve_voices(nr_voices, 0); // Reserve nothing for MIDI, assume it will "steal" from the digi voices
+
+        if (install_sound(DIGI_AUTODETECT, MIDI_AUTODETECT, nullptr) == 0)
+        {
+            auto msg = fmt::format("Successfully installed sound. {} voices reserved", nr_voices);
+            logger->log(LOG_INFO, COMP_SOUND, "Initialization", msg, OUTC_SUCCESS);
+
+            // One fewer voice for the samples, as MIDI playing will use a voice.
+            voices.resize(nr_voices - 1, kNoVoice);
+            break;
+        }
+
+        auto msg = fmt::format("Failed reserving %d voices. Will try %d.", nr_voices, (nr_voices / 2));
+        logger->log(LOG_INFO, COMP_SOUND, "Initialization", msg, OUTC_FAILED);
+
+        nr_voices /= 2;
+    }
+
+    // Sound effects are loud, the music is queiter (its background music, so it should not be disturbing).
+    // FIXME: shouldn't this be the Allegro max volume and half of that instead of 220 and 110?
+    set_volume(kMaxVolume, kMaxVolume / 2);
 }
 
 cSoundPlayer::~cSoundPlayer() {
-
-}
-
-void cSoundPlayer::destroyAllSounds() {
-	if (maximumVoices > -1) {
-		for (int i = 0; i < maximumVoices; i++) {
-			destroySound(i, true);
-		}
-	}
-}
-
-void cSoundPlayer::think() {
-    if (maximumVoices < 0) return;
-
-    for (int i = 0; i < maximumVoices; i++) {
-        int pos;
-        int voice = voices[i];
-
-        //if it contains a voice get its position
-        if (voice != -1) {
-            pos = voice_get_position(voice);
-        } else {
-            pos = -2;
-        }
-
-        //if it is at the end then release it
-        if (pos == -1) {
-            destroySound(voice, true);
+    for (int voice : voices) {
+        if (voice != kNoVoice) {
+            deallocate_voice(voice);
         }
     }
 }
 
-void cSoundPlayer::destroySound(int voice, bool force) {
-	if (maximumVoices < 0) return;
-	if (voice < 0) return;
-	if (voices[voice] < 0) return;
-
-	if (force) {
-		deallocate_voice(voices[voice]);
-	} else {
-		release_voice(voices[voice]);
-	}
-
-	for (int i = 0; i < maximumVoices; i++) {
-		if (voices[i] == voice) {
-			voices[i] = -1;
-			break;
-		}
-	}
+int cSoundPlayer::getMaxVolume() {
+    return kAllegroMaxVolume;
 }
 
-void cSoundPlayer::playSound(int sampleId, int pan, int vol) {
-	playSound((SAMPLE *)gfxaudio[sampleId].dat, pan, vol);
+void cSoundPlayer::think() {
+    for (int& voice : voices) {
+        if (voice == kNoVoice) {
+            continue;
+        }
+
+        auto pos = voice_get_position(voice);
+        if (pos == kFinishedPLaying) {
+            deallocate_voice(voice); // Same as release_voice, as it stopped playing
+            voice = kNoVoice;
+        }
+    }
 }
 
-void cSoundPlayer::playSound(SAMPLE *sample, int pan, int vol) {
-	if (maximumVoices < 0) return;
+void cSoundPlayer::playSound(int sampleId) {
+    playSound(sampleId, kAllegroMaxVolume);
+}
 
+void cSoundPlayer::playSound(int sampleId, int vol) {
+    if (vol <= 0) {
+        return;
+    }
+
+    auto voice = std::find(voices.begin(), voices.end(), kNoVoice);
+    if (voice == voices.end()) {
+        cLogger::getInstance()->log(eLogLevel::LOG_WARN, eLogComponent::COMP_SOUND, "Playing sound",
+                                    "Cannot play sample, no more voices available.");
+        return;
+    }
+
+    vol = std::clamp(vol, 0, kAllegroMaxVolume);
+
+    const SAMPLE* sample = soundData->getSample(sampleId);
 	assert(sample);
-	if (vol < 0) return;
-	assert(pan >= 0 && pan < 256);
-	assert(vol > 0 && vol <= 256);
 
-	// allocate voice
-	int voice = allocate_voice(sample);
+	*voice = allocate_voice(sample);
+    assert(*voice != kNoVoiceAvailable);
 
-	if (voice != -1) {
-		voice_set_playmode(voice,0);
-		voice_set_volume(voice, vol);
-		voice_set_pan(voice, pan);
-		voice_start(voice);
+    voice_set_playmode(*voice, PLAYMODE_PLAY | PLAYMODE_FORWARD); // The default
+    voice_set_volume(*voice, vol);
+    voice_set_pan(*voice, kAllegroPanCenter);
+    voice_start(*voice);
+}
 
-		for (int i = 0; i < maximumVoices; i++) {
-			if (voices[i] == -1) {
-				voices[i] = voice;
-				break;
-			}
-		}
+void cSoundPlayer::playVoice(int sampleId, int house) {
+	if (house == HARKONNEN) {
+		sampleId += 1;
+	} else if (house == ORDOS) {
+		sampleId += 2;
 	}
+
+    playSound(sampleId);
+}
+
+void cSoundPlayer::playMusic(int sampleId) {
+    play_midi(soundData->getMusic(sampleId), kNoLoop);
 }

--- a/utils/cSoundPlayer.cpp
+++ b/utils/cSoundPlayer.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cassert>
 #include <memory>
+#include <stdexcept>
 
 namespace {
 
@@ -40,8 +41,9 @@ class cSoundData {
 
         gfxaudio = load_datafile("data/gfxaudio.dat");
         if (gfxaudio == nullptr) {
-            logger->log(LOG_ERROR, COMP_SOUND, "Initialization", "Could not hook/load datafile: gfxaudio.dat.", OUTC_FAILED);
-            throw 1; // FIXME: real exception
+            static auto msg = "Could not hook/load datafile: gfxaudio.dat.";
+            logger->log(LOG_ERROR, COMP_SOUND, "Initialization", msg, OUTC_FAILED);
+            throw std::runtime_error(msg);
         } else {
             logger->log(LOG_INFO, COMP_SOUND, "Initialization", "Hooked datafile: gfxaudio.dat.", OUTC_SUCCESS);
         }

--- a/utils/cSoundPlayer.h
+++ b/utils/cSoundPlayer.h
@@ -1,14 +1,3 @@
-/*
- * cSoundPlayer.h
- *
- *  Created on: 6-aug-2010
- *      Author: Stefan
- *
- *  A class responsible for playing sounds. But also managing the sounds being played (ie, not
- *  playing too many sounds in the same frame, etc).
- *
- */
-
 #pragma once
 
 #include "cPlatformLayerInit.h"

--- a/utils/cSoundPlayer.h
+++ b/utils/cSoundPlayer.h
@@ -9,30 +9,37 @@
  *
  */
 
-#ifndef CSOUNDPLAYER_H_
-#define CSOUNDPLAYER_H_
+#pragma once
+
+#include "cPlatformLayerInit.h"
+#include "data/gfxaudio.h" // Use IDs from this file to play samples
+
+#include <memory>
+#include <vector>
+
+class cSoundData;
 
 class cSoundPlayer {
-
 	public:
-		cSoundPlayer(int maxVoices);
+        // Initialize the platform layer before creating this object.
+		explicit cSoundPlayer(const cPlatformLayerInit& init);
+		cSoundPlayer(const cPlatformLayerInit& init, int maxNrVoices);
 		~cSoundPlayer();
 
-		void playSound(SAMPLE *sample, int pan, int vol);
-		void playSound(int sampleId, int pan, int vol);
+        static int getMaxVolume();
+
+        void playSound(int sampleId); // Maximum volume
+		void playSound(int sampleId, int vol);
+
+        // Pass the sample ID of the Atreides voice
+        void playVoice(int sampleId, int house);
+
+        void playMusic(int sampleId);
 
 		// think about voices, clear voices, etc.
 		void think();
 
-        void destroyAllSounds();
-
-	protected:
-		void destroySound(int voice, bool force);
-
 	private:
-		int maximumVoices;
-		int voices[256];
-
+		std::vector<int> voices;
+        std::unique_ptr<cSoundData> soundData;
 };
-
-#endif /* CSOUNDPLAYER_H_ */

--- a/utils/cTimeManager.cpp
+++ b/utils/cTimeManager.cpp
@@ -118,8 +118,7 @@ void cTimeManager::handleTimerGameTime() {
     // keep up with time cycles
     while (timerGlobal > 0) {
         game.think_fading();
-        game.getSoundPlayer().think();
-        game.think_music();
+        game.think_audio();
         game.think_mentat();
         game.think_state();
 

--- a/utils/cTimeManager.cpp
+++ b/utils/cTimeManager.cpp
@@ -1,6 +1,7 @@
 #include "../include/d2tmh.h"
 
 #include "timers.h"
+#include "utils/cSoundPlayer.h"
 
 cTimeManager::cTimeManager() {
     timerUnits = 0;
@@ -117,7 +118,7 @@ void cTimeManager::handleTimerGameTime() {
     // keep up with time cycles
     while (timerGlobal > 0) {
         game.think_fading();
-        game.getSoundPlayer()->think();
+        game.getSoundPlayer().think();
         game.think_music();
         game.think_mentat();
         game.think_state();

--- a/utils/common.cpp
+++ b/utils/common.cpp
@@ -878,7 +878,7 @@ void install_bullets() {
     logbook("Installing:  BULLET TYPES");
 
     for (int i = 0; i < MAX_BULLET_TYPES; i++) {
-        sBulletInfo[i].bmp = NULL; // in case an invalid bitmap; default is a small rocket
+        sBulletInfo[i].bmp = nullptr; // in case an invalid bitmap; default is a small rocket
         sBulletInfo[i].deathParticle = -1; // this points to a bitmap (in data file, using index)
         sBulletInfo[i].damage = 0;      // damage to vehicles
         sBulletInfo[i].damage_inf = 0;  // damage to infantry
@@ -1067,7 +1067,7 @@ void install_bullets() {
     strcpy(sBulletInfo[BULLET_TURRET].description, "BULLET_TURRET");
 
     // EXEPTION: Shimmer/ Sonic tank
-    sBulletInfo[BULLET_SHIMMER].bmp = NULL;
+    sBulletInfo[BULLET_SHIMMER].bmp = nullptr;
     sBulletInfo[BULLET_SHIMMER].deathParticle = -1;
     sBulletInfo[BULLET_SHIMMER].bmp_width = 0;
     sBulletInfo[BULLET_SHIMMER].damage = 55;
@@ -1720,7 +1720,7 @@ bool MIDI_music_playing() {
 
 void setMusicVolume(int i) {
     if (game.bMp3) {
-        if (mp3_music != NULL) {
+        if (mp3_music != nullptr) {
         	almp3_adjust_mp3(mp3_music, i, 127, 1000, false);
         }
     } else {
@@ -1734,7 +1734,7 @@ void mp3_play_file(char filename[VOLUME_MAX]) {
   char *data = new char[len];  // mp3 file in memory
 	FILE *f = fopen(filename, "r");
 
-	if (f != NULL) {
+	if (f != nullptr) {
 		fread(data, 1, len, f);
 		fclose(f);
 	} else {
@@ -1742,11 +1742,11 @@ void mp3_play_file(char filename[VOLUME_MAX]) {
 		allegro_message("Could not find MP3 file, add-on incomplete. Switching to MIDI mode");
 		game.bMp3=false;
 
-		if (mp3_music != NULL) {
+		if (mp3_music != nullptr) {
 		   almp3_destroy_mp3(mp3_music);
 		}
 
-		mp3_music = NULL;
+		mp3_music = nullptr;
 		return;
 	}
 
@@ -1984,7 +1984,7 @@ void Shimmer(int r, int x, int y) {
 void INIT_PREVIEWS() {
     for (int i = 0; i < MAX_SKIRMISHMAPS; i++) {
         s_PreviewMap &previewMap = PreviewMap[i];
-        previewMap.terrain = NULL;
+        previewMap.terrain = nullptr;
 
         // clear out name
         memset(previewMap.name, 0, sizeof(previewMap.name));
@@ -2032,8 +2032,4 @@ const char* toStringBuildTypeSpecificType(const eBuildType &buildType, const int
             break;
     }
     return "";
-}
-
-char scanCodeToAscii(int scanCode) {
-    return (char)scancode_to_ascii(scanCode);
 }

--- a/utils/common.cpp
+++ b/utils/common.cpp
@@ -1679,7 +1679,7 @@ void play_sound_id_with_distance(int s, int iDistance) {
 	if (!game.bPlaySound) return; // do not play sound when boolean is false.
 
 	if (iDistance <= 1) { // means "on screen" (meaning fixed volume, and no need for panning)
-        game.getSoundPlayer().playSound(s);
+        game.playSound(s);
 		return;
 	}
 
@@ -1688,7 +1688,7 @@ void play_sound_id_with_distance(int s, int iDistance) {
     float maxDistance = mapCamera->divideByZoomLevel(map.getMaxDistanceInPixels()/2);
     float distanceNormalized = 1.0 - ((float)iDistance / maxDistance);
 
-    float volume = game.getSoundPlayer().getMaxVolume() * distanceNormalized;
+    float volume = game.getMaxVolume() * distanceNormalized;
 
     // zoom factor influences volume (more zoomed in means louder)
     float volumeFactor = mapCamera->factorZoomLevel(0.7f);
@@ -1707,7 +1707,7 @@ void play_sound_id_with_distance(int s, int iDistance) {
         logbook(msg);
     }
 
-    game.getSoundPlayer().playSound(s, iVolFactored);
+    game.playSound(s, iVolFactored);
 }
 
 bool MIDI_music_playing() {
@@ -1831,7 +1831,7 @@ void playMusicByType(int iType) {
             iNumber = iNumber+1;
         }
         // play midi file
-        game.getSoundPlayer().playMusic(iNumber);
+        game.playMusic(iNumber);
     }
 }
 

--- a/utils/common.h
+++ b/utils/common.h
@@ -9,6 +9,7 @@
   2001 - 2021 (c) code by Stefan Hendriks
 
   */
+#pragma once
 
 #include <string>
 
@@ -52,12 +53,9 @@ int iFindCloseBorderCell(int iCll);
 
 void mp3_play_file(char filename[255]);
 
-void play_sound_id(int s, int volume);
-void play_sound_id(int s);
 void play_sound_id_with_distance(int s, int iOnScreen);
 
 bool MIDI_music_playing();
-void play_voice(int iType);
 void setMusicVolume(int i);
 
 void playMusicByType(int iType);
@@ -65,8 +63,6 @@ void Shimmer(int r, int x, int y);
 int create_bullet(int type, int fromCell, int targetCell, int unitWhichShoots, int structureWhichShoots);
 
 int distanceBetweenCellAndCenterOfScreen(int iCell);
-
-int getAmountReservedVoicesAndInstallSound();
 
 const char* toStringBuildTypeSpecificType(const eBuildType &buildType, const int &specificTypeId);
 


### PR DESCRIPTION
- Init and de-init are now done in CSoundPlayer.
- CSoundPlayer reads the audio datafile and owns the data
- Cleaned up some (not all) audio related functions in common.h
- Left mp3 related code behind, as that can be removed in the next PR.

In the next PR, I'd like to move the rest of the audio functions and remove almp3. This PR will be too big, if I do that in one go.

I playtested it and the game works as before.