### PR TITLE
Rename members in cGame class to use m_ prefix

### DIFF
--- a/cGame.h
+++ b/cGame.h
@@ -29,74 +29,82 @@ class cPlatformLayerInit;
 class cPlayer;
 class cSoundPlayer;
 
+// Naming thoughts:
+// member variables, start with m_<camelCasedVariableName>
+//
+// functions are camelCased()
+// exceptions (for now):
+// think()
+// thinkFast_...()
+// thinkSlow_....() --> for now used to distinguish certain speed of "thinking" / invocations
+// state_...() --> because elegible for moving away
+
 class cGame : public cScenarioObserver, cInputObserver {
 
 public:
-
 	cGame();
 	~cGame();
 
-	std::string game_filename;
+	std::string m_gameFilename;
 
-	bool windowed;			 // windowed
-	std::string version; // version number, or name.
+	bool m_windowed;			    // windowed
+	std::string m_version;          // version number, or name.
 
     // Alpha (for fading in/out)
-    int fadeAlpha;           // 255 = opaque , anything else
-    eFadeAction fadeAction;    // 0 = NONE, 1 = fade out (go to 0), 2 = fade in (go to 255)
+    int m_fadeAlpha;                // 255 = opaque , anything else
+    eFadeAction m_fadeAction;       // 0 = NONE, 1 = fade out (go to 0), 2 = fade in (go to 255)
 
     // resolution of the game
-	int screen_x;
-	int screen_y;
-    int ini_screen_width;
-    int ini_screen_height;
+	int m_screenX;
+	int m_screenY;
+    int m_iniScreenWidth;
+    int m_iniScreenHeight;
 
-    bool bPlaySound;            // play sound?
-    bool bDisableAI;            // disable AI thinking?
-    bool bOneAi;                // disable all but one AI brain? (default == false)
-    bool bDisableReinforcements;// disable any reinforcements from scenario ini file?
-    bool bDrawUsages;           // draw the amount of structures/units/bullets used during combat
-    bool bDrawUnitDebug;        // draw the unit debug info (rects, paths, etc)
-    bool bNoAiRest;             // Campaign AI does not have long initial REST time
-    bool bPlayMusic;            // play any music?
-    bool bMp3;                  // use mp3 files instead of midi
+    bool m_playSound;               // play sound?
+    bool m_disableAI;               // disable AI thinking?
+    bool m_oneAi;                   // disable all but one AI brain? (default == false)
+    bool m_disableReinforcements;   // disable any reinforcements from scenario ini file?
+    bool m_drawUsages;              // draw the amount of structures/units/bullets used during combat
+    bool m_drawUnitDebug;           // draw the unit debug info (rects, paths, etc)
+    bool m_noAiRest;                // Campaign AI does not have long initial REST time
+    bool m_playMusic;               // play any music?
+    bool m_mp3;                     // use mp3 files instead of midi
 
-	bool bPlaying;				// playing or not
-    bool bSkirmish;             // playing a skirmish game  or not
-	int screenshot;				// screenshot taking number
+	bool m_playing;				    // playing or not
+    bool m_skirmish;                // playing a skirmish game or not
+	int m_screenshot;				// screenshot taking number
 
-	void init();		// initialize all game variables
-	void mission_init(); // initialize variables for mission loading only
-	void run();			// run the game
+    int m_region;                   // what region is selected? (changed by cSelectYourNextConquestState class)
+	int m_mission;		            // what mission are we playing? (= techlevel)
 
-    int iRegion;        // what region is selected? (changed by cSelectYourNextConquestState class)
-	int iMission;		// what mission are we playing? (= techlevel)
+	int m_pathsCreated;
 
-	int paths_created;
+    int m_musicVolume;              // volume of the mp3 / midi
+    int m_musicType;
 
-    int iMusicVolume;       // volume of the mp3 / midi
+    cRectangle *m_mapViewport;
 
+    // Initialization functions
+    void init();		            // initialize all game variables
+    void missionInit();             // initialize variables for mission loading only
+    void setupPlayers();            // initialize players only (combat state initialization)
+    bool setupGame();               // only call once, to initialize game object (TODO: in constructor?)
+    void shutdown();
+    void initSkirmish() const;      // initialize combat state to start a skirmish game
+    void createAndPrepareMentatForHumanPlayer();
+    void loadScenario();
 
-    int iMusicType;
+    void run();			            // run the game (MAIN LOOP)
 
     void thinkSlow_combat();
 
-    void winning();       // winning (during combat you get the window "you have been successful"), after clicking you get to debrief
-    void losing();        // losing (during combat you get the window "you have lost"), after clicking you get to debrief
-    void options();
-
-	void setup_players();
-
     void think_audio();
-
 	void think_mentat();
+    void think_fading();
+    void think_state();
 
-    void START_FADING_OUT(); // fade out with current screen_bmp, this is a little game loop itself!
-
+    void initiateFadingOut();        // fade out with current screen_bmp, this is a little game loop itself!
     void prepareMentatForPlayer();
-
-	bool setupGame();
-	void shutdown();
 
 	bool isState(int thisState);
 
@@ -133,26 +141,13 @@ public:
 
     int getColorFadeSelected(int color);
 
-    void think_fading();
-
-    cRectangle * mapViewport;
-
-    void init_skirmish() const;
-
-    void createAndPrepareMentatForHumanPlayer();
-
-    void loadScenario();
-
-    void think_state();
-
     cMouse *getMouse() {
-        return mouse; // NOOOO
+        return m_mouse; // NOOOO
     }
-
-    void shakeScreen(int duration);
 
     void setPlayerToInteractFor(cPlayer *pPlayer);
 
+    // Event handling
     void onNotifyGameEvent(const s_GameEvent &event) override;
     void onNotifyMouseEvent(const s_MouseEvent &event) override;
     void onNotifyKeyboardEvent(const cKeyboardEvent &event) override;
@@ -183,6 +178,7 @@ public:
         return "";
     }
 
+    void shakeScreen(int duration);
     void reduceShaking();
 
     cAllegroDataRepository * getDataRepository() {
@@ -199,105 +195,108 @@ public:
     void setLoseFlags(int value);
 
     void setMissionLost();
-
     void setMissionWon();
 
+    // FPS related
     bool isRunningAtIdealFps();
-
     void resetFrameCount();
-
     void setFps();
-
     int getFps();
 
     void prepareMentatToTellAboutHouse(int house);
 
     void drawCombatMouse();
-
 private:
     /**
      * Variables start here
      */
-    std::unique_ptr<cPlatformLayerInit> _PLInit;
-    cInteractionManager *_interactionManager;
+
+    std::unique_ptr<cPlatformLayerInit> m_PLInit;
+    cInteractionManager *m_interactionManager;
     cAllegroDataRepository *m_dataRepository;
 
-    std::unique_ptr<cSoundPlayer> _soundplayer;
+    std::unique_ptr<cSoundPlayer> m_soundPlayer;
 
-    cMouse *mouse;
-    cKeyboard *keyboard;
+    cMouse *m_mouse;
+    cKeyboard *m_keyboard;
 
-    bool missionWasWon; // hack: used for state transitioning :/
+    bool m_missionWasWon;               // hack: used for state transitioning :/
 
-	int state;
+	int m_state;
 
-	cAbstractMentat *pMentat; // TODO: Move this into a currentState class (as field)?
+	cAbstractMentat *m_mentat;          // TODO: Move this into a m_currentState class (as field)?
 
-    float fade_select;        // fade color when selected
-    bool bFadeSelectDir;    // fade select direction
+    float m_fadeSelect;                 // fade color when selected
+    bool m_fadeSelectDir;               // fade select direction
 
     // screen shaking
-    int shake_x;
-    int shake_y;
-    int TIMER_shake;
+    int m_shakeX;
+    int m_shakeY;
 
-    int TIMER_evaluatePlayerStatus;
+    int m_TIMER_shake;
+    int m_TIMER_evaluatePlayerStatus;
 
     // win/lose flags
-    int8_t winFlags, loseFlags;
+    int8_t m_winFlags, m_loseFlags;
 
-    int frame_count, fps;  // fps and such
+    int m_frameCount, m_fps;            // fps and such
 
-    int nextState;
+    int m_nextState;
 
     // the current game state we are running
-    cGameState *currentState;
+    cGameState *m_currentState;
 
-    cGameState *states[GAME_MAX_STATES];
+    cGameState *m_states[GAME_MAX_STATES];
 
-    void updateState();
-    void combat();		// the combat part (main) of the game
     bool isMusicPlaying();
 
-    void stateMentat(cAbstractMentat *mentat);  // state mentat talking and interaction
-    void menu();		// main menu
+    void updateMouseAndKeyboardStateAndGamePlaying(); // ugly name, to point out this does two things :/
+    void drawState();           // draws currentState, or calls any of the other functions which don't have state obj yet
+    void drawStateCombat();		// the combat part (main) of the game
+    void drawStateMenu();		// main menu
+    void drawStateWinning();    // drawStateWinning (during combat you get the window "you have been successful"),
+                                // after clicking you get to debrief
 
-    void drawState();
+    void drawStateLosing();     // drawStateLosing (during combat you get the window "you have lost"),
+                                // after clicking you get to debrief
+
+
+    void drawStateMentat(cAbstractMentat *mentat);  // state mentat talking and interaction
+
     void shakeScreenAndBlitBuffer();
     void handleTimeSlicing();
 
     bool isResolutionInGameINIFoundAndSet();
     void setScreenResolutionFromGameIniSettings();
 
+    void initPlayers(bool rememberHouse) const;
+
     void install_bitmaps();
 
-    bool isMissionWon() const;
+    [[nodiscard]] bool isMissionWon() const;
 
-    bool isMissionFailed() const;
+    [[nodiscard]] bool isMissionFailed() const;
 
-    bool hasGameOverConditionHarvestForSpiceQuota() const;
+    [[nodiscard]] bool hasGameOverConditionHarvestForSpiceQuota() const;
 
-    bool hasGameOverConditionPlayerHasNoBuildings() const;
+    [[nodiscard]] bool hasGameOverConditionPlayerHasNoBuildings() const;
 
-    bool hasWinConditionHumanMustLoseAllBuildings() const;
+    [[nodiscard]] bool hasWinConditionHumanMustLoseAllBuildings() const;
 
-    bool hasWinConditionAIShouldLoseEverything() const;
+    [[nodiscard]] bool hasWinConditionAIShouldLoseEverything() const;
 
-    bool allAIPlayersAreDestroyed() const;
+    [[nodiscard]] bool allAIPlayersAreDestroyed() const;
 
-    bool hasGameOverConditionAIHasNoBuildings() const;
+    [[nodiscard]] bool hasGameOverConditionAIHasNoBuildings() const;
 
     void transitionStateIfRequired();
 
     void setState(int newState);
 
-    void initPlayers(bool rememberHouse) const;
-
     void saveBmpScreenToDisk();
 
+    // Combat state specific event handling for now
     void onNotifyKeyboardEventGamePlaying(const cKeyboardEvent &event);
-
     void onKeyDownGamePlaying(const cKeyboardEvent &event);
-
     void onKeyPressedGamePlaying(const cKeyboardEvent &event);
 };

--- a/cGame_draw.cpp
+++ b/cGame_draw.cpp
@@ -12,53 +12,53 @@
 #include "include/d2tmh.h"
 
 // Fading between menu items
-void cGame::START_FADING_OUT() {
+void cGame::initiateFadingOut() {
     // set state to fade out
-    fadeAction = eFadeAction::FADE_OUT; // fade out
+    m_fadeAction = eFadeAction::FADE_OUT; // fade out
 
     // copy the last bitmap of screen into a separate bitmap which we use for fading out.
     draw_sprite(bmp_fadeout, bmp_screen, 0, 0);
 }
 
 // this shows the you have lost bmp at screen, after mouse press the mentat debriefing state will begin
-void cGame::losing() {
-    blit(bmp_winlose, bmp_screen, 0, 0, 0, 0, screen_x, screen_y);
+void cGame::drawStateLosing() {
+    blit(bmp_winlose, bmp_screen, 0, 0, 0, 0, m_screenX, m_screenY);
 
     draw_sprite(bmp_screen, (BITMAP *) gfxdata[MOUSE_NORMAL].dat, mouse_x, mouse_y);
 
-    if (mouse->isLeftButtonClicked()) {
+    if (m_mouse->isLeftButtonClicked()) {
         // OMG, MENTAT IS NOT HAPPY
-        state = GAME_LOSEBRIEF;
+        m_state = GAME_LOSEBRIEF;
 
-        if (bSkirmish) {
-            game.mission_init();
+        if (m_skirmish) {
+            game.missionInit();
         }
 
         createAndPrepareMentatForHumanPlayer();
 
         // FADE OUT
-        START_FADING_OUT();
+        initiateFadingOut();
     }
 }
 
 // this shows the you have won bmp at screen, after mouse press the mentat debriefing state will begin
-void cGame::winning() {
-    blit(bmp_winlose, bmp_screen, 0, 0, 0, 0, screen_x, screen_y);
+void cGame::drawStateWinning() {
+    blit(bmp_winlose, bmp_screen, 0, 0, 0, 0, m_screenX, m_screenY);
 
     draw_sprite(bmp_screen, (BITMAP *) gfxdata[MOUSE_NORMAL].dat, mouse_x, mouse_y);
 
-    if (mouse->isLeftButtonClicked()) {
+    if (m_mouse->isLeftButtonClicked()) {
         // Mentat will be happy, after that enter "Select your next Conquest"
-        state = GAME_WINBRIEF;
+        m_state = GAME_WINBRIEF;
 
-        if (bSkirmish) {
-            game.mission_init();
+        if (m_skirmish) {
+            game.missionInit();
         }
 
         createAndPrepareMentatForHumanPlayer();
 
         // FADE OUT
-        START_FADING_OUT();
+        initiateFadingOut();
     }
 }
 

--- a/cGame_logic.cpp
+++ b/cGame_logic.cpp
@@ -30,64 +30,64 @@ constexpr auto kMaxAlpha = 255;
 };
 
 cGame::cGame() {
-    memset(states, 0, sizeof(cGameState *));
+    memset(m_states, 0, sizeof(cGameState *));
 
-    nextState = -1;
-    currentState = nullptr;
-    screen_x = 800;
-    screen_y = 600;
-    windowed = false;
-    bPlaySound = true;
-    bPlayMusic = true;
-    bMp3 = false;
+    m_nextState = -1;
+    m_currentState = nullptr;
+    m_screenX = 800;
+    m_screenY = 600;
+    m_windowed = false;
+    m_playSound = true;
+    m_playMusic = true;
+    m_mp3 = false;
     // default INI screen width and height is not loaded
     // if not loaded, we will try automatic setup
-    ini_screen_width = -1;
-    ini_screen_height = -1;
+    m_iniScreenWidth = -1;
+    m_iniScreenHeight = -1;
 
-  version = "0.6.x";
+    m_version = "0.6.x";
 
-    pMentat = nullptr;
+    m_mentat = nullptr;
 }
 
 
 void cGame::init() {
-    nextState = -1;
-    missionWasWon = false;
-    currentState = nullptr;
-    screenshot = 0;
-    bPlaying = true;
+    m_nextState = -1;
+    m_missionWasWon = false;
+    m_currentState = nullptr;
+    m_screenshot = 0;
+    m_playing = true;
 
-    TIMER_evaluatePlayerStatus = 5;
+    m_TIMER_evaluatePlayerStatus = 5;
 
-    bSkirmish = false;
+    m_skirmish = false;
 
     // Alpha (for fading in/out)
-    fadeAlpha = kMinAlpha;             // 255 = opaque , anything else
-    fadeAction = eFadeAction::FADE_IN; // 0 = NONE, 1 = fade out (go to 0), 2 = fade in (go to 255)
+    m_fadeAlpha = kMinAlpha;             // 255 = opaque , anything else
+    m_fadeAction = eFadeAction::FADE_IN; // 0 = NONE, 1 = fade out (go to 0), 2 = fade in (go to 255)
 
-    iMusicVolume = 96; // volume is 0...
+    m_musicVolume = 96; // volume is 0...
 
-    paths_created = 0;
+    m_pathsCreated = 0;
 
     setState(GAME_INITIALIZE);
 
     // mentat
-    delete pMentat;
-    pMentat = nullptr;
+    delete m_mentat;
+    m_mentat = nullptr;
 
-    fade_select = 1.0f;
+    m_fadeSelect = 1.0f;
 
-    bFadeSelectDir = true;    // fade select direction
+    m_fadeSelectDir = true;    // fade select direction
 
-    iRegion = 1;          // what region ? (calumative, from player perspective, NOT the actual region number)
-    iMission = 0;         // calculated by mission loading (region -> mission calculation)
+    m_region = 1;          // what region ? (calumative, from player perspective, NOT the actual region number)
+    m_mission = 0;         // calculated by mission loading (region -> mission calculation)
 
-    shake_x = 0;
-    shake_y = 0;
-    TIMER_shake = 0;
+    m_shakeX = 0;
+    m_shakeY = 0;
+    m_TIMER_shake = 0;
 
-    iMusicType = MUSIC_MENU;
+    m_musicType = MUSIC_MENU;
 
     map.init(64, 64);
 
@@ -102,38 +102,38 @@ void cGame::init() {
     }
 
     // Units & Structures are already initialized in map.init()
-    if (game.bMp3 && mp3_music) {
-        almp3_stop_autopoll_mp3(mp3_music); // stop auto updateState
+    if (game.m_mp3 && mp3_music) {
+        almp3_stop_autopoll_mp3(mp3_music); // stop auto updateMouseAndKeyboardStateAndGamePlaying
     }
 
     // Load properties
-    INI_Install_Game(game_filename);
+    INI_Install_Game(m_gameFilename);
 
     mp3_music = nullptr;
 }
 
 // TODO: Bad smell (duplicate code)
 // initialize for missions
-void cGame::mission_init() {
+void cGame::missionInit() {
     mapCamera->resetZoom();
 
     // first 15 seconds, do not evaluate player alive status
-    TIMER_evaluatePlayerStatus = 5;
+    m_TIMER_evaluatePlayerStatus = 5;
 
-    winFlags = 0;
-    loseFlags = 0;
+    m_winFlags = 0;
+    m_loseFlags = 0;
 
-    iMusicVolume = 96; // volume is 0...
+    m_musicVolume = 96; // volume is 0...
 
-    paths_created = 0;
+    m_pathsCreated = 0;
 
-    fade_select = 1.0f;
+    m_fadeSelect = 1.0f;
 
-    bFadeSelectDir = true;    // fade select direction
+    m_fadeSelectDir = true;    // fade select direction
 
-    shake_x = 0;
-    shake_y = 0;
-    TIMER_shake = 0;
+    m_shakeX = 0;
+    m_shakeY = 0;
+    m_TIMER_shake = 0;
 
     map.init(64, 64);
 
@@ -144,7 +144,7 @@ void cGame::mission_init() {
 
 void cGame::initPlayers(bool rememberHouse) const {
     int maxThinkingAIs = MAX_PLAYERS;
-    if (bOneAi) {
+    if (m_oneAi) {
         maxThinkingAIs = 1;
     }
 
@@ -157,9 +157,9 @@ void cGame::initPlayers(bool rememberHouse) const {
 
         if (i > HUMAN && i < AI_CPU5) {
             // TODO: playing attribute? (from ai player class?)
-            if (!game.bDisableAI) {
+            if (!game.m_disableAI) {
                 if (maxThinkingAIs > 0) {
-                    if (game.bSkirmish) {
+                    if (game.m_skirmish) {
                         brain = new brains::cPlayerBrainSkirmish(&pPlayer);
                     } else {
                         brain = new brains::cPlayerBrainCampaign(&pPlayer);
@@ -180,7 +180,7 @@ void cGame::initPlayers(bool rememberHouse) const {
             pPlayer.setHouse(h);
         }
 
-        if (bSkirmish) {
+        if (m_skirmish) {
             pPlayer.setCredits(2500);
         }
     }
@@ -190,8 +190,8 @@ void cGame::initPlayers(bool rememberHouse) const {
  * Thinking every second while in combat
  */
 void cGame::thinkSlow_combat() {
-    if (TIMER_evaluatePlayerStatus > 0) {
-        TIMER_evaluatePlayerStatus--;
+    if (m_TIMER_evaluatePlayerStatus > 0) {
+        m_TIMER_evaluatePlayerStatus--;
     } else {
         // TODO: Better way is with events (ie created/destroyed). However, there is no such
         // bookkeeping per player *yet*. So instead, for now, we "poll" for this data.
@@ -214,7 +214,7 @@ void cGame::thinkSlow_combat() {
 
             // TODO: event : Player joined/became alive, etc?
         }
-        TIMER_evaluatePlayerStatus = 2;
+        m_TIMER_evaluatePlayerStatus = 2;
     }
 
     if (isMissionFailed()) {
@@ -229,39 +229,39 @@ void cGame::thinkSlow_combat() {
 }
 
 void cGame::setMissionWon() {
-    missionWasWon = true;
+    m_missionWasWon = true;
     setState(GAME_WINNING);
 
-    shake_x = 0;
-    shake_y = 0;
-    TIMER_shake = 0;
-    mouse->setTile(MOUSE_NORMAL);
+    m_shakeX = 0;
+    m_shakeY = 0;
+    m_TIMER_shake = 0;
+    m_mouse->setTile(MOUSE_NORMAL);
 
-    _soundplayer->playVoice(SOUND_VOICE_07_ATR, players[HUMAN].getHouse());
+    m_soundPlayer->playVoice(SOUND_VOICE_07_ATR, players[HUMAN].getHouse());
 
     playMusicByType(MUSIC_WIN);
 
     // copy over
-    blit(bmp_screen, bmp_winlose, 0, 0, 0, 0, screen_x, screen_y);
+    blit(bmp_screen, bmp_winlose, 0, 0, 0, 0, m_screenX, m_screenY);
 
     allegroDrawer->drawCenteredSprite(bmp_winlose, (BITMAP *) gfxinter[BMP_WINNING].dat);
 }
 
 void cGame::setMissionLost() {
-    missionWasWon = false;
+    m_missionWasWon = false;
     setState(GAME_LOSING);
 
-    shake_x = 0;
-    shake_y = 0;
-    TIMER_shake = 0;
-    mouse->setTile(MOUSE_NORMAL);
+    m_shakeX = 0;
+    m_shakeY = 0;
+    m_TIMER_shake = 0;
+    m_mouse->setTile(MOUSE_NORMAL);
 
-    _soundplayer->playVoice(SOUND_VOICE_08_ATR, players[HUMAN].getHouse());
+    m_soundPlayer->playVoice(SOUND_VOICE_08_ATR, players[HUMAN].getHouse());
 
     playMusicByType(MUSIC_LOSE);
 
     // copy over
-    blit(bmp_screen, bmp_winlose, 0, 0, 0, 0, screen_x, screen_y);
+    blit(bmp_screen, bmp_winlose, 0, 0, 0, 0, m_screenX, m_screenY);
 
     allegroDrawer->drawCenteredSprite(bmp_winlose, (BITMAP *) gfxinter[BMP_LOSING].dat);
 }
@@ -291,7 +291,7 @@ bool cGame::isMissionFailed() const {
                 // since we have a fixed list of players.
 
                 // so for now just do this:
-                return false; // it is meant to win the game by losing all...
+                return false; // it is meant to win the game by drawStateLosing all...
             } else {
                 return true; // nope, it should lose mission now
             }
@@ -344,16 +344,16 @@ bool cGame::allAIPlayersAreDestroyed() const {
 
 
 /**
- * Remember, the 'winFlags' are used to determine when the game is "over". Only then the lose flags are evaluated
+ * Remember, the 'm_winFlags' are used to determine when the game is "over". Only then the lose flags are evaluated
  * and used to determine who has won. (According to the SCEN specification).
  * @return
  */
 bool cGame::hasWinConditionHumanMustLoseAllBuildings() const {
-    return (loseFlags & WINLOSEFLAGS_HUMAN_HAS_BUILDINGS) != 0;
+    return (m_loseFlags & WINLOSEFLAGS_HUMAN_HAS_BUILDINGS) != 0;
 }
 
 bool cGame::hasWinConditionAIShouldLoseEverything() const {
-    return (loseFlags & WINLOSEFLAGS_AI_NO_BUILDINGS) != 0;
+    return (m_loseFlags & WINLOSEFLAGS_AI_NO_BUILDINGS) != 0;
 }
 
 /**
@@ -361,7 +361,7 @@ bool cGame::hasWinConditionAIShouldLoseEverything() const {
  * @return
  */
 bool cGame::hasGameOverConditionPlayerHasNoBuildings() const {
-    return (winFlags & WINLOSEFLAGS_HUMAN_HAS_BUILDINGS) != 0;
+    return (m_winFlags & WINLOSEFLAGS_HUMAN_HAS_BUILDINGS) != 0;
 }
 
 /**
@@ -369,42 +369,42 @@ bool cGame::hasGameOverConditionPlayerHasNoBuildings() const {
  * @return
  */
 bool cGame::hasGameOverConditionHarvestForSpiceQuota() const {
-    return (winFlags & WINLOSEFLAGS_QUOTA) != 0;
+    return (m_winFlags & WINLOSEFLAGS_QUOTA) != 0;
 }
 
 bool cGame::hasGameOverConditionAIHasNoBuildings() const {
-    return (winFlags & WINLOSEFLAGS_AI_NO_BUILDINGS) != 0;
+    return (m_winFlags & WINLOSEFLAGS_AI_NO_BUILDINGS) != 0;
 }
 
 void cGame::think_mentat() {
-    if (pMentat) {
-        pMentat->think();
+    if (m_mentat) {
+        m_mentat->think();
     }
 }
 
 // think function belongs to combat state (tbd)
 void cGame::think_audio() {
-    _soundplayer->think();
+    m_soundPlayer->think();
 
-    if (!game.bPlayMusic) // no music enabled, so no need to think
+    if (!game.m_playMusic) // no music enabled, so no need to think
         return;
 
     // all this does is repeating music in the same theme.
-    if (iMusicType < 0)
+    if (m_musicType < 0)
         return;
 
     if (!isMusicPlaying()) {
 
-        if (iMusicType == MUSIC_ATTACK) {
-            iMusicType = MUSIC_PEACE; // set back to peace
+        if (m_musicType == MUSIC_ATTACK) {
+            m_musicType = MUSIC_PEACE; // set back to peace
         }
 
-        playMusicByType(iMusicType);
+        playMusicByType(m_musicType);
     }
 }
 
 bool cGame::isMusicPlaying() {
-    if (bMp3 && mp3_music) {
+    if (m_mp3 && mp3_music) {
         int s = almp3_poll_mp3(mp3_music);
         return !(s == ALMP3_POLL_PLAYJUSTFINISHED || s == ALMP3_POLL_NOTPLAYING);
     }
@@ -413,11 +413,11 @@ bool cGame::isMusicPlaying() {
     return MIDI_music_playing();
 }
 
-void cGame::updateState() {
-    mouse->updateState(); // calls observers that are interested in mouse input
-    keyboard->updateState(); // calls observers that are interested in keyboard input
+void cGame::updateMouseAndKeyboardStateAndGamePlaying() {
+    m_mouse->updateState(); // calls observers that are interested in mouse input
+    m_keyboard->updateState(); // calls observers that are interested in keyboard input
 
-    if (state != GAME_PLAYING) {
+    if (m_state != GAME_PLAYING) {
         return;
     }
 
@@ -428,29 +428,29 @@ void cGame::updateState() {
     }
 }
 
-void cGame::combat() {
+void cGame::drawStateCombat() {
     drawManager->drawCombatState();
 }
 
-// stateMentat logic + drawing mouth/eyes
-void cGame::stateMentat(cAbstractMentat *mentat) {
+// drawStateMentat logic + drawing mouth/eyes
+void cGame::drawStateMentat(cAbstractMentat *mentat) {
     draw_sprite(bmp_screen, bmp_backgroundMentat, 0, 0);
 
-    mouse->setTile(MOUSE_NORMAL);
+    m_mouse->setTile(MOUSE_NORMAL);
 
     mentat->draw();
     mentat->interact();
 
-    mouse->draw();
+    m_mouse->draw();
 }
 
 // draw menu
-void cGame::menu() {
-    currentState->draw();
+void cGame::drawStateMenu() {
+    m_currentState->draw();
 }
 
-void cGame::init_skirmish() const {
-    game.mission_init();
+void cGame::initSkirmish() const {
+    game.missionInit();
 }
 
 void cGame::handleTimeSlicing() {
@@ -460,41 +460,41 @@ void cGame::handleTimeSlicing() {
 }
 
 void cGame::shakeScreenAndBlitBuffer() {
-    if (TIMER_shake == 0) {
-		    TIMER_shake = -1;
+    if (m_TIMER_shake == 0) {
+        m_TIMER_shake = -1;
 	  }
 
 	  // blitSprite on screen
-	  if (TIMER_shake > 0)
+	  if (m_TIMER_shake > 0)
 	  {
 		    // the more we get to the 'end' the less we 'throttle'.
 		    // Structure explosions are 6 time units per cell.
 		    // Max is 9 cells (9*6=54)
 		    // the max border is then 9. So, we do time / 6
-        TIMER_shake = std::min(TIMER_shake, 69);
-        int offset = std::min(TIMER_shake / 5, 9);
+        m_TIMER_shake = std::min(m_TIMER_shake, 69);
+        int offset = std::min(m_TIMER_shake / 5, 9);
 
-        shake_x = -abs(offset / 2) + rnd(offset);
-        shake_y = -abs(offset / 2) + rnd(offset);
+          m_shakeX = -abs(offset / 2) + rnd(offset);
+          m_shakeY = -abs(offset / 2) + rnd(offset);
 
-		    blit(bmp_screen, bmp_throttle, 0, 0, 0 + shake_x, 0 + shake_y, screen_x, screen_y);
-		    blit(bmp_throttle, screen, 0, 0, 0, 0, screen_x, screen_y);
+		    blit(bmp_screen, bmp_throttle, 0, 0, 0 + m_shakeX, 0 + m_shakeY, m_screenX, m_screenY);
+		    blit(bmp_throttle, screen, 0, 0, 0, 0, m_screenX, m_screenY);
 	  }
 	  else
 	  {
-		    if (fadeAction == eFadeAction::FADE_NONE) {
+		    if (m_fadeAction == eFadeAction::FADE_NONE) {
   		  // Not shaking and not fading.
-        blit(bmp_screen, screen, 0, 0, 0, 0, screen_x, screen_y);
+        blit(bmp_screen, screen, 0, 0, 0, 0, m_screenX, m_screenY);
     } else {
         // Fading
-        assert(fadeAlpha >= kMinAlpha);
-        assert(fadeAlpha <= kMaxAlpha);
-        auto temp = std::unique_ptr<BITMAP, decltype(&destroy_bitmap)>(create_bitmap(game.screen_x, game.screen_y), destroy_bitmap);
+        assert(m_fadeAlpha >= kMinAlpha);
+        assert(m_fadeAlpha <= kMaxAlpha);
+        auto temp = std::unique_ptr<BITMAP, decltype(&destroy_bitmap)>(create_bitmap(game.m_screenX, game.m_screenY), destroy_bitmap);
 			  assert(temp);
 			  clear(temp.get());
-        set_trans_blender(0, 0, 0, fadeAlpha);
+        set_trans_blender(0, 0, 0, m_fadeAlpha);
         draw_trans_sprite(temp.get(), bmp_screen, 0, 0);
-			  blit(temp.get(), screen, 0, 0, 0, 0, screen_x, screen_y);
+			  blit(temp.get(), screen, 0, 0, 0, 0, m_screenX, m_screenY);
 		}
 	}
 }
@@ -502,43 +502,43 @@ void cGame::shakeScreenAndBlitBuffer() {
 void cGame::drawState() {
     clear(bmp_screen);
 
-    if (fadeAction == eFadeAction::FADE_OUT) {
+    if (m_fadeAction == eFadeAction::FADE_OUT) {
         draw_sprite(bmp_screen, bmp_fadeout, 0, 0);
         return;
     }
 
     // this makes fade-in happen after fade-out automatically
-    if (fadeAlpha == kMinAlpha) {
-        fadeAction = eFadeAction::FADE_IN;
+    if (m_fadeAlpha == kMinAlpha) {
+        m_fadeAction = eFadeAction::FADE_IN;
     }
 
-    switch (state) {
+    switch (m_state) {
         case GAME_TELLHOUSE:
-            stateMentat(pMentat);
+            drawStateMentat(m_mentat);
             break;
         case GAME_PLAYING:
-            combat();
+            drawStateCombat();
             break;
         case GAME_BRIEFING:
-            stateMentat(pMentat);
+            drawStateMentat(m_mentat);
             break;
         case GAME_MENU:
-            menu();
+            drawStateMenu();
             break;
         case GAME_WINNING:
-            winning();
+            drawStateWinning();
             break;
         case GAME_LOSING:
-            losing();
+            drawStateLosing();
             break;
         case GAME_WINBRIEF:
-            stateMentat(pMentat);
+            drawStateMentat(m_mentat);
             break;
         case GAME_LOSEBRIEF:
-            stateMentat(pMentat);
+            drawStateMentat(m_mentat);
             break;
         default:
-            currentState->draw();
+            m_currentState->draw();
             // TODO: GAME_STATISTICS, ETC
     }
 }
@@ -549,20 +549,20 @@ void cGame::drawState() {
 void cGame::run() {
     set_trans_blender(0, 0, 0, 128);
 
-    while (bPlaying) {
+    while (m_playing) {
         TimeManager.processTime();
-        updateState();
+        updateMouseAndKeyboardStateAndGamePlaying();
         handleTimeSlicing(); // handle time diff (needs to change!)
         drawState(); // run game state, includes interaction + drawing
         transitionStateIfRequired();
-        _interactionManager->interactWithKeyboard(); // generic interaction
+        m_interactionManager->interactWithKeyboard(); // generic interaction
         shakeScreenAndBlitBuffer(); // finally, draw the bmp_screen to real screen (double buffering)
-        frame_count++;
+        m_frameCount++;
     }
 }
 
 void cGame::shakeScreen(int duration) {
-    game.TIMER_shake += duration;
+    game.m_TIMER_shake += duration;
 }
 
 /**
@@ -573,41 +573,41 @@ void cGame::shutdown() {
     logger->logHeader("SHUTDOWN");
 
     for (int i = 0; i < GAME_MAX_STATES; i++) {
-        cGameState *pState = states[i];
+        cGameState *pState = m_states[i];
         if (pState) {
             if (pState->getType() != eGameStateType::GAMESTATE_SELECT_YOUR_NEXT_CONQUEST) {
-                if (currentState == pState) {
-                    currentState = nullptr; // reset
+                if (m_currentState == pState) {
+                    m_currentState = nullptr; // reset
                 }
                 delete pState;
-                states[i] = nullptr;
+                m_states[i] = nullptr;
             } else {
-                if (currentState == pState) {
-                    currentState = nullptr; // reset
+                if (m_currentState == pState) {
+                    m_currentState = nullptr; // reset
                 }
-                states[i] = nullptr;
+                m_states[i] = nullptr;
             }
         }
     }
 
-    if (currentState != nullptr) {
+    if (m_currentState != nullptr) {
         assert(false);
-        if (currentState->getType() != eGameStateType::GAMESTATE_SELECT_YOUR_NEXT_CONQUEST) {
+        if (m_currentState->getType() != eGameStateType::GAMESTATE_SELECT_YOUR_NEXT_CONQUEST) {
             // destroy game state object, unless we talk about the region select
-            delete currentState;
+            delete m_currentState;
         } else {
-            currentState = nullptr;
+            m_currentState = nullptr;
         }
     }
 
-    delete pMentat;
-    delete mapViewport;
+    delete m_mentat;
+    delete m_mapViewport;
 
     drawManager->destroy();
     delete drawManager;
 
     delete mapCamera;
-    delete _interactionManager;
+    delete m_interactionManager;
 
 
     cStructureFactory::destroy();
@@ -620,9 +620,9 @@ void cGame::shutdown() {
 
     delete allegroDrawer;
     delete m_dataRepository;
-    _soundplayer.reset();
-    delete mouse;
-    delete keyboard;
+    m_soundPlayer.reset();
+    delete m_mouse;
+    delete m_keyboard;
 
     if (gfxdata) {
         unload_datafile(gfxdata);
@@ -648,33 +648,33 @@ void cGame::shutdown() {
 
     // MP3 Library
     if (mp3_music) {
-        almp3_stop_autopoll_mp3(mp3_music); // stop auto updateState
+        almp3_stop_autopoll_mp3(mp3_music); // stop auto updateMouseAndKeyboardStateAndGamePlaying
         almp3_destroy_mp3(mp3_music);
     }
 
     logbook("Allegro MP3 library shut down.");
 
     // Release the game dev framework, so that it can do cleanup
-    _PLInit.reset();
+    m_PLInit.reset();
 }
 
 bool cGame::isResolutionInGameINIFoundAndSet() {
-    return game.ini_screen_height != -1 && game.ini_screen_width != -1;
+    return game.m_iniScreenHeight != -1 && game.m_iniScreenWidth != -1;
 }
 
 void cGame::setScreenResolutionFromGameIniSettings() {
-    if (game.ini_screen_width < 800) {
-        game.ini_screen_width = 800;
+    if (game.m_iniScreenWidth < 800) {
+        game.m_iniScreenWidth = 800;
         logbook("INI screen width < 800; unsupported; will set to 800.");
     }
-    if (game.ini_screen_height < 600) {
-        game.ini_screen_height = 600;
+    if (game.m_iniScreenHeight < 600) {
+        game.m_iniScreenHeight = 600;
         logbook("INI screen height < 600; unsupported; will set to 600.");
     }
-    game.screen_x = game.ini_screen_width;
-    game.screen_y = game.ini_screen_height;
+    game.m_screenX = game.m_iniScreenWidth;
+    game.m_screenY = game.m_iniScreenHeight;
     char msg[255];
-    sprintf(msg, "Resolution %dx%d loaded from ini file.", game.ini_screen_width, game.ini_screen_height);
+    sprintf(msg, "Resolution %dx%d loaded from ini file.", game.m_iniScreenWidth, game.m_iniScreenHeight);
     cLogger::getInstance()->log(LOG_INFO, COMP_ALLEGRO, "Resolution from ini file", msg);
 }
 
@@ -693,10 +693,10 @@ bool cGame::setupGame() {
 
 	logger->logHeader("Version information");
 	logger->log(LOG_INFO, COMP_VERSION, "Initializing",
-              fmt::format("Version {}, Compiled at {} , {}", game.version, __DATE__, __TIME__));
+              fmt::format("Version {}, Compiled at {} , {}", game.m_version, __DATE__, __TIME__));
 
     // init game
-    if (game.windowed) {
+    if (game.m_windowed) {
         logger->log(LOG_INFO, COMP_SETUP, "Initializing", "Windowed mode");
     } else {
         logger->log(LOG_INFO, COMP_SETUP, "Initializing", "Fullscreen mode");
@@ -706,7 +706,7 @@ bool cGame::setupGame() {
 
     // FIXME: eventually, we will want to grab this object in the constructor. But then cGame cannot be a
     // global anymore, because it needs to be destructed before main exits.
-    _PLInit = std::make_unique<cPlatformLayerInit>("d2tm.cfg");
+    m_PLInit = std::make_unique<cPlatformLayerInit>("d2tm.cfg");
 
     int r = install_timer();
     if (r > -1) {
@@ -720,14 +720,14 @@ bool cGame::setupGame() {
     alfont_init();
     logger->log(LOG_INFO, COMP_ALLEGRO, "Initializing ALFONT", "alfont_init()", OUTC_SUCCESS);
     install_keyboard();
-    keyboard = new cKeyboard();
+    m_keyboard = new cKeyboard();
     logger->log(LOG_INFO, COMP_ALLEGRO, "Initializing Allegro Keyboard", "install_keyboard()", OUTC_SUCCESS);
     install_mouse();
-    mouse = new cMouse();
+    m_mouse = new cMouse();
     logger->log(LOG_INFO, COMP_ALLEGRO, "Initializing Allegro Mouse", "install_mouse()", OUTC_SUCCESS);
 
     /* set up the interrupt routines... */
-    game.TIMER_shake = 0;
+    game.m_TIMER_shake = 0;
 
     LOCK_VARIABLE(allegro_timerUnits);
     LOCK_VARIABLE(allegro_timerGlobal);
@@ -744,10 +744,10 @@ bool cGame::setupGame() {
 
     logger->log(LOG_INFO, COMP_ALLEGRO, "Set up timer related variables", "LOCK_VARIABLE/LOCK_FUNCTION", OUTC_SUCCESS);
 
-    frame_count = fps = 0;
+    m_frameCount = m_fps = 0;
 
 	// set window title
-    auto title = fmt::format("Dune II - The Maker [{}] - (by Stefan Hendriks)", game.version);
+    auto title = fmt::format("Dune II - The Maker [{}] - (by Stefan Hendriks)", game.m_version);
 
 	// Set window title
 	set_window_title(title.c_str());
@@ -765,18 +765,18 @@ bool cGame::setupGame() {
     // but is already set up. Perhaps even offer it in the options screen? So the user
     // can specify how much CPU this game may use?
 
-    if (game.windowed) {
+    if (game.m_windowed) {
         cLogger::getInstance()->log(LOG_INFO, COMP_ALLEGRO, "Windowed mode requested.", "");
 
         if (isResolutionInGameINIFoundAndSet()) {
             setScreenResolutionFromGameIniSettings();
         }
 
-        r = set_gfx_mode(GFX_AUTODETECT_WINDOWED, game.screen_x, game.screen_y, game.screen_x, game.screen_y);
+        r = set_gfx_mode(GFX_AUTODETECT_WINDOWED, game.m_screenX, game.m_screenY, game.m_screenX, game.m_screenY);
 
         char msg[255];
-        sprintf(msg, "Initializing graphics mode (windowed) with resolution %d by %d, colorDepth %d.", game.screen_x,
-                game.screen_y, colorDepth);
+        sprintf(msg, "Initializing graphics mode (windowed) with resolution %d by %d, colorDepth %d.", game.m_screenX,
+                game.m_screenY, colorDepth);
         logbook(msg);
 
         if (r > -1) {
@@ -793,10 +793,10 @@ bool cGame::setupGame() {
         bool mustAutoDetectResolution = false;
         if (isResolutionInGameINIFoundAndSet()) {
             setScreenResolutionFromGameIniSettings();
-            r = set_gfx_mode(GFX_AUTODETECT_FULLSCREEN, game.screen_x, game.screen_y, game.screen_x, game.screen_y);
+            r = set_gfx_mode(GFX_AUTODETECT_FULLSCREEN, game.m_screenX, game.m_screenY, game.m_screenX, game.m_screenY);
             char msg[255];
             sprintf(msg, "Setting up %dx%d resolution from ini file (using colorDepth %d). r = %d",
-                    game.ini_screen_width, game.ini_screen_height, colorDepth, r);
+                    game.m_iniScreenWidth, game.m_iniScreenHeight, colorDepth, r);
             cLogger::getInstance()->log(LOG_INFO, COMP_ALLEGRO, "Custom resolution from ini file.", msg);
             mustAutoDetectResolution = r < 0;
         } else {
@@ -874,23 +874,23 @@ bool cGame::setupGame() {
         logbook("Display 'switch to background' mode set");
     }
 
-    if (!bPlaySound) {
-        _soundplayer = std::make_unique<cSoundPlayer>(*_PLInit, 0);
+    if (!m_playSound) {
+        m_soundPlayer = std::make_unique<cSoundPlayer>(*m_PLInit, 0);
     } else {
-        _soundplayer = std::make_unique<cSoundPlayer>(*_PLInit);
+        m_soundPlayer = std::make_unique<cSoundPlayer>(*m_PLInit);
     }
 
     /***
      * Viewport(s)
      */
-    mapViewport = new cRectangle(0, cSideBar::TopBarHeight, game.screen_x - cSideBar::SidebarWidth,
-                                 game.screen_y - cSideBar::TopBarHeight);
+    m_mapViewport = new cRectangle(0, cSideBar::TopBarHeight, game.m_screenX - cSideBar::SidebarWidth,
+                                 game.m_screenY - cSideBar::TopBarHeight);
 
     /***
     Bitmap Creation
     ***/
 
-    bmp_screen = create_bitmap(game.screen_x, game.screen_y);
+    bmp_screen = create_bitmap(game.m_screenX, game.m_screenY);
 
     if (bmp_screen == nullptr) {
         allegro_message("Failed to create a memory bitmap");
@@ -901,7 +901,7 @@ bool cGame::setupGame() {
         clear(bmp_screen);
     }
 
-    bmp_backgroundMentat = create_bitmap(game.screen_x, game.screen_y);
+    bmp_backgroundMentat = create_bitmap(game.m_screenX, game.m_screenY);
 
     if (bmp_backgroundMentat == nullptr) {
         allegro_message("Failed to create a memory bitmap");
@@ -915,9 +915,9 @@ bool cGame::setupGame() {
         clear_to_color(bmp_backgroundMentat, makecol(8, 8, 16));
         bool offsetX = false;
 
-        float horizon = game.screen_y / 2;
-        float centered = game.screen_x / 2;
-        for (int y = 0; y < game.screen_y; y++) {
+        float horizon = game.m_screenY / 2;
+        float centered = game.m_screenX / 2;
+        for (int y = 0; y < game.m_screenY; y++) {
             float diffYToCenter = 1.0f;
             if (y < horizon) {
                 diffYToCenter = y / horizon;
@@ -925,7 +925,7 @@ bool cGame::setupGame() {
                 diffYToCenter = 1 - ((y - horizon) / horizon);
             }
 
-            for (int x = offsetX ? 0 : 1; x < game.screen_x; x += 2) {
+            for (int x = offsetX ? 0 : 1; x < game.m_screenX; x += 2) {
                 float diffXToCenter = 1.0f;
                 if (x < centered) {
                     diffXToCenter = x / centered;
@@ -943,7 +943,7 @@ bool cGame::setupGame() {
         }
     }
 
-    bmp_throttle = create_bitmap(game.screen_x, game.screen_y);
+    bmp_throttle = create_bitmap(game.m_screenX, game.m_screenY);
 
     if (bmp_throttle == nullptr) {
         allegro_message("Failed to create a memory bitmap");
@@ -953,7 +953,7 @@ bool cGame::setupGame() {
         logbook("Memory bitmap created: bmp_throttle");
     }
 
-    bmp_winlose = create_bitmap(game.screen_x, game.screen_y);
+    bmp_winlose = create_bitmap(game.m_screenX, game.m_screenY);
 
     if (bmp_winlose == nullptr) {
         allegro_message("Failed to create a memory bitmap");
@@ -963,7 +963,7 @@ bool cGame::setupGame() {
         logbook("Memory bitmap created: bmp_winlose");
     }
 
-    bmp_fadeout = create_bitmap(game.screen_x, game.screen_y);
+    bmp_fadeout = create_bitmap(game.m_screenX, game.m_screenY);
 
     if (bmp_fadeout == nullptr) {
         allegro_message("Failed to create a memory bitmap");
@@ -1030,9 +1030,9 @@ bool cGame::setupGame() {
     logbook(fmt::format("Seed is {}", t));
     srand(t);
 
-    game.bPlaying = true;
-    game.screenshot = 0;
-    game.state = GAME_INITIALIZE;
+    game.m_playing = true;
+    game.m_screenshot = 0;
+    game.m_state = GAME_INITIALIZE;
 
     set_palette(general_palette);
 
@@ -1071,7 +1071,7 @@ bool cGame::setupGame() {
     // unit/structures catalog loaded - which the install_upgrades depends on.
     install_upgrades();
 
-    game.setup_players();
+    game.setupPlayers();
 
     playMusicByType(MUSIC_MENU);
 
@@ -1084,9 +1084,9 @@ bool cGame::setupGame() {
  * Set up players
  * (Elegible for combat state object initialization)
  */
-void cGame::setup_players() {
-    mouse->setMouseObserver(nullptr);
-    keyboard->setKeyboardObserver(nullptr);
+void cGame::setupPlayers() {
+    m_mouse->setMouseObserver(nullptr);
+    m_keyboard->setKeyboardObserver(nullptr);
 
     // make sure each player has an own item builder
     for (int i = HUMAN; i < MAX_PLAYERS; i++) {
@@ -1104,64 +1104,64 @@ void cGame::setup_players() {
         cOrderProcesser *orderProcesser = new cOrderProcesser(thePlayer);
         thePlayer->setOrderProcesser(orderProcesser);
 
-        cGameControlsContext *gameControlsContext = new cGameControlsContext(thePlayer, this->mouse);
+        cGameControlsContext *gameControlsContext = new cGameControlsContext(thePlayer, this->m_mouse);
         thePlayer->setGameControlsContext(gameControlsContext);
 
         // set tech level
-        thePlayer->setTechLevel(game.iMission);
+        thePlayer->setTechLevel(game.m_mission);
     }
 
-    delete _interactionManager;
+    delete m_interactionManager;
     cPlayer *humanPlayer = &players[HUMAN];
-    _interactionManager = new cInteractionManager(humanPlayer);
-    mouse->setMouseObserver(_interactionManager);
-    keyboard->setKeyboardObserver(_interactionManager);
+    m_interactionManager = new cInteractionManager(humanPlayer);
+    m_mouse->setMouseObserver(m_interactionManager);
+    m_keyboard->setKeyboardObserver(m_interactionManager);
 }
 
 bool cGame::isState(int thisState) {
-    return (state == thisState);
+    return (m_state == thisState);
 }
 
 void cGame::setState(int newState) {
-    if (newState == state) {
+    if (newState == m_state) {
         // ignore
         return;
     }
 
     char msg[255];
-    sprintf(msg, "Setting state from %d(=%s) to %d(=%s)", state, stateString(state), newState, stateString(newState));
+    sprintf(msg, "Setting state from %d(=%s) to %d(=%s)", m_state, stateString(m_state), newState, stateString(newState));
     logbook(msg);
 
     if (newState > -1) {
         bool deleteOldState = (newState != GAME_REGION &&
-                               newState != GAME_PLAYING); // don't delete these states, but re-use!
-        if (state == GAME_OPTIONS && newState == GAME_SETUPSKIRMISH) {
+                               newState != GAME_PLAYING); // don't delete these m_states, but re-use!
+        if (m_state == GAME_OPTIONS && newState == GAME_SETUPSKIRMISH) {
             deleteOldState = false; // so we don't lose data when we go back
         }
 
         if (deleteOldState) {
-            delete states[newState];
-            states[newState] = nullptr;
+            delete m_states[newState];
+            m_states[newState] = nullptr;
         }
 
-        cGameState *existingStatePtr = states[newState];
+        cGameState *existingStatePtr = m_states[newState];
         if (existingStatePtr) {
-            if (currentState->getType() == GAMESTATE_SELECT_YOUR_NEXT_CONQUEST) {
-                cSelectYourNextConquestState *pState = dynamic_cast<cSelectYourNextConquestState *>(currentState);
+            if (m_currentState->getType() == GAMESTATE_SELECT_YOUR_NEXT_CONQUEST) {
+                cSelectYourNextConquestState *pState = dynamic_cast<cSelectYourNextConquestState *>(m_currentState);
 
-                if (missionWasWon) {
+                if (m_missionWasWon) {
                     // we won
-                    if (game.iMission > 1) {
+                    if (game.m_mission > 1) {
                         pState->conquerRegions();
                     }
-                    pState->REGION_SETUP_NEXT_MISSION(game.iMission, players[HUMAN].getHouse());
+                    pState->REGION_SETUP_NEXT_MISSION(game.m_mission, players[HUMAN].getHouse());
                 } else {
                     // OR: did not win
                     pState->REGION_SETUP_LOST_MISSION();
                 }
             }
 
-            currentState = existingStatePtr;
+            m_currentState = existingStatePtr;
         } else {
             cGameState *newStatePtr = nullptr;
 
@@ -1171,11 +1171,11 @@ void cGame::setState(int newState) {
                 pState->calculateOffset();
                 logbook("Setup:  WORLD");
                 pState->INSTALL_WORLD();
-                if (game.iMission > 1) {
+                if (game.m_mission > 1) {
                     pState->conquerRegions();
                 }
                 // first creation
-                pState->REGION_SETUP_NEXT_MISSION(game.iMission, players[HUMAN].getHouse());
+                pState->REGION_SETUP_NEXT_MISSION(game.m_mission, players[HUMAN].getHouse());
 
                 newStatePtr = pState;
             } else if (newState == GAME_SETUPSKIRMISH) {
@@ -1186,9 +1186,9 @@ void cGame::setState(int newState) {
             } else if (newState == GAME_SELECT_HOUSE) {
                 newStatePtr = new cChooseHouseGameState(*this);
             } else if (newState == GAME_OPTIONS) {
-                BITMAP *background = create_bitmap(screen_x, screen_y);
+                BITMAP *background = create_bitmap(m_screenX, m_screenY);
                 allegroDrawer->drawSprite(background, bmp_screen, 0, 0);
-                newStatePtr = new cOptionsState(*this, background, state);
+                newStatePtr = new cOptionsState(*this, background, m_state);
             } else if (newState == GAME_PLAYING) {
                 // evaluate all players, so we have initial 'alive' values set properly
                 for (int i = 1; i < MAX_PLAYERS; i++) {
@@ -1207,49 +1207,49 @@ void cGame::setState(int newState) {
                 game.onNotifyGameEvent(event);
             }
 
-            states[newState] = newStatePtr;
-            currentState = newStatePtr;
+            m_states[newState] = newStatePtr;
+            m_currentState = newStatePtr;
         }
     }
 
-    state = newState;
+    m_state = newState;
 }
 
 void cGame::think_fading() {
     // Fading of the entire screen
-    if (fadeAction == eFadeAction::FADE_OUT) {
-        fadeAlpha -= 2;
-        if (fadeAlpha < kMinAlpha) {
-            fadeAlpha = kMinAlpha;
-            fadeAction = eFadeAction::FADE_NONE;
+    if (m_fadeAction == eFadeAction::FADE_OUT) {
+        m_fadeAlpha -= 2;
+        if (m_fadeAlpha < kMinAlpha) {
+            m_fadeAlpha = kMinAlpha;
+            m_fadeAction = eFadeAction::FADE_NONE;
         }
-    } else if (fadeAction == eFadeAction::FADE_IN) {
-        fadeAlpha += 2;
-        if (fadeAlpha > kMaxAlpha) {
-            fadeAlpha = kMaxAlpha;
-            fadeAction = eFadeAction::FADE_NONE;
+    } else if (m_fadeAction == eFadeAction::FADE_IN) {
+        m_fadeAlpha += 2;
+        if (m_fadeAlpha > kMaxAlpha) {
+            m_fadeAlpha = kMaxAlpha;
+            m_fadeAction = eFadeAction::FADE_NONE;
         }
     }
 
     // Fading / pulsating of selected stuff
     static constexpr float fadeSelectIncrement = 1 / 256.0f;
-    if (bFadeSelectDir) {
-        fade_select += fadeSelectIncrement;
+    if (m_fadeSelectDir) {
+        m_fadeSelect += fadeSelectIncrement;
 
         // when 255, then fade back
-        if (fade_select > 0.99) {
-            fade_select = 1.0f;
-            bFadeSelectDir = false;
+        if (m_fadeSelect > 0.99) {
+            m_fadeSelect = 1.0f;
+            m_fadeSelectDir = false;
         }
 
         return;
     }
 
-    fade_select -= fadeSelectIncrement;
+    m_fadeSelect -= fadeSelectIncrement;
     // not too dark,
     // 0.03125
-    if (fade_select < 0.3125f) {
-        bFadeSelectDir = true;
+    if (m_fadeSelect < 0.3125f) {
+        m_fadeSelectDir = true;
     }
 }
 
@@ -1263,79 +1263,79 @@ cGame::~cGame() {
 
 void cGame::prepareMentatForPlayer() {
     int house = players[HUMAN].getHouse();
-    if (state == GAME_BRIEFING) {
-        game.mission_init();
-        game.setup_players();
-        INI_Load_scenario(house, iRegion, pMentat);
-        INI_LOAD_BRIEFING(house, iRegion, INI_BRIEFING, pMentat);
-    } else if (state == GAME_WINBRIEF) {
+    if (m_state == GAME_BRIEFING) {
+        game.missionInit();
+        game.setupPlayers();
+        INI_Load_scenario(house, m_region, m_mentat);
+        INI_LOAD_BRIEFING(house, m_region, INI_BRIEFING, m_mentat);
+    } else if (m_state == GAME_WINBRIEF) {
         if (rnd(100) < 50) {
-            pMentat->loadScene("win01");
+            m_mentat->loadScene("win01");
         } else {
-            pMentat->loadScene("win02");
+            m_mentat->loadScene("win02");
         }
-        INI_LOAD_BRIEFING(house, iRegion, INI_WIN, pMentat);
-    } else if (state == GAME_LOSEBRIEF) {
+        INI_LOAD_BRIEFING(house, m_region, INI_WIN, m_mentat);
+    } else if (m_state == GAME_LOSEBRIEF) {
         if (rnd(100) < 50) {
-            pMentat->loadScene("lose01");
+            m_mentat->loadScene("lose01");
         } else {
-            pMentat->loadScene("lose02");
+            m_mentat->loadScene("lose02");
         }
-        INI_LOAD_BRIEFING(house, iRegion, INI_LOSE, pMentat);
+        INI_LOAD_BRIEFING(house, m_region, INI_LOSE, m_mentat);
     }
 }
 
 void cGame::createAndPrepareMentatForHumanPlayer() {
-    delete pMentat;
+    delete m_mentat;
     int houseIndex = players[0].getHouse();
     if (houseIndex == ATREIDES) {
-        pMentat = new cAtreidesMentat();
+        m_mentat = new cAtreidesMentat();
     } else if (houseIndex == HARKONNEN) {
-        pMentat = new cHarkonnenMentat();
+        m_mentat = new cHarkonnenMentat();
     } else if (houseIndex == ORDOS) {
-        pMentat = new cOrdosMentat();
+        m_mentat = new cOrdosMentat();
     } else {
         // fallback
-        pMentat = new cBeneMentat();
+        m_mentat = new cBeneMentat();
     }
     prepareMentatForPlayer();
-    pMentat->speak();
+    m_mentat->speak();
 }
 
 void cGame::prepareMentatToTellAboutHouse(int house) {
-    delete pMentat;
-    pMentat = new cBeneMentat();
-    pMentat->setHouse(house);
-    // create new stateMentat
+    delete m_mentat;
+    m_mentat = new cBeneMentat();
+    m_mentat->setHouse(house);
+    // create new drawStateMentat
     if (house == ATREIDES) {
-        INI_LOAD_BRIEFING(ATREIDES, 0, INI_DESCRIPTION, pMentat);
-        pMentat->loadScene("platr"); // load planet of atreides
+        INI_LOAD_BRIEFING(ATREIDES, 0, INI_DESCRIPTION, m_mentat);
+        m_mentat->loadScene("platr"); // load planet of atreides
     } else if (house == HARKONNEN) {
-        INI_LOAD_BRIEFING(HARKONNEN, 0, INI_DESCRIPTION, pMentat);
-        pMentat->loadScene("plhar"); // load planet of harkonnen
+        INI_LOAD_BRIEFING(HARKONNEN, 0, INI_DESCRIPTION, m_mentat);
+        m_mentat->loadScene("plhar"); // load planet of harkonnen
     } else if (house == ORDOS) {
-        INI_LOAD_BRIEFING(ORDOS, 0, INI_DESCRIPTION, pMentat);
-        pMentat->loadScene("plord"); // load planet of ordos
+        INI_LOAD_BRIEFING(ORDOS, 0, INI_DESCRIPTION, m_mentat);
+        m_mentat->loadScene("plord"); // load planet of ordos
     } else {
-        pMentat->setSentence(0, "Looks like you choose an unknown house");
+        m_mentat->setSentence(0, "Looks like you choose an unknown house");
     }
     // todo: Sardaukar, etc? (Super Dune 2 features)
-    pMentat->speak();
+    m_mentat->speak();
 }
 
 void cGame::loadScenario() {
     int iHouse = players[HUMAN].getHouse();
-    INI_Load_scenario(iHouse, game.iRegion, pMentat);
+    INI_Load_scenario(iHouse, game.m_region, m_mentat);
 }
 
 void cGame::think_state() {
-    if (currentState) {
-        currentState->thinkFast();
+    if (m_currentState) {
+        m_currentState->thinkFast();
     }
 }
 
 void cGame::setPlayerToInteractFor(cPlayer *pPlayer) {
-    _interactionManager->setPlayerToInteractFor(pPlayer);
+    m_interactionManager->setPlayerToInteractFor(pPlayer);
 }
 
 void cGame::onNotifyGameEvent(const s_GameEvent &event) {
@@ -1394,7 +1394,7 @@ void cGame::onEventSpecialLaunch(const s_GameEvent &event) {
             if (structureId > -1) {
                 cAbstractStructure *pStructure = structure[structureId];
                 if (pStructure && pStructure->isValid()) {
-                    _soundplayer->playSound(SOUND_PLACE);
+                    m_soundPlayer->playSound(SOUND_PLACE);
                     create_bullet(special.providesTypeId, pStructure->getCell(), deployCell, -1, structureId);
 
                     // notify game that the item just has been finished!
@@ -1443,8 +1443,8 @@ void cGame::onEventSpecialLaunch(const s_GameEvent &event) {
 }
 
 void cGame::reduceShaking() {
-    if (TIMER_shake > 0) {
-        TIMER_shake--;
+    if (m_TIMER_shake > 0) {
+        m_TIMER_shake--;
     }
 }
 
@@ -1505,9 +1505,9 @@ void cGame::install_bitmaps() {
 }
 
 int cGame::getColorFadeSelected(int r, int g, int b, bool rFlag, bool gFlag, bool bFlag) {
-    int desiredRed = rFlag ? r * fade_select : r;
-    int desiredGreen = gFlag ? g * fade_select : g;
-    int desiredBlue = bFlag ? b * fade_select : b;
+    int desiredRed = rFlag ? r * m_fadeSelect : r;
+    int desiredGreen = gFlag ? g * m_fadeSelect : g;
+    int desiredBlue = bFlag ? b * m_fadeSelect : b;
     return makecol(desiredRed, desiredGreen, desiredBlue);
 }
 
@@ -1530,48 +1530,48 @@ int cGame::getColorPlaceGood() {
 void cGame::setWinFlags(int value) {
     if (DEBUGGING) {
         char msg[255];
-        sprintf(msg, "Changing winFlags from %d to %d", winFlags, value);
+        sprintf(msg, "Changing m_winFlags from %d to %d", m_winFlags, value);
         logbook(msg);
     }
-    winFlags = value;
+    m_winFlags = value;
 }
 
 void cGame::setLoseFlags(int value) {
     if (DEBUGGING) {
         char msg[255];
-        sprintf(msg, "Changing loseFlags from %d to %d", loseFlags, value);
+        sprintf(msg, "Changing m_loseFlags from %d to %d", m_loseFlags, value);
         logbook(msg);
     }
-    loseFlags = value;
+    m_loseFlags = value;
 }
 
 bool cGame::isRunningAtIdealFps() {
-    return fps < IDEAL_FPS;
+    return m_fps > IDEAL_FPS;
 }
 
 void cGame::resetFrameCount() {
-    frame_count = 0;
+    m_frameCount = 0;
 }
 
 void cGame::setFps() {
-    fps = frame_count;
+    m_fps = m_frameCount;
 }
 
 int cGame::getFps() {
-    return fps;
+    return m_fps;
 }
 
 void cGame::onNotifyMouseEvent(const s_MouseEvent &event) {
     // pass through any classes that are interested
-    if (currentState) {
-        currentState->onNotifyMouseEvent(event);
+    if (m_currentState) {
+        m_currentState->onNotifyMouseEvent(event);
     }
 }
 
 void cGame::onNotifyKeyboardEvent(const cKeyboardEvent &event) {
     // pass through any classes that are interested
-    if (currentState) {
-        currentState->onNotifyKeyboardEvent(event);
+    if (m_currentState) {
+        m_currentState->onNotifyKeyboardEvent(event);
     }
 
     // take screenshot
@@ -1580,55 +1580,55 @@ void cGame::onNotifyKeyboardEvent(const cKeyboardEvent &event) {
     }
 
     // TODO: this has to be its own state class. Then this if is no longer needed.
-    if (state == GAME_PLAYING) {
+    if (m_state == GAME_PLAYING) {
         onNotifyKeyboardEventGamePlaying(event);
     }
 }
 
 void cGame::transitionStateIfRequired() {
-    if (nextState > -1) {
-        setState(nextState);
+    if (m_nextState > -1) {
+        setState(m_nextState);
 
-        if (nextState == GAME_BRIEFING) {
+        if (m_nextState == GAME_BRIEFING) {
             playMusicByType(MUSIC_BRIEFING);
             game.createAndPrepareMentatForHumanPlayer();
         }
 
-        nextState = -1;
+        m_nextState = -1;
     }
 }
 
 void cGame::setNextStateToTransitionTo(int newState) {
-    nextState = newState;
+    m_nextState = newState;
 }
 
 void cGame::drawCombatMouse() {
-    if (mouse->isBoxSelecting()) {
-        allegroDrawer->drawRectangle(bmp_screen, mouse->getBoxSelectRectangle(),
+    if (m_mouse->isBoxSelecting()) {
+        allegroDrawer->drawRectangle(bmp_screen, m_mouse->getBoxSelectRectangle(),
                                      game.getColorFadeSelected(255, 255, 255));
     }
 
-    if (mouse->isMapScrolling()) {
-        cPoint startPoint = mouse->getDragLineStartPoint();
-        cPoint endPoint = mouse->getDragLineEndPoint();
+    if (m_mouse->isMapScrolling()) {
+        cPoint startPoint = m_mouse->getDragLineStartPoint();
+        cPoint endPoint = m_mouse->getDragLineEndPoint();
         allegroDrawer->drawLine(bmp_screen, startPoint.x, startPoint.y, endPoint.x, endPoint.y,
                                 game.getColorFadeSelected(255, 255, 255));
     }
 
-    mouse->draw();
+    m_mouse->draw();
 }
 
 void cGame::saveBmpScreenToDisk() {
     char filename[25];
 
-    if (screenshot < 10) {
-        sprintf(filename, "%dx%d_000%d.bmp", screen_x, screen_y, screenshot);
-    } else if (screenshot < 100) {
-        sprintf(filename, "%dx%d_00%d.bmp", screen_x, screen_y, screenshot);
-    } else if (screenshot < 1000) {
-        sprintf(filename, "%dx%d_0%d.bmp", screen_x, screen_y, screenshot);
+    if (m_screenshot < 10) {
+        sprintf(filename, "%dx%d_000%d.bmp", m_screenX, m_screenY, m_screenshot);
+    } else if (m_screenshot < 100) {
+        sprintf(filename, "%dx%d_00%d.bmp", m_screenX, m_screenY, m_screenshot);
+    } else if (m_screenshot < 1000) {
+        sprintf(filename, "%dx%d_0%d.bmp", m_screenX, m_screenY, m_screenshot);
     } else {
-        sprintf(filename, "%dx%d_%d.bmp", screen_x, screen_y, screenshot);
+        sprintf(filename, "%dx%d_%d.bmp", m_screenX, m_screenY, m_screenshot);
     }
 
     save_bmp(filename, bmp_screen, general_palette);
@@ -1638,7 +1638,7 @@ void cGame::saveBmpScreenToDisk() {
     cPlayer &humanPlayer = players[HUMAN];
     humanPlayer.addNotification(fmt::format("Screenshot saved {}.", filename), eNotificationType::NEUTRAL);
 
-    screenshot++;
+    m_screenshot++;
 }
 
 void cGame::onNotifyKeyboardEventGamePlaying(const cKeyboardEvent &event) {
@@ -1685,21 +1685,21 @@ void cGame::onKeyPressedGamePlaying(const cKeyboardEvent &event) {
 }
 
 void cGame::playSound(int sampleId) {
-    _soundplayer->playSound(sampleId);
+    m_soundPlayer->playSound(sampleId);
 }
 
 void cGame::playSound(int sampleId, int vol) {
-    _soundplayer->playSound(sampleId, vol);
+    m_soundPlayer->playSound(sampleId, vol);
 }
 
 void cGame::playVoice(int sampleId, int house) {
-    _soundplayer->playVoice(sampleId, house);
+    m_soundPlayer->playVoice(sampleId, house);
 }
 
 void cGame::playMusic(int sampleId) {
-    _soundplayer->playMusic(sampleId);
+    m_soundPlayer->playMusic(sampleId);
 }
 
 int cGame::getMaxVolume() {
-    return _soundplayer->getMaxVolume();
+    return m_soundPlayer->getMaxVolume();
 }

--- a/controls/cGameControlsContext.cpp
+++ b/controls/cGameControlsContext.cpp
@@ -40,7 +40,7 @@ void cGameControlsContext::updateMouseCell(const cPoint &coords) {
         return;
     }
 
-    if (coords.x > (game.screen_x - cSideBar::SidebarWidth)) {
+    if (coords.x > (game.m_screenX - cSideBar::SidebarWidth)) {
         mouseCell = MOUSECELL_SIDEBAR; // on sidebar
         return;
     }

--- a/controls/cGameControlsContext.h
+++ b/controls/cGameControlsContext.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// this class holds the game controls context. This means, the updateState() method
+// this class holds the game controls context. This means, the updateMouseAndKeyboardStateAndGamePlaying() method
 // will check how the mouse is positioned in this particular frame. It then updates
 // any ids, or other relevant data.
 //

--- a/controls/cMouse.cpp
+++ b/controls/cMouse.cpp
@@ -194,8 +194,8 @@ void cMouse::boxSelectLogic(int mouseCell) {
 
             // assign 2nd coordinates
             mouse_co_x2 = mouse_x;
-            if (mouse_x > game.screen_x - cSideBar::SidebarWidth) {
-                mouse_co_x2 = game.screen_x - cSideBar::SidebarWidth - 1;
+            if (mouse_x > game.m_screenX - cSideBar::SidebarWidth) {
+                mouse_co_x2 = game.m_screenX - cSideBar::SidebarWidth - 1;
             }
 
             mouse_co_y2 = mouse_y;

--- a/drawers/CreditsDrawer.cpp
+++ b/drawers/CreditsDrawer.cpp
@@ -18,7 +18,7 @@ CreditsDrawer::CreditsDrawer(cPlayer * thePlayer) : player(thePlayer){
 
 	// center credits bar within sidebar
     int widthCreditsBar = ((BITMAP *)gfxinter[CREDITS_BAR].dat)->w;
-	drawX = game.screen_x - (cSideBar::SidebarWidthWithoutCandyBar / 2) - (widthCreditsBar / 2);
+	drawX = game.m_screenX - (cSideBar::SidebarWidthWithoutCandyBar / 2) - (widthCreditsBar / 2);
 	drawY = 0;
 }
 
@@ -204,7 +204,7 @@ void CreditsDrawer::drawCurrentCredits() {
 	int offset = getXDrawingOffset(currentCredits);
 
 	for (int i=0; i < 6; i++) {
-		// the actual position to draw on is: ((game.screen_x - 120) +
+		// the actual position to draw on is: ((game.m_screenX - 120) +
 		//        screen        -  14 + (6 digits (each 20 pixels due borders))
 		int dx = ((offset + i) * 20);
 		int dy = 0;
@@ -237,7 +237,7 @@ void CreditsDrawer::drawPreviousCredits() {
 	int offset = getXDrawingOffset(previousCredits);
 
 	for (int i=0; i < 6; i++) {
-		// the actual position to draw on is: ((game.screen_x - 120) +
+		// the actual position to draw on is: ((game.m_screenX - 120) +
 		//        screen        -  14 + (6 digits (each 20 pixels due borders))
 		int dx = ((offset + i) * 20);
 		int dy = 0;

--- a/drawers/cAllegroDrawer.cpp
+++ b/drawers/cAllegroDrawer.cpp
@@ -126,16 +126,16 @@ void cAllegroDrawer::maskedStretchBlit(BITMAP *src, BITMAP *dest, int src_x, int
 void cAllegroDrawer::drawCenteredSprite(BITMAP *dest, BITMAP *src) {
 	assert(src);
 	assert(dest);
-	int xPos = getCenteredXPosForBitmap(src, game.screen_x);
+	int xPos = getCenteredXPosForBitmap(src, game.m_screenX);
 	int yPos = getCenteredYPosForBitmap(src);
 	draw_sprite(dest, src, xPos, yPos);
 }
 
 void cAllegroDrawer::drawSpriteCenteredRelativelyVertical(BITMAP *dest, BITMAP* src, float percentage) {
-	int xPos = getCenteredXPosForBitmap(src, game.screen_x);
+	int xPos = getCenteredXPosForBitmap(src, game.m_screenX);
 
 	// we want to know the 'center' first. This is done in the percentage
-	int wantedYPos = ((float)game.screen_y * percentage);
+	int wantedYPos = ((float)game.m_screenY * percentage);
 
 	// we need to know the height of the src
 	int height = src->h;
@@ -155,7 +155,7 @@ void cAllegroDrawer::drawCenteredSpriteHorizontal(BITMAP *dest, BITMAP *src, int
 void cAllegroDrawer::drawCenteredSpriteVertical(BITMAP *dest, BITMAP *src, int x) {
 	assert(src);
 	assert(dest);
-	int yPos = getCenteredXPosForBitmap(src, game.screen_x);
+	int yPos = getCenteredXPosForBitmap(src, game.m_screenX);
 	draw_sprite(dest, src, x, yPos);
 }
 
@@ -170,7 +170,7 @@ int cAllegroDrawer::getCenteredYPosForBitmap(BITMAP *bmp) {
 	assert(bmp);
 	int height = bmp->h;
 	int halfOfHeight = height / 2;
-	return (game.screen_y / 2) - halfOfHeight;
+	return (game.m_screenY / 2) - halfOfHeight;
 }
 
 void cAllegroDrawer::blit(sBitmap *src, BITMAP *dest, int src_x, int src_y, int width, int height, int pos_x, int pos_y) {

--- a/drawers/cBuildingListDrawer.cpp
+++ b/drawers/cBuildingListDrawer.cpp
@@ -95,7 +95,7 @@ void cBuildingListDrawer::drawButton(cBuildingList *list, bool pressed) {
 
 
 int cBuildingListDrawer::getDrawX() {
-	return (game.screen_x - cSideBar::SidebarWidthWithoutCandyBar) + 2;
+	return (game.m_screenX - cSideBar::SidebarWidthWithoutCandyBar) + 2;
 }
 
 int cBuildingListDrawer::getDrawY() {
@@ -304,7 +304,7 @@ void cBuildingListDrawer::drawList(cBuildingList *list, bool shouldDrawStructure
         }
     }
 
-	set_clip_rect(bmp_screen, 0, 0, game.screen_x, game.screen_y);
+	set_clip_rect(bmp_screen, 0, 0, game.m_screenX, game.m_screenY);
 }
 
 /**

--- a/drawers/cMessageDrawer.cpp
+++ b/drawers/cMessageDrawer.cpp
@@ -149,7 +149,7 @@ void cMessageDrawer::initCombatPosition() {
 
     int margin = 4;
     int widthOfOptionsButton = 160 + margin;
-    int desiredWidth = game.screen_x - (cSideBar::SidebarWidth + widthOfOptionsButton);
+    int desiredWidth = game.m_screenX - (cSideBar::SidebarWidth + widthOfOptionsButton);
     createMessageBarBmp(desiredWidth);
 
     // default positions in-game (battle mode)

--- a/drawers/cMiniMapDrawer.cpp
+++ b/drawers/cMiniMapDrawer.cpp
@@ -18,7 +18,7 @@ cMiniMapDrawer::cMiniMapDrawer(cMap *theMap, cPlayer *thePlayer, cMapCamera *the
 
     int halfWidthOfMinimap = cSideBar::WidthOfMinimap / 2;
     int halfWidthOfMap = getMapWidthInPixels() / 2;
-    int topLeftX = game.screen_x - cSideBar::WidthOfMinimap;
+    int topLeftX = game.m_screenX - cSideBar::WidthOfMinimap;
     drawX = topLeftX + (halfWidthOfMinimap - halfWidthOfMap);
 
     int halfHeightOfMinimap = cSideBar::HeightOfMinimap / 2;
@@ -233,7 +233,7 @@ void cMiniMapDrawer::draw() {
     drawStaticFrame();
 
     drawViewPortRectangle();
-    set_clip_rect(bmp_screen, 0, 0, game.screen_x, game.screen_y);
+    set_clip_rect(bmp_screen, 0, 0, game.m_screenX, game.m_screenY);
 }
 
 void cMiniMapDrawer::drawStaticFrame() {

--- a/drawers/cMouseDrawer.cpp
+++ b/drawers/cMouseDrawer.cpp
@@ -21,7 +21,7 @@ int cMouseDrawer::getDrawXToolTip(int width) {
 	int x = mouseX + 32;
 
 	// correct drawing position so it does not fall off screen.
-	int diffX = (x + width) - game.screen_x;
+	int diffX = (x + width) - game.m_screenX;
 	if (diffX > 0) {
 		x-= diffX;
 	}
@@ -32,7 +32,7 @@ int cMouseDrawer::getDrawYToolTip(int height) {
 	int y = mouseY + 32;
 
 	// correct drawing position so it does not fall off screen.
-	int diffY = (y + height) - game.screen_y;
+	int diffY = (y + height) - game.m_screenY;
 	if (diffY > 0) {
 		y -= diffY;
 	}

--- a/drawers/cOrderDrawer.cpp
+++ b/drawers/cOrderDrawer.cpp
@@ -14,8 +14,8 @@ cOrderDrawer::cOrderDrawer(cPlayer *thePlayer) : player(thePlayer) {
     int halfOfSidebar = cSideBar::SidebarWidthWithoutCandyBar / 2;
     int halfOfHeightLeftForButton = 50 / 2; // 50 = height of 1 row icons which is removed for Starport
     int halfOfButtonHeight = buttonBitmap->h / 2;
-    buttonRect = cRectangle((game.screen_x - halfOfSidebar) - halfOfButton,
-                                (game.screen_y - halfOfHeightLeftForButton) - halfOfButtonHeight,
+    buttonRect = cRectangle((game.m_screenX - halfOfSidebar) - halfOfButton,
+                            (game.m_screenY - halfOfHeightLeftForButton) - halfOfButtonHeight,
                                 buttonBitmap->w, buttonBitmap->h);
     _isMouseOverOrderButton = false;
 

--- a/drawers/cParticleDrawer.cpp
+++ b/drawers/cParticleDrawer.cpp
@@ -18,7 +18,7 @@ void cParticleDrawer::determineParticlesToDraw() {
     for (int i=0; i < MAX_PARTICLES; i++) {
         cParticle &pParticle = particle[i];
         if (!pParticle.isValid()) continue;
-        if (!pParticle.isWithinViewport(game.mapViewport)) continue;
+        if (!pParticle.isWithinViewport(game.m_mapViewport)) continue;
 
         if (pParticle.getLayer() == D2TM_RENDER_LAYER_PARTICLE_BOTTOM) {
             particlesLowerLayer.push_back(i);

--- a/drawers/cSideBarDrawer.cpp
+++ b/drawers/cSideBarDrawer.cpp
@@ -25,13 +25,13 @@ void cSideBarDrawer::drawCandybar() {
         createCandyBar();
     }
 
-	int drawX = game.screen_x - cSideBar::SidebarWidth;
+	int drawX = game.m_screenX - cSideBar::SidebarWidth;
 	int drawY = 40;
 	draw_sprite(bmp_screen, candybar, drawX, drawY);
 }
 
 void cSideBarDrawer::createCandyBar() {
-    int heightInPixels = (game.screen_y - cSideBar::TopBarHeight);
+    int heightInPixels = (game.m_screenY - cSideBar::TopBarHeight);
     candybar = create_bitmap_ex(8, 24, heightInPixels);
     clear_to_color(candybar, makecol(0, 0, 0));
 
@@ -73,10 +73,10 @@ void cSideBarDrawer::createCandyBar() {
 //    set_palette(thePlayer->pal);
 //
 //    // black out
-//    rectfill(bmp_screen, (game.screen_x-160), 0, game.screen_x, game.screen_y, makecol(0,0,0));
+//    rectfill(bmp_screen, (game.m_screenX-160), 0, game.m_screenX, game.m_screenY, makecol(0,0,0));
 //
 //    // upper bar
-//    rectfill(bmp_screen, 0, 0, game.screen_x, 42, makecol(0,0,0));
+//    rectfill(bmp_screen, 0, 0, game.m_screenX, 42, makecol(0,0,0));
 //
 //    int iHouse = thePlayer->getHouse();
 //
@@ -119,13 +119,13 @@ void cSideBarDrawer::drawBuildingLists() {
     // draw background of buildlist
     BITMAP * backgroundSprite = (BITMAP *)gfxinter[BMP_GERALD_ICONLIST_BACKGROUND].dat;
 
-    int drawX = game.screen_x - cSideBar::SidebarWidthWithoutCandyBar + 1;
+    int drawX = game.m_screenX - cSideBar::SidebarWidthWithoutCandyBar + 1;
 
     int startY = cSideBar::TopBarHeight + cSideBar::HeightOfMinimap + cSideBar::HorizontalCandyBarHeight +
                  cSideBar::HeightOfListButton;
 
-    for (; drawX < game.screen_x; drawX += backgroundSprite->w) {
-        for (int drawY=startY; drawY < game.screen_y; drawY += backgroundSprite->h) {
+    for (; drawX < game.m_screenX; drawX += backgroundSprite->w) {
+        for (int drawY=startY; drawY < game.m_screenY; drawY += backgroundSprite->h) {
             draw_sprite(bmp_screen, backgroundSprite, drawX, drawY);
         }
     }
@@ -144,11 +144,11 @@ void cSideBarDrawer::drawBuildingLists() {
         selectedList = sidebar->getList(selectedListId);
     }
 
-    int endY = game.screen_y;
+    int endY = game.m_screenY;
     int rows = 6;
     if (selectedList && selectedList->getType() == eListType::LIST_STARPORT) {
         rows = 5;
-        endY = game.screen_y - 50;
+        endY = game.m_screenY - 50;
     }
 
     for (int i = 1; i < 3; i++) {
@@ -161,19 +161,19 @@ void cSideBarDrawer::drawBuildingLists() {
         // horizontal lines
         for (int j = 1; j < rows; j++) {
             int barY = iDrawY - 1 + (j * 50);
-            line(bmp_screen, iDrawX, barY-1, game.screen_x, barY-1, darker);
-            line(bmp_screen, iDrawX, barY, game.screen_x, barY, veryDark);
+            line(bmp_screen, iDrawX, barY-1, game.m_screenX, barY - 1, darker);
+            line(bmp_screen, iDrawX, barY, game.m_screenX, barY, veryDark);
         }
     }
 
     if (selectedList && selectedList->getType() == eListType::LIST_STARPORT) {
-        rectfill(bmp_screen, iDrawX, endY, game.screen_x, game.screen_y, sidebarColor);
+        rectfill(bmp_screen, iDrawX, endY, game.m_screenX, game.m_screenY, sidebarColor);
         draw_sprite(bmp_screen, horBar, iDrawX-1, endY); // just below the last icons
     }
 
     // vertical lines at the side
-    line(bmp_screen, iDrawX - 1, iDrawY-38, iDrawX-1, game.screen_y, makecol(255, 211, 125)); // left
-    line(bmp_screen, game.screen_x - 1, iDrawY-38, game.screen_x - 1, endY, makecol(209, 150, 28)); // right
+    line(bmp_screen, iDrawX - 1, iDrawY-38, iDrawX-1, game.m_screenY, makecol(255, 211, 125)); // left
+    line(bmp_screen, game.m_screenX - 1, iDrawY - 38, game.m_screenX - 1, endY, makecol(209, 150, 28)); // right
 
     // END drawing icons grid
 
@@ -207,7 +207,7 @@ void cSideBarDrawer::draw() {
     set_palette(player->pal);
 
     // black out sidebar
-    rectfill(bmp_screen, (game.screen_x-cSideBar::SidebarWidth), 0, game.screen_x, game.screen_y, makecol(0,0,0));
+    rectfill(bmp_screen, (game.m_screenX - cSideBar::SidebarWidth), 0, game.m_screenX, game.m_screenY, makecol(0, 0, 0));
 
     drawCandybar();
 
@@ -223,7 +223,7 @@ void cSideBarDrawer::drawCapacities() {
 
 void cSideBarDrawer::drawCreditsUsage() {
     int barTotalHeight = (cSideBar::HeightOfMinimap - 76);
-    int barX = (game.screen_x - cSideBar::SidebarWidth) + (cSideBar::VerticalCandyBarWidth / 3);
+    int barX = (game.m_screenX - cSideBar::SidebarWidth) + (cSideBar::VerticalCandyBarWidth / 3);
     int barY = cSideBar::TopBarHeight + 48;
     int barWidth = (cSideBar::VerticalCandyBarWidth / 3) - 1;
     cRectangle powerBarRect(barX, barY, barWidth, barTotalHeight);
@@ -280,8 +280,8 @@ void cSideBarDrawer::drawCreditsUsage() {
 
 void cSideBarDrawer::drawPowerUsage() const {
     int arbitraryMargin = 6;
-    int barTotalHeight = game.screen_y - (cSideBar::TotalHeightBeforePowerBarStarts + cSideBar::PowerBarMarginHeight);
-    int barX = (game.screen_x - cSideBar::SidebarWidth) + (cSideBar::VerticalCandyBarWidth / 3);
+    int barTotalHeight = game.m_screenY - (cSideBar::TotalHeightBeforePowerBarStarts + cSideBar::PowerBarMarginHeight);
+    int barX = (game.m_screenX - cSideBar::SidebarWidth) + (cSideBar::VerticalCandyBarWidth / 3);
     int barY = cSideBar::TotalHeightBeforePowerBarStarts + arbitraryMargin;
     int barWidth = (cSideBar::VerticalCandyBarWidth / 3) - 1;
     cRectangle powerBarRect(barX, barY, barWidth, barTotalHeight);
@@ -334,7 +334,7 @@ void cSideBarDrawer::drawPowerUsage() const {
 
 void cSideBarDrawer::drawMinimap() {
 	BITMAP * sprite = (BITMAP *)gfxinter[HORIZONTAL_CANDYBAR].dat;
-	int drawX = (game.screen_x - sprite->w) + 1;
+	int drawX = (game.m_screenX - sprite->w) + 1;
 	// 128 pixels (each pixel is a cell) + 8 margin
     int heightMinimap = cSideBar::HeightOfMinimap;
 	int drawY = cSideBar::TopBarHeight + heightMinimap;
@@ -352,7 +352,7 @@ void cSideBarDrawer::drawMinimap() {
     }
 
     // else, we render the house emblem
-	rectfill(bmp_screen, drawX + 1, cSideBar::TopBarHeight + 1, game.screen_x, drawY, player->getEmblemBackgroundColor());
+	rectfill(bmp_screen, drawX + 1, cSideBar::TopBarHeight + 1, game.m_screenX, drawY, player->getEmblemBackgroundColor());
 
 	if (player->isHouse(ATREIDES) || player->isHouse(HARKONNEN) || player->isHouse(ORDOS)) {
 	    int bitmapId = BMP_SELECT_HOUSE_ATREIDES;

--- a/drawers/cStructureDrawer.cpp
+++ b/drawers/cStructureDrawer.cpp
@@ -327,7 +327,7 @@ void cStructureDrawer::drawStructuresForLayer(int layer) {
         }
 	}
 
-	rectfill(bmp_screen, (game.screen_x-cSideBar::SidebarWidth), 0, game.screen_x, game.screen_y, makecol(0,0,0));
+	rectfill(bmp_screen, (game.m_screenX - cSideBar::SidebarWidth), 0, game.m_screenX, game.m_screenY, makecol(0, 0, 0));
 }
 
 void cStructureDrawer::drawStructureHealthBar(int iStructure) {

--- a/drawers/cTextDrawer.cpp
+++ b/drawers/cTextDrawer.cpp
@@ -55,7 +55,7 @@ void cTextDrawer::drawTextCentered(const char *msg, int y) const{
 void cTextDrawer::drawTextCentered(const char * msg, int y, int color) const {
 	int lenghtInPixels = alfont_text_length(font, msg);
 	int half = lenghtInPixels / 2;
-	int xPos = (game.screen_x / 2) - half;
+	int xPos = (game.m_screenX / 2) - half;
     drawText(xPos, y, color, msg);
 }
 
@@ -97,8 +97,8 @@ void cTextDrawer::drawTextBottomLeft(const char * msg) const {
 
 void cTextDrawer::drawTextBottomRight(int color, const char * msg) const {
 	int lenghtInPixels = alfont_text_length(font, msg);
-	int x = game.screen_x - lenghtInPixels;
-	int y = game.screen_y - getFontHeight();
+	int x = game.m_screenX - lenghtInPixels;
+	int y = game.m_screenY - getFontHeight();
 	drawText(x, y, color, msg);
 }
 
@@ -108,7 +108,7 @@ int cTextDrawer::getFontHeight() const {
 }
 
 void cTextDrawer::drawTextBottomLeft(int color, const char * msg) const {
-	int y = game.screen_y - alfont_text_height(font);
+	int y = game.m_screenY - alfont_text_height(font);
 	drawText(0, y, color, msg);
 }
 

--- a/gameobjects/cFlag.cpp
+++ b/gameobjects/cFlag.cpp
@@ -18,8 +18,8 @@ void cFlag::draw() {
     int drawX = mapCamera->getWindowXPosition(absCoords.x);
     int drawY = mapCamera->getWindowYPosition(absCoords.y);
 
-    if ((drawX >= 0 && drawX < game.screen_x) &&
-        (drawY >= 0 && drawY < game.screen_y)) { // within screen
+    if ((drawX >= 0 && drawX < game.m_screenX) &&
+        (drawY >= 0 && drawY < game.m_screenY)) { // within screen
         // draw it
 
         int pixelWidth = flagBitmap->w;

--- a/gameobjects/projectiles/bullet.cpp
+++ b/gameobjects/projectiles/bullet.cpp
@@ -64,10 +64,10 @@ void cBullet::draw() {
     int x = draw_x();
     int y = draw_y();
 
-    if (x < -getBulletBmpWidth() || x > (game.screen_x + getBulletBmpWidth()))
+    if (x < -getBulletBmpWidth() || x > (game.m_screenX + getBulletBmpWidth()))
         return;
 
-    if (y < getBulletBmpHeight() || y > game.screen_y + getBulletBmpHeight())
+    if (y < getBulletBmpHeight() || y > game.m_screenY + getBulletBmpHeight())
         return;
 
     int ba = bullet_face_angle(fDegrees(posX, posY, targetX, targetY));

--- a/gameobjects/units/cUnit.cpp
+++ b/gameobjects/units/cUnit.cpp
@@ -770,7 +770,7 @@ void cUnit::draw() {
                                          );
     }
 
-    if (game.bDrawUnitDebug) {
+    if (game.m_drawUnitDebug) {
         // render pixel at the very center
         putpixel(bmp_screen, center_draw_x(), center_draw_y(), makecol(255, 255, 0));
 
@@ -3524,7 +3524,7 @@ int CREATE_PATH(int iUnitId, int iPathCountUnits) {
 
     // Too many paths where created , so we wait a little.
     // make sure not to create too many paths at once
-    if (game.paths_created > 40) {
+    if (game.m_pathsCreated > 40) {
         pUnit.log("CREATE_PATH -- END 3");
         pUnit.TIMER_movewait = (50 + rnd(50));
         return -3;
@@ -3558,7 +3558,7 @@ int CREATE_PATH(int iUnitId, int iPathCountUnits) {
     int goal_cell = pUnit.iGoalCell;
     int controller = pUnit.iPlayer;
 
-    game.paths_created++;
+    game.m_pathsCreated++;
     memset(temp_map, -1, sizeof(temp_map));
 
     the_cll = -1;

--- a/gamestates/cChooseHouseGameState.cpp
+++ b/gamestates/cChooseHouseGameState.cpp
@@ -7,26 +7,26 @@
 cChooseHouseGameState::cChooseHouseGameState(cGame &theGame) :
     cGameState(theGame),
     textDrawer(cTextDrawer(bene_font)) {
-    backButtonRect = textDrawer.getAsRectangle(0, game.screen_y - textDrawer.getFontHeight(), " BACK");
+    backButtonRect = textDrawer.getAsRectangle(0, game.m_screenY - textDrawer.getFontHeight(), " BACK");
 
     bmp_Dune = (BITMAP *) gfxinter[BMP_GAME_DUNE].dat;
 
-    int duneAtTheRight = game.screen_x - bmp_Dune->w;
-    int duneAlmostAtBottom = game.screen_y - (bmp_Dune->h * 0.90);
+    int duneAtTheRight = game.m_screenX - bmp_Dune->w;
+    int duneAlmostAtBottom = game.m_screenY - (bmp_Dune->h * 0.90);
     coords_Dune = cPoint(duneAtTheRight, duneAlmostAtBottom);
 
     bmp_SelectYourHouseTitle = (BITMAP *) gfxinter[BMP_SELECT_YOUR_HOUSE].dat;
 
-    selectYourHouseXCentered = (game.screen_x / 2) - bmp_SelectYourHouseTitle->w / 2;
+    selectYourHouseXCentered = (game.m_screenX / 2) - bmp_SelectYourHouseTitle->w / 2;
     coords_SelectYourHouseTitle = cPoint(selectYourHouseXCentered, 0);
 
     bmp_HouseAtreides = (BITMAP *) gfxinter[BMP_SELECT_HOUSE_ATREIDES].dat;
     bmp_HouseOrdos = (BITMAP *) gfxinter[BMP_SELECT_HOUSE_ORDOS].dat;
     bmp_HouseHarkonnen = (BITMAP *) gfxinter[BMP_SELECT_HOUSE_HARKONNEN].dat;
 
-    int selectYourHouseY = game.screen_y * 0.25f;
+    int selectYourHouseY = game.m_screenY * 0.25f;
 
-    int columnWidth = game.screen_x / 7; // empty, atr, empty, har, empty, ord, empty (7 columns)
+    int columnWidth = game.m_screenX / 7; // empty, atr, empty, har, empty, ord, empty (7 columns)
 
     int offset = (columnWidth / 2) - (bmp_HouseAtreides->w / 2);
 
@@ -96,20 +96,20 @@ void cChooseHouseGameState::onMouseLeftButtonClicked(const s_MouseEvent &event) 
         game.prepareMentatToTellAboutHouse(ATREIDES);
         game.playSound(SOUND_ATREIDES);
         game.setNextStateToTransitionTo(GAME_TELLHOUSE);
-        game.START_FADING_OUT();
+        game.initiateFadingOut();
     } else if (event.coords.isWithinRectangle(&houseOrdos)) {
         game.prepareMentatToTellAboutHouse(ORDOS);
         game.playSound(SOUND_ORDOS);
         game.setNextStateToTransitionTo(GAME_TELLHOUSE);
-        game.START_FADING_OUT();
+        game.initiateFadingOut();
     } else if (event.coords.isWithinRectangle(&houseHarkonnen)) {
         game.prepareMentatToTellAboutHouse(HARKONNEN);
         game.playSound(SOUND_HARKONNEN);
         game.setNextStateToTransitionTo(GAME_TELLHOUSE);
-        game.START_FADING_OUT();
+        game.initiateFadingOut();
     } else if (event.coords.isWithinRectangle(backButtonRect)) {
         game.setNextStateToTransitionTo(GAME_MENU);
-        game.START_FADING_OUT();
+        game.initiateFadingOut();
     }
 }
 

--- a/gamestates/cMainMenuGameState.cpp
+++ b/gamestates/cMainMenuGameState.cpp
@@ -8,7 +8,7 @@ cMainMenuGameState::cMainMenuGameState(cGame &theGame) : cGameState(theGame), te
     int logoWidth = bmp_D2TM_Title->w;
     int logoHeight = bmp_D2TM_Title->h;
 
-    int centerOfScreen = game.screen_x / 2;
+    int centerOfScreen = game.m_screenX / 2;
 
     logoX = centerOfScreen - (logoWidth / 2);
     logoY = (logoHeight/10);
@@ -112,8 +112,8 @@ void cMainMenuGameState::thinkFast() {
 
 void cMainMenuGameState::draw() const {
     if (DEBUGGING) {
-        for (int x = 0; x < game.screen_x; x += 60) {
-            for (int y = 0; y < game.screen_y; y += 20) {
+        for (int x = 0; x < game.m_screenX; x += 60) {
+            for (int y = 0; y < game.m_screenY; y += 20) {
                 rect(bmp_screen, x, y, x + 50, y + 10, makecol(64, 64, 64));
                 putpixel(bmp_screen, x, y, makecol(255, 255, 255));
                 alfont_textprintf(bmp_screen, bene_font, x, y, makecol(32, 32, 32), "Debug");
@@ -127,15 +127,15 @@ void cMainMenuGameState::draw() const {
 
     gui_window->draw();
 
-    int creditsX = (game.screen_x / 2) - (alfont_text_length(bene_font, "CREDITS") / 2);
+    int creditsX = (game.m_screenX / 2) - (alfont_text_length(bene_font, "CREDITS") / 2);
     GUI_DRAW_BENE_TEXT_MOUSE_SENSITIVE(creditsX, 1, "CREDITS", makecol(64, 64, 64));
 
 
     // draw version
-    textDrawer.drawTextBottomRight(game.version.c_str());
+    textDrawer.drawTextBottomRight(game.m_version.c_str());
 
     // mp3 addon?
-    if (game.bMp3) {
+    if (game.m_mp3) {
         textDrawer.drawTextBottomLeft("Music: MP3 ADD-ON");
     } else {
         textDrawer.drawTextBottomLeft("Music: MIDI");
@@ -151,7 +151,7 @@ void cMainMenuGameState::draw() const {
     game.getMouse()->draw();
 
     if (key[KEY_ESC]) {
-        game.bPlaying=false;
+        game.m_playing=false;
     }
 }
 

--- a/gamestates/cOptionsState.cpp
+++ b/gamestates/cOptionsState.cpp
@@ -7,11 +7,11 @@ cOptionsState::cOptionsState(cGame &theGame, BITMAP *background, int prevState)
   ,  background(background)
   ,  prevState(prevState)
   ,  textDrawer(cTextDrawer(bene_font)) {
-    int margin = game.screen_y * 0.3;
+    int margin = game.m_screenY * 0.3;
     int mainMenuFrameX = margin;
     int mainMenuFrameY = margin;
-    int mainMenuWidth = game.screen_x - (margin * 2);
-    int mainMenuHeight = game.screen_y - (margin * 2);
+    int mainMenuWidth = game.m_screenX - (margin * 2);
+    int mainMenuHeight = game.m_screenY - (margin * 2);
 
     margin = 4;
     int buttonHeight = (textDrawer.getFontHeight() + margin);
@@ -24,7 +24,7 @@ cOptionsState::cOptionsState(cGame &theGame, BITMAP *background, int prevState)
     const eGuiTextAlignHorizontal buttonTextAlignment = eGuiTextAlignHorizontal::CENTER;
 
     // Title
-    gui_window->setTitle("Dune II - The Maker - version " + game.version);
+    gui_window->setTitle("Dune II - The Maker - version " + game.m_version);
 
     // EXIT
     int rows = 2;

--- a/gamestates/cSelectYourNextConquestState.cpp
+++ b/gamestates/cSelectYourNextConquestState.cpp
@@ -21,8 +21,8 @@ cSelectYourNextConquestState::cSelectYourNextConquestState(cGame &theGame) : cGa
 }
 
 void cSelectYourNextConquestState::calculateOffset() {
-    offsetX = (game.screen_x - 640) / 2;
-    offsetY = (game.screen_y - 480) / 2; // same goes for offsetY (but then for 480 height).
+    offsetX = (game.m_screenX - 640) / 2;
+    offsetY = (game.m_screenY - 480) / 2; // same goes for offsetY (but then for 480 height).
 }
 
 cSelectYourNextConquestState::~cSelectYourNextConquestState() {
@@ -57,7 +57,7 @@ void cSelectYourNextConquestState::thinkFast() {
         }
 
         int iHouse = players[0].getHouse();
-        int iMission = game.iMission;
+        int iMission = game.m_mission;
 
         if (regionSceneState == SCENE_INIT) {
             REGION_SETUP_NEXT_MISSION(iMission, iHouse);
@@ -335,21 +335,21 @@ void cSelectYourNextConquestState::loadScenarioAndTransitionToNextState(int iMis
     iNewReg += iReg;
 
     //char msg[255];
-//sprintf(msg, "Mission = %d", game.iMission);
+//sprintf(msg, "Mission = %d", game.m_mission);
 //allegro_message(msg);
 
-    game.mission_init();
+    game.missionInit();
     game.setNextStateToTransitionTo(GAME_BRIEFING);
-    game.iRegion = iNewReg;
-    game.iMission++;                        // FINALLY ADD MISSION NUMBER...
+    game.m_region = iNewReg;
+    game.m_mission++;                        // FINALLY ADD MISSION NUMBER...
 
-    // set up stateMentat
+    // set up drawStateMentat
     game.createAndPrepareMentatForHumanPlayer();
 
     // load map
     game.loadScenario();
 
-    //sprintf(msg, "Mission = %d", game.iMission);
+    //sprintf(msg, "Mission = %d", game.m_mission);
 //allegro_message(msg);
 
     playMusicByType(MUSIC_BRIEFING);
@@ -357,7 +357,7 @@ void cSelectYourNextConquestState::loadScenarioAndTransitionToNextState(int iMis
     //allegro_message(msg);
 
     state = REGSTATE_FADEOUT;
-    game.START_FADING_OUT();
+    game.initiateFadingOut();
 }
 
 cRegion * cSelectYourNextConquestState::getRegionMouseIsOver() const {
@@ -600,7 +600,7 @@ void cSelectYourNextConquestState::onMouseLeftButtonClicked(const s_MouseEvent &
 
     cRegion *pRegion = getRegionMouseIsOver();
     if (pRegion && pRegion->bSelectable) {
-        loadScenarioAndTransitionToNextState(game.iMission);
+        loadScenarioAndTransitionToNextState(game.m_mission);
     }
 }
 

--- a/gamestates/cSetupSkirmishGameState.cpp
+++ b/gamestates/cSetupSkirmishGameState.cpp
@@ -49,17 +49,17 @@ cSetupSkirmishGameState::cSetupSkirmishGameState(cGame &theGame) : cGameState(th
     widthOfSomething = 300; //??
 
     // Screen
-    screen_x = game.screen_x;
-    screen_y = game.screen_y;
+    screen_x = game.m_screenX;
+    screen_y = game.m_screenY;
 
     // Background
     background = create_bitmap(screen_x, screen_y);
     clear_to_color(background, makecol(0, 0, 0));
 
     BITMAP *dunePlanet = (BITMAP *) gfxinter[BMP_GAME_DUNE].dat;
-    allegroDrawer->drawSprite(background, dunePlanet, game.screen_x * 0.2, (game.screen_y * 0.5));
+    allegroDrawer->drawSprite(background, dunePlanet, game.m_screenX * 0.2, (game.m_screenY * 0.5));
 
-    for (int dy = 0; dy < game.screen_y; dy += 2) {
+    for (int dy = 0; dy < game.m_screenY; dy += 2) {
         allegroDrawer->drawLine(background, 0, dy, screen_x, dy, makecol(0, 0, 0));
     }
 
@@ -103,7 +103,7 @@ cSetupSkirmishGameState::cSetupSkirmishGameState(cGame &theGame) : cGameState(th
     mapListTitle = cRectangle(mapListFrameX, mapListFrameY, mapListFrameWidth, mapListFrameHeight);
 
     // actual list of maps
-//    int mapListHeight = screen_y - (topBarHeight + topRightBoxHeight + topBarHeight + topBarHeight);
+//    int mapListHeight = m_screenY - (topBarHeight + topRightBoxHeight + topBarHeight + topBarHeight);
     int mapListHeight = screen_y - (mapListTitle.getY() + mapListTitle.getHeight() + topBarHeight + 1);
     int mapListWidth = mapListTitle.getWidth();
     int mapListTopX = mapListTitle.getX();
@@ -292,7 +292,7 @@ cSetupSkirmishGameState::getTextColorForRect(const s_SkirmishPlayer &sSkirmishPl
         return sSkirmishPlayer.bPlaying ? colorSelectedRedFade : colorDisabledFade;
     }
 
-    if (sSkirmishPlayer.bHuman) { // should be redundant when player is always bPlaying?
+    if (sSkirmishPlayer.bHuman) { // should be redundant when player is always m_playing?
         return colorWhite;
     }
 
@@ -387,13 +387,13 @@ void cSetupSkirmishGameState::drawWorms(const cRectangle &wormsRect) const {
 void cSetupSkirmishGameState::prepareSkirmishGameToPlayAndTransitionToCombatState(int iSkirmishMap) {
     s_PreviewMap &selectedMap = PreviewMap[iSkirmishMap];
 
-    // this needs to be before setup_players :/
-    game.iMission = 9; // high tech level (TODO: make this customizable)
+    // this needs to be before setupPlayers :/
+    game.m_mission = 9; // high tech level (TODO: make this customizable)
 
-    game.setup_players();
+    game.setupPlayers();
 
     // Starting skirmish mode
-    game.bSkirmish = true;
+    game.m_skirmish = true;
 
     /* set up starting positions */
     std::vector<int> iStartPositions;
@@ -438,11 +438,11 @@ void cSetupSkirmishGameState::prepareSkirmishGameToPlayAndTransitionToCombatStat
     }
 
     int maxThinkingAIs = MAX_PLAYERS;
-    if (game.bOneAi) {
+    if (game.m_oneAi) {
         maxThinkingAIs = 1;
     }
 
-    if (game.bDisableAI) {
+    if (game.m_disableAI) {
         maxThinkingAIs = 0;
     }
 
@@ -662,7 +662,7 @@ void cSetupSkirmishGameState::prepareSkirmishGameToPlayAndTransitionToCombatStat
 
     drawManager->getMessageDrawer()->initCombatPosition();
 
-    game.START_FADING_OUT();
+    game.initiateFadingOut();
     game.setNextStateToTransitionTo(GAME_PLAYING); // this deletes the current state object
 }
 
@@ -882,8 +882,8 @@ void cSetupSkirmishGameState::onMouseLeftButtonClickedAtWorms() {
 
 void cSetupSkirmishGameState::onMouseLeftButtonClickedAtStartButton() {
     int topBarHeight = 21;
-    int screen_y = game.screen_y;
-    int screen_x = game.screen_x;
+    int screen_y = game.m_screenY;
+    int screen_x = game.m_screenX;
 
     int startButtonWidth = textDrawer.textLength("START");
     int startButtonHeight = topBarHeight;

--- a/gui/actions/cGuiActionExitGame.cpp
+++ b/gui/actions/cGuiActionExitGame.cpp
@@ -1,6 +1,6 @@
 #include "d2tmh.h"
 
 void cGuiActionExitGame::execute() {
-    game.bPlaying = false;
-    game.START_FADING_OUT();
+    game.m_playing = false;
+    game.initiateFadingOut();
 }

--- a/gui/actions/cGuiActionFadeOutOnly.cpp
+++ b/gui/actions/cGuiActionFadeOutOnly.cpp
@@ -1,5 +1,5 @@
 #include "d2tmh.h"
 
 void cGuiActionFadeOutOnly::execute() {
-    game.START_FADING_OUT();
+    game.initiateFadingOut();
 }

--- a/gui/actions/cGuiActionSelectHouse.cpp
+++ b/gui/actions/cGuiActionSelectHouse.cpp
@@ -2,5 +2,5 @@
 
 void cGuiActionSelectHouse::execute() {
     game.setNextStateToTransitionTo(GAME_SELECT_HOUSE);
-    game.START_FADING_OUT();
+    game.initiateFadingOut();
 }

--- a/gui/actions/cGuiActionSetupSkirmishGame.cpp
+++ b/gui/actions/cGuiActionSetupSkirmishGame.cpp
@@ -2,7 +2,7 @@
 
 void cGuiActionSetupSkirmishGame::execute() {
     INI_PRESCAN_SKIRMISH();
-    game.init_skirmish();
+    game.initSkirmish();
     game.setNextStateToTransitionTo(GAME_SETUPSKIRMISH);
-    game.START_FADING_OUT();
+    game.initiateFadingOut();
 }

--- a/gui/actions/cGuiActionToGameState.cpp
+++ b/gui/actions/cGuiActionToGameState.cpp
@@ -6,6 +6,6 @@ cGuiActionToGameState::cGuiActionToGameState(int nextState, bool fadeOut) : fade
 void cGuiActionToGameState::execute() {
     game.setNextStateToTransitionTo(nextState);
     if (fadeOut) {
-        game.START_FADING_OUT();
+        game.initiateFadingOut();
     }
 }

--- a/ini.cpp
+++ b/ini.cpp
@@ -1210,14 +1210,14 @@ std::string INI_GetScenarioFileName(int iHouse, int iRegion) {
 
 
 void INI_Load_scenario(int iHouse, int iRegion, cAbstractMentat *pMentat) {
-    game.bSkirmish = false;
-    game.mission_init();
+    game.m_skirmish = false;
+    game.missionInit();
 
     std::string filename = INI_GetScenarioFileName(iHouse, iRegion);
 
-    game.iMission = getTechLevelByRegion(iRegion);
+    game.m_mission = getTechLevelByRegion(iRegion);
 
-    logbook(fmt::format("[SCENARIO] '{}' (Mission {})", filename, game.iMission));
+    logbook(fmt::format("[SCENARIO] '{}' (Mission {})", filename, game.m_mission));
     logbook("[SCENARIO] Opening file");
 
     // declare some temp fields while reading the scenario file.
@@ -2199,13 +2199,13 @@ void INI_Install_Game(std::string filename) {
 //				  game.windowed = (INI_WordValueBOOL(linefeed) == false);
 //				  break;
                     case WORD_SCREENWIDTH:
-                        game.ini_screen_width = INI_WordValueINT(linefeed);
+                        game.m_iniScreenWidth = INI_WordValueINT(linefeed);
                         break;
                     case WORD_SCREENHEIGHT:
-                        game.ini_screen_height = INI_WordValueINT(linefeed);
+                        game.m_iniScreenHeight = INI_WordValueINT(linefeed);
                         break;
                     case WORD_MP3MUSIC:
-                        game.bMp3 = INI_WordValueBOOL(linefeed);
+                        game.m_mp3 = INI_WordValueBOOL(linefeed);
                         break;
                 }
             }

--- a/main.cpp
+++ b/main.cpp
@@ -78,13 +78,13 @@ ALMP3_MP3   *mp3_music; // pointer to mp3 music
 #endif
 
 int handleArguments(int argc, char *argv[]) {
-    game.bDisableAI = false;
-    game.bDisableReinforcements = false;
-    game.bDrawUsages = false;
-    game.bDrawUnitDebug = false;
-    game.bOneAi = false;
-    game.windowed = false;
-    game.bNoAiRest = false;
+    game.m_disableAI = false;
+    game.m_disableReinforcements = false;
+    game.m_drawUsages = false;
+    game.m_drawUnitDebug = false;
+    game.m_oneAi = false;
+    game.m_windowed = false;
+    game.m_noAiRest = false;
 
 	if (argc > 1) {
 		for (int i = 1; i < argc; i++) {
@@ -92,33 +92,33 @@ int handleArguments(int argc, char *argv[]) {
 			if (command.compare("-game") == 0) {
 				if ((i + 1) < argc) {
 					i++;
-					game.game_filename = std::string(argv[i]);
+					game.m_gameFilename = std::string(argv[i]);
 				}
 			} else if (command.compare("-windowed") == 0) {
 				// Windowed flag passed, so use that
-				game.windowed = true;
+				game.m_windowed = true;
 			} else if (command.compare("-nomusic") == 0) {
-				game.bPlayMusic = false;
+				game.m_playMusic = false;
 			} else if (command.compare("-nosound") == 0) {
 			    // disable all sound effects
-				game.bPlayMusic = false;
-				game.bPlaySound = false;
+				game.m_playMusic = false;
+				game.m_playSound = false;
 			} else if (command.compare("-debug") == 0) {
 			    // generic debugging enabled
                 bDoDebug = true;
 			} else if (command.compare("-debug-units") == 0) {
                 // unit debugging enabled
-                game.bDrawUnitDebug = true;
+                game.m_drawUnitDebug = true;
 			} else if (command.compare("-noai") == 0) {
-                game.bDisableAI = true;
+                game.m_disableAI = true;
             } else if (command.compare("-oneai") == 0) {
-                game.bOneAi = true;
+                game.m_oneAi = true;
             } else if (command.compare("-noreinforcements") == 0) {
-                game.bDisableReinforcements = true;
+                game.m_disableReinforcements = true;
             } else if (command.compare("-noairest") == 0) {
-                game.bNoAiRest = true;
+                game.m_noAiRest = true;
             } else if (command.compare("-usages") == 0) {
-                game.bDrawUsages = true;
+                game.m_drawUsages = true;
             }
 		}
 	} // arguments passed
@@ -130,7 +130,7 @@ int handleArguments(int argc, char *argv[]) {
 	Entry point of the game
 */
 int main(int argc, char **argv) {
-	game.game_filename = "game.ini";
+	game.m_gameFilename = "game.ini";
 
     if (handleArguments(argc, argv) > 0) {
         return 0;

--- a/managers/cDrawManager.cpp
+++ b/managers/cDrawManager.cpp
@@ -40,7 +40,7 @@ cDrawManager::~cDrawManager() {
 void cDrawManager::drawCombatState() {
     // MAP
 	assert(mapDrawer);
-	allegroDrawer->setClippingFor(bmp_screen, 0, cSideBar::TopBarHeight, mapCamera->getWindowWidth(), game.screen_y);
+	allegroDrawer->setClippingFor(bmp_screen, 0, cSideBar::TopBarHeight, mapCamera->getWindowWidth(), game.m_screenY);
     mapDrawer->drawTerrain();
 
 	// Only draw units/structures, etc, when we do NOT press D
@@ -92,7 +92,7 @@ void cDrawManager::drawCombatState() {
 
     allegroDrawer->resetClippingFor(bmp_screen);
 
-    if (game.bDrawUsages) {
+    if (game.m_drawUsages) {
         drawDebugInfoUsages();
         particleDrawer->drawDebugInfo();
     }
@@ -178,7 +178,7 @@ void cDrawManager::drawRallyPoint() {
 }
 
 void cDrawManager::drawSidebar() {
-    allegroDrawer->setClippingFor(bmp_screen, game.screen_x-cSideBar::SidebarWidth, 0, game.screen_x, game.screen_y);
+    allegroDrawer->setClippingFor(bmp_screen, game.m_screenX - cSideBar::SidebarWidth, 0, game.m_screenX, game.m_screenY);
     sidebarDrawer->draw();
     miniMapDrawer->draw();
     allegroDrawer->resetClippingFor(bmp_screen);
@@ -224,9 +224,9 @@ void cDrawManager::drawMouse() {
 
 void cDrawManager::drawTopBarBackground() {
     if (topBarBmp == nullptr) {
-        topBarBmp = create_bitmap(game.screen_x, 30);
+        topBarBmp = create_bitmap(game.m_screenX, 30);
         BITMAP *topbarPiece = (BITMAP *)gfxinter[BMP_TOPBAR_BACKGROUND].dat;
-        for (int x = 0; x < game.screen_x; x+= topbarPiece->w) {
+        for (int x = 0; x < game.m_screenX; x+= topbarPiece->w) {
             allegroDrawer->drawSprite(topBarBmp, topbarPiece, x, 0);
         }
 
@@ -261,12 +261,12 @@ void cDrawManager::setPlayerToDraw(cPlayer * playerToDraw) {
 
 void cDrawManager::drawOptionBar() {
     // upper bar
-    rectfill(bmp_screen, 0, 0, game.screen_x, cSideBar::TopBarHeight, makecol(0,0,0));
+    rectfill(bmp_screen, 0, 0, game.m_screenX, cSideBar::TopBarHeight, makecol(0, 0, 0));
     if (optionsBar == NULL) {
-        optionsBar = create_bitmap(game.screen_x, 40);
+        optionsBar = create_bitmap(game.m_screenX, 40);
         clear_to_color(optionsBar, sidebarColor);
 
-        for (int w = 0; w < (game.screen_x + 800); w += 789) {
+        for (int w = 0; w < (game.m_screenX + 800); w += 789) {
             draw_sprite(optionsBar, (BITMAP *)gfxinter[BMP_GERALD_TOP_BAR].dat, w, 31);
         }
     }
@@ -277,7 +277,7 @@ void cDrawManager::drawOptionBar() {
 void cDrawManager::drawNotifications() {
     std::vector<cPlayerNotification> &notifications = player->getNotifications();
 //    int y = cSideBar::TopBarHeight + 14; // 12 pixels
-    int y = game.screen_y - 11;
+    int y = game.m_screenY - 11;
     for (auto &notification : notifications) {
         textDrawer->drawText(4, y, notification.getColor(), notification.getMessage().c_str());
         y-=15;

--- a/managers/cKeyboardManager.cpp
+++ b/managers/cKeyboardManager.cpp
@@ -53,9 +53,9 @@ void cKeyboardManager::DEBUG_KEYS() {
 
     //JUMP TO MISSION 9
     if (key[KEY_F1] && players[HUMAN].getHouse() > 0) {
-        game.mission_init();
-        game.iMission = 9;
-        game.iRegion = 22;
+        game.missionInit();
+        game.m_mission = 9;
+        game.m_region = 22;
         game.setNextStateToTransitionTo(GAME_BRIEFING);
         playMusicByType(MUSIC_BRIEFING);
         game.createAndPrepareMentatForHumanPlayer();
@@ -121,9 +121,9 @@ void cKeyboardManager::DEBUG_KEYS() {
 
     //JUMP TO MISSION 3
     if (key[KEY_F6] && players[HUMAN].getHouse() > 0) {
-        game.mission_init();
-        game.iMission = 3;
-        game.iRegion = 6;
+        game.missionInit();
+        game.m_mission = 3;
+        game.m_region = 6;
         game.setNextStateToTransitionTo(GAME_BRIEFING);
         playMusicByType(MUSIC_BRIEFING);
         game.createAndPrepareMentatForHumanPlayer();
@@ -131,18 +131,18 @@ void cKeyboardManager::DEBUG_KEYS() {
 
     //JUMP TO MISSION 4
     if (key[KEY_F7] && players[HUMAN].getHouse() > 0) {
-        game.mission_init();
-        game.iMission = 4;
-        game.iRegion = 10;
+        game.missionInit();
+        game.m_mission = 4;
+        game.m_region = 10;
         game.setNextStateToTransitionTo(GAME_BRIEFING);
         playMusicByType(MUSIC_BRIEFING);
         game.createAndPrepareMentatForHumanPlayer();
     }
     //JUMP TO MISSION 5
     if (key[KEY_F8] && players[HUMAN].getHouse() > 0) {
-        game.mission_init();
-        game.iMission = 5;
-        game.iRegion = 13;
+        game.missionInit();
+        game.m_mission = 5;
+        game.m_region = 13;
         game.setNextStateToTransitionTo(GAME_BRIEFING);
         playMusicByType(MUSIC_BRIEFING);
         game.createAndPrepareMentatForHumanPlayer();

--- a/map/cMap.cpp
+++ b/map/cMap.cpp
@@ -479,13 +479,13 @@ void cMap::draw_units() {
         if (!pUnit.isValid()) continue;
 
         // DEBUG MODE: DRAW PATHS
-        if (game.bDrawUnitDebug) {
+        if (game.m_drawUnitDebug) {
             pUnit.draw_path();
         }
 
         if (pUnit.iType != SANDWORM) continue;
 
-        if (pUnit.isWithinViewport(game.mapViewport)) {
+        if (pUnit.isWithinViewport(game.m_mapViewport)) {
             pUnit.draw();
         }
 
@@ -501,7 +501,7 @@ void cMap::draw_units() {
         if (!pUnit.isInfantryUnit())
             continue; // skip non-infantry units
 
-        if (pUnit.isWithinViewport(game.mapViewport)) {
+        if (pUnit.isWithinViewport(game.m_mapViewport)) {
             // draw
             pUnit.draw();
         }
@@ -519,7 +519,7 @@ void cMap::draw_units() {
             pUnit.isInfantryUnit())
             continue; // skip airborn, infantry and sandworm
 
-        if (pUnit.isWithinViewport(game.mapViewport)) {
+        if (pUnit.isWithinViewport(game.m_mapViewport)) {
             // draw
             pUnit.draw();
         }
@@ -529,7 +529,7 @@ void cMap::draw_units() {
 }
 
 void cMap::drawUnitDebug(cUnit &pUnit) const {
-    if (!game.bDrawUnitDebug) return;
+    if (!game.m_drawUnitDebug) return;
 
     pUnit.draw_debug();
 }
@@ -543,7 +543,7 @@ void cMap::draw_units_2nd() {
         cUnit &pUnit = unit[i];
         if (!pUnit.isValid()) continue;
         if (!pUnit.bHovered && !pUnit.bSelected) continue;
-        if (!pUnit.isWithinViewport(game.mapViewport)) continue;
+        if (!pUnit.isWithinViewport(game.m_mapViewport)) continue;
         if (pUnit.iTempHitPoints > -1) continue;
 
         pUnit.draw_health();
@@ -559,7 +559,7 @@ void cMap::draw_units_2nd() {
         if (!pUnit.isValid()) continue;
         if (!pUnit.isAirbornUnit()) continue;
 
-        if (pUnit.isWithinViewport(game.mapViewport)) {
+        if (pUnit.isWithinViewport(game.m_mapViewport)) {
             pUnit.draw();
             // TODO: Only human players?
             pUnit.draw_health();

--- a/map/cMapCamera.cpp
+++ b/map/cMapCamera.cpp
@@ -15,8 +15,8 @@ cMapCamera::cMapCamera(cMap * theMap) : pMap(theMap) {
     int widthOfSidebar = cSideBar::SidebarWidth;
     heightOfTopBar = cSideBar::TopBarHeight;
 
-    windowWidth=game.screen_x-widthOfSidebar;
-    windowHeight= game.screen_y - heightOfTopBar;
+    windowWidth= game.m_screenX - widthOfSidebar;
+    windowHeight= game.m_screenY - heightOfTopBar;
 
     viewportWidth=windowWidth;
     viewportHeight=windowHeight;
@@ -199,14 +199,14 @@ void cMapCamera::thinkInteraction() {
 		}
 	}
 
-	if (mouse_x >= (game.screen_x-2) || key[KEY_RIGHT]) {
+	if (mouse_x >= (game.m_screenX - 2) || key[KEY_RIGHT]) {
 		if (getViewportEndX() < ((map.getWidth()*TILESIZE_WIDTH_PIXELS)+halfViewportWidth)) {
             setViewportPosition(viewportStartX += 1, viewportStartY);
             pMouse->setTile(MOUSE_RIGHT);
 		}
 	}
 
-	if (mouse_y >= (game.screen_y-2) || key[KEY_DOWN]) {
+	if (mouse_y >= (game.m_screenY - 2) || key[KEY_DOWN]) {
 		if ((getViewportEndY()) < ((map.getHeight()*TILESIZE_HEIGHT_PIXELS)+halfViewportHeight)) {
             setViewportPosition(viewportStartX, viewportStartY += 1);
             pMouse->setTile(MOUSE_DOWN);

--- a/map/cRandomMapGenerator.cpp
+++ b/map/cRandomMapGenerator.cpp
@@ -94,16 +94,16 @@ void cRandomMapGenerator::generateRandomMap(int startingPoints) {
 
             // blit on screen
             drawProgress(progress);
-            blit(bmp_screen, screen, 0, 0, 0, 0, game.screen_x, game.screen_y);
+            blit(bmp_screen, screen, 0, 0, 0, 0, game.m_screenX, game.m_screenY);
 
         }
 
         // take screenshot
         if (key[KEY_F11]) {
             char filename[25];
-            sprintf(filename, "%dx%d_%d.bmp", game.screen_x, game.screen_y, game.screenshot);
+            sprintf(filename, "%dx%d_%d.bmp", game.m_screenX, game.m_screenY, game.m_screenshot);
             save_bmp(filename, bmp_screen, general_palette);
-            game.screenshot++;
+            game.m_screenshot++;
         }
 
     }
@@ -113,20 +113,20 @@ void cRandomMapGenerator::generateRandomMap(int startingPoints) {
 
     // blit on screen
     drawProgress(progress);
-    blit(bmp_screen, screen, 0, 0, 0, 0, game.screen_x, game.screen_y);
+    blit(bmp_screen, screen, 0, 0, 0, 0, game.m_screenX, game.m_screenY);
 
     mapEditor.removeSingleRockSpots();
 
 
     // blit on screen
     drawProgress(progress);
-    blit(bmp_screen, screen, 0, 0, 0, 0, game.screen_x, game.screen_y);
+    blit(bmp_screen, screen, 0, 0, 0, 0, game.m_screenX, game.m_screenY);
 
     mapEditor.removeSingleRockSpots();
 
     // blit on screen
     drawProgress(progress);
-    blit(bmp_screen, screen, 0, 0, 0, 0, game.screen_x, game.screen_y);
+    blit(bmp_screen, screen, 0, 0, 0, 0, game.m_screenX, game.m_screenY);
 
     while (a_spice > 0) {
         int iCll = map.getRandomCellWithinMapWithSafeDistanceFromBorder(0);
@@ -135,7 +135,7 @@ void cRandomMapGenerator::generateRandomMap(int startingPoints) {
         a_spice--;
         // blit on screen
         drawProgress(progress);
-        blit(bmp_screen, screen, 0, 0, 0, 0, game.screen_x, game.screen_y);
+        blit(bmp_screen, screen, 0, 0, 0, 0, game.m_screenX, game.m_screenY);
     }
 
     while (a_hill > 0) {
@@ -145,7 +145,7 @@ void cRandomMapGenerator::generateRandomMap(int startingPoints) {
         progress += piece;
         // blit on screen
         drawProgress(progress);
-        blit(bmp_screen, screen, 0, 0, 0, 0, game.screen_x, game.screen_y);
+        blit(bmp_screen, screen, 0, 0, 0, 0, game.m_screenX, game.m_screenY);
     }
 
 
@@ -161,7 +161,7 @@ void cRandomMapGenerator::generateRandomMap(int startingPoints) {
     // blit on screen
     progress += 25;
     drawProgress(progress);
-    blit(bmp_screen, screen, 0, 0, 0, 0, game.screen_x, game.screen_y);
+    blit(bmp_screen, screen, 0, 0, 0, 0, game.m_screenX, game.m_screenY);
 
     clear_to_color(randomMapEntry.terrain, makecol(0, 0, 0));
 
@@ -201,7 +201,7 @@ void cRandomMapGenerator::generateRandomMap(int startingPoints) {
 
     // blit on screen
     drawProgress(progress);
-    blit(bmp_screen, screen, 0, 0, 0, 0, game.screen_x, game.screen_y);
+    blit(bmp_screen, screen, 0, 0, 0, 0, game.m_screenX, game.m_screenY);
 }
 
 void cRandomMapGenerator::drawProgress(float progress) const {

--- a/mentat/cAbstractMentat.cpp
+++ b/mentat/cAbstractMentat.cpp
@@ -44,8 +44,8 @@ cAbstractMentat::cAbstractMentat() {
     font = alfont_load_font("data/arrak.ttf");
 
     // offsetX = 0 for screen resolution 640x480, ie, meaning > 640 we take the difference / 2
-    offsetX = (game.screen_x - 640) / 2;
-    offsetY = (game.screen_y - 480) / 2; // same goes for offsetY (but then for 480 height).
+    offsetX = (game.m_screenX - 640) / 2;
+    offsetY = (game.m_screenY - 480) / 2; // same goes for offsetY (but then for 480 height).
 
 	memset(sentence, 0, sizeof(sentence));
 	logbook("cAbstractMentat::cAbstractMentat()");

--- a/mentat/cNoButtonCommand.cpp
+++ b/mentat/cNoButtonCommand.cpp
@@ -5,5 +5,5 @@ void cNoButtonCommand::execute(cAbstractMentat&) {
     // head back to choose house
     players[HUMAN].setHouse(GENERALHOUSE);
     game.setNextStateToTransitionTo(GAME_SELECT_HOUSE);
-    game.START_FADING_OUT();
+    game.initiateFadingOut();
 }

--- a/mentat/cProceedButtonCommand.cpp
+++ b/mentat/cProceedButtonCommand.cpp
@@ -7,21 +7,21 @@ void cProceedButtonCommand::execute(cAbstractMentat &mentat) {
         drawManager->getMessageDrawer()->initCombatPosition();
 
         // CENTER MOUSE
-        game.getMouse()->positionMouseCursor(game.screen_x / 2, game.screen_y / 2);
+        game.getMouse()->positionMouseCursor(game.m_screenX / 2, game.m_screenY / 2);
 
-        game.START_FADING_OUT();
+        game.initiateFadingOut();
 
         playMusicByType(MUSIC_PEACE);
         return;
     }
 
-    if (game.bSkirmish) {
+    if (game.m_skirmish) {
         if (game.isState(GAME_WINBRIEF) || game.isState(GAME_LOSEBRIEF)) {
-            // regardless of winning or losing, always go back to main menu
+            // regardless of drawStateWinning or drawStateLosing, always go back to main menu
             game.setNextStateToTransitionTo(GAME_SETUPSKIRMISH);
-            game.init_skirmish();
+            game.initSkirmish();
             playMusicByType(MUSIC_MENU);
-            game.START_FADING_OUT();
+            game.initiateFadingOut();
         } else {
             logbook("cProceedButtonCommand pressed, in skirmish mode and state is not WINBRIEF nor LOSEBRIEF!?");
         }
@@ -37,18 +37,18 @@ void cProceedButtonCommand::execute(cAbstractMentat &mentat) {
         // PLAY THE MUSIC
         playMusicByType(MUSIC_CONQUEST);
 
-        game.START_FADING_OUT();
+        game.initiateFadingOut();
         return;
     }
 
     // lost mission
     if (game.isState(GAME_LOSEBRIEF)) {
-        game.mission_init();
+        game.missionInit();
         // lost mission > 1, so we go back to region select
-        if (game.iMission > 1)   {
+        if (game.m_mission > 1)   {
             game.setNextStateToTransitionTo(GAME_REGION);
 
-            game.iMission--; // we did not win
+            game.m_mission--; // we did not win
 
             // PLAY THE MUSIC
             playMusicByType(MUSIC_CONQUEST);
@@ -60,7 +60,7 @@ void cProceedButtonCommand::execute(cAbstractMentat &mentat) {
             mentat.resetSpeak();
         }
 
-        game.START_FADING_OUT();
+        game.initiateFadingOut();
         return;
     }
 }

--- a/mentat/cYesButtonCommand.cpp
+++ b/mentat/cYesButtonCommand.cpp
@@ -3,12 +3,12 @@
 void cYesButtonCommand::execute(cAbstractMentat& mentat) {
     logbook("cYesButtonCommand::execute()");
     game.setNextStateToTransitionTo(GAME_BRIEFING);
-    game.iMission = 1; // first mission
-    game.iRegion  = 1; // and the first "region" so to speak
-    game.mission_init();
+    game.m_mission = 1; // first mission
+    game.m_region  = 1; // and the first "region" so to speak
+    game.missionInit();
 
     players[HUMAN].setHouse(mentat.getHouse());
 
-    game.START_FADING_OUT();
+    game.initiateFadingOut();
 }
 

--- a/player/brains/cPlayerBrainCampaign.cpp
+++ b/player/brains/cPlayerBrainCampaign.cpp
@@ -13,7 +13,7 @@ namespace brains {
         // timer is substracted every 100 ms with 1 (ie, 10 == 10*100 = 1000ms == 1 second)
         // 10*60 -> 1 minute. * 4 -> 4 minutes
         TIMER_rest = (10 * 60) * 4;
-        if (game.bNoAiRest) {
+        if (game.m_noAiRest) {
             TIMER_rest = 10;
         }
         myBase = std::vector<S_structurePosition>();
@@ -310,42 +310,42 @@ namespace brains {
             }
         }
 
-        if (game.iMission == 2) {
+        if (game.m_mission == 2) {
             produceLevel2Missions(soldierKind, infantryKind);
             return;
         }
 
-        if (game.iMission == 3) {
+        if (game.m_mission == 3) {
             produceLevel3Missions(trikeKind, soldierKind, infantryKind);
             return;
         }
 
-        if (game.iMission == 4) {
+        if (game.m_mission == 4) {
             produceLevel4Missions(trikeKind, infantryKind);
             return;
         }
 
-        if (game.iMission == 5) {
+        if (game.m_mission == 5) {
             produceLevel5Missions(trikeKind, infantryKind);
             return;
         }
 
-        if (game.iMission == 6) {
+        if (game.m_mission == 6) {
             produceLevel6Missions(trikeKind, infantryKind);
             return;
         }
 
-        if (game.iMission == 7) {
+        if (game.m_mission == 7) {
             produceLevel7Missions(trikeKind, infantryKind);
             return;
         }
 
-        if (game.iMission == 8) {
+        if (game.m_mission == 8) {
             produceLevel8Missions(trikeKind, infantryKind);
             return;
         }
 
-        if (game.iMission == 9) {
+        if (game.m_mission == 9) {
             produceLevel9Missions(trikeKind, infantryKind);
             return;
         }

--- a/player/brains/cPlayerBrainSkirmish.cpp
+++ b/player/brains/cPlayerBrainSkirmish.cpp
@@ -14,7 +14,7 @@ namespace brains {
 //         10*60 -> 1 minute. * 4 -> 4 minutes
 //        TIMER_rest = (10 * 60) * 4;
         TIMER_rest = rnd(25); // todo: based on difficulty?
-        if (game.bNoAiRest) {
+        if (game.m_noAiRest) {
             TIMER_rest = 10;
         }
         TIMER_produceMissionCooldown = 0;

--- a/player/cPlayer.cpp
+++ b/player/cPlayer.cpp
@@ -342,7 +342,7 @@ bool cPlayer::bEnoughSpiceCapacityToStoreCredits(int threshold) const {
 }
 
 bool cPlayer::bEnoughPower() const {
-    if (!game.bSkirmish) {
+    if (!game.m_skirmish) {
         // AI cheats on power
         if (!m_Human) {
             // Dune 2 non-skirmish AI cheats; else it will be unplayable in some missions.
@@ -1281,7 +1281,7 @@ int cPlayer::findRandomUnitTarget(int playerIndexToAttack) {
         }
 
         // HACK HACK: the AI player does not need to discover an enemy player yet
-        if (isVisibleForPlayer || game.bSkirmish) {
+        if (isVisibleForPlayer || game.m_skirmish) {
             iTargets[maxTargets] = i;
             maxTargets++;
 
@@ -1308,7 +1308,7 @@ int cPlayer::findRandomStructureTarget(int iAttackPlayer) {
         if (structure[i])
             if (structure[i]->getOwner() == iAttackPlayer)
                 if (map.isVisible(structure[i]->getCell(), this) ||
-                    game.bSkirmish) {
+                    game.m_skirmish) {
                     iTargets[iT] = i;
 
                     iT++;
@@ -1722,7 +1722,7 @@ void cPlayer::onEntityDiscovered(const s_GameEvent &event) {
 //        // do nothing
 //        return;
 //    }
-    if (game.iMusicType != MUSIC_PEACE) {
+    if (game.m_musicType != MUSIC_PEACE) {
         // nothing to do here music-wise
         return;
     }

--- a/sidebar/cBuildingListFactory.cpp
+++ b/sidebar/cBuildingListFactory.cpp
@@ -33,7 +33,7 @@ int cBuildingListFactory::getButtonDrawY() {
 }
 
 int cBuildingListFactory::getButtonDrawXStart() {
-	return (game.screen_x - 200) + 2;
+	return (game.m_screenX - 200) + 2;
 }
 
 

--- a/sidebar/cBuildingListUpdater.cpp
+++ b/sidebar/cBuildingListUpdater.cpp
@@ -18,7 +18,7 @@ void cBuildingListUpdater::onStructureCreated(int structureType) {
     } else {
         // AI players...
 
-        if (game.bSkirmish) {
+        if (game.m_skirmish) {
             // on skirmish mode use the 'strict' / no cheating mode (same as human players)
             onStructureCreatedSkirmishMode(structureType);
             evaluateUpgrades();
@@ -430,7 +430,7 @@ void cBuildingListUpdater::onStructureDestroyed(int structureType) {
     } else {
         // AI players...
 
-        if (game.bSkirmish) {
+        if (game.m_skirmish) {
             // on skirmish mode use the 'strict' / no cheating mode (same as human players)
             onStructureDestroyedSkirmishMode();
             evaluateUpgrades();

--- a/sidebar/cSideBar.cpp
+++ b/sidebar/cSideBar.cpp
@@ -113,7 +113,7 @@ void cSideBar::thinkProgressAnimation() {
 }
 
 void cSideBar::onMouseAt(const s_MouseEvent &event) {
-    isMouseOverSidebarValue = event.coords.x > (game.screen_x - cSideBar::SidebarWidth);
+    isMouseOverSidebarValue = event.coords.x > (game.m_screenX - cSideBar::SidebarWidth);
     drawManager->getMessageDrawer()->setKeepMessage(isMouseOverSidebarValue);
 
     if (selectedListID < 0) return;

--- a/utils/cBestScreenResolutionFinder.cpp
+++ b/utils/cBestScreenResolutionFinder.cpp
@@ -130,17 +130,17 @@ bool cBestScreenResolutionFinder::acquireBestScreenResolutionFullScreen() {
         if (screenResolution) {
             if (screenResolution->isTested()) {
                 if (screenResolution->isUsable()) {
-                    game.screen_x = screenResolution->getWidth();
-                    game.screen_y = screenResolution->getHeight();
+                    game.m_screenX = screenResolution->getWidth();
+                    game.m_screenY = screenResolution->getHeight();
 
                     int r;
 #ifdef UNIX
-                    r = set_gfx_mode(GFX_AUTODETECT, game.screen_x, game.screen_y, game.screen_x, game.screen_y);
+                    r = set_gfx_mode(GFX_AUTODETECT, game.m_screenX, game.m_screenY, game.m_screenX, game.m_screenY);
 #else
-                    r = set_gfx_mode(GFX_DIRECTX_ACCEL, game.screen_x, game.screen_y, game.screen_x, game.screen_y);
+                    r = set_gfx_mode(GFX_DIRECTX_ACCEL, game.m_screenX, game.m_screenY, game.m_screenX, game.m_screenY);
 #endif
                     char msg[255];
-                    sprintf(msg, "setting up full screen mode with resolution %dx%d, result code: %d", game.screen_x, game.screen_y, r);
+                    sprintf(msg, "setting up full screen mode with resolution %dx%d, result code: %d", game.m_screenX, game.m_screenY, r);
                     logbook(msg);
                     return (r == 0); // return true only if r==0
                 }

--- a/utils/cStructureUtils.cpp
+++ b/utils/cStructureUtils.cpp
@@ -229,8 +229,8 @@ bool cStructureUtils::isStructureVisibleOnScreen(cAbstractStructure *structure) 
 	int width = mapCamera->factorZoomLevel(structure->getWidthInPixels());
 	int height = mapCamera->factorZoomLevel(structure->getHeightInPixels());
 
-	return (drawX + width  >= 0 && drawX < game.screen_x) &&
-	       (drawY + height >= 0 && drawY < game.screen_y);
+	return (drawX + width  >= 0 && drawX < game.m_screenX) &&
+           (drawY + height >= 0 && drawY < game.m_screenY);
 }
 
 bool cStructureUtils::isMouseOverStructure(cAbstractStructure *structure, int screenX, int screenY) {
@@ -308,7 +308,7 @@ int cStructureUtils::getTotalPowerOutForPlayer(cPlayer * pPlayer) {
         }
 	}
 
-	if (!game.bSkirmish) {
+	if (!game.m_skirmish) {
 	    // ?? (mission 9 etc AI has no power)
 	}
 	return totalPowerOut;

--- a/utils/cTimeManager.cpp
+++ b/utils/cTimeManager.cpp
@@ -64,9 +64,9 @@ void cTimeManager::handleTimerAllegroTimerSeconds() {
         gameTime++;
 
         if (game.isState(GAME_PLAYING)) {
-            game.paths_created = 0;
+            game.m_pathsCreated = 0;
 
-            if (!game.bDisableReinforcements) {
+            if (!game.m_disableReinforcements) {
                 THINK_REINFORCEMENTS();
             }
 
@@ -95,13 +95,12 @@ void cTimeManager::handleTimerAllegroTimerSeconds() {
         // Frame Per Second counter
         game.setFps();
 
-        // 'auto resting'
+        // 'auto resting' / giving CPU some time for other processes
         if (game.isRunningAtIdealFps()) {
+            iRest += 1; // give CPU a bit more slack
+        } else {
             if (iRest > 0) iRest -= 1;
             if (iRest < 0) iRest = 0;
-        } else {
-            if (iRest < 500) iRest += 1;
-            if (iRest > 500) iRest = 500;
         }
 
         game.resetFrameCount();

--- a/utils/common.cpp
+++ b/utils/common.cpp
@@ -1676,7 +1676,7 @@ int distanceBetweenCellAndCenterOfScreen(int iCell) {
  * @param iDistance
  */
 void play_sound_id_with_distance(int s, int iDistance) {
-	if (!game.bPlaySound) return; // do not play sound when boolean is false.
+	if (!game.m_playSound) return; // do not play sound when boolean is false.
 
 	if (iDistance <= 1) { // means "on screen" (meaning fixed volume, and no need for panning)
         game.playSound(s);
@@ -1719,7 +1719,7 @@ bool MIDI_music_playing() {
 }
 
 void setMusicVolume(int i) {
-    if (game.bMp3) {
+    if (game.m_mp3) {
         if (mp3_music != nullptr) {
         	almp3_adjust_mp3(mp3_music, i, 127, 1000, false);
         }
@@ -1740,7 +1740,7 @@ void mp3_play_file(char filename[VOLUME_MAX]) {
 	} else {
 		logbook("MP3: Could not find mp3 file for add-on, switching to MIDI mode");
 		allegro_message("Could not find MP3 file, add-on incomplete. Switching to MIDI mode");
-		game.bMp3=false;
+		game.m_mp3=false;
 
 		if (mp3_music != nullptr) {
 		   almp3_destroy_mp3(mp3_music);
@@ -1758,14 +1758,14 @@ void mp3_play_file(char filename[VOLUME_MAX]) {
 	int result = almp3_play_mp3(mp3_music, BUFFER_SIZE, VOLUME_MAX, PAN_CENTER);
 	assert(result == ALMP3_OK);
 
-	setMusicVolume(game.iMusicVolume);
+	setMusicVolume(game.m_musicVolume);
 }
 
 // play type of music
 void playMusicByType(int iType) {
-    game.iMusicType = iType;
+    game.m_musicType = iType;
 
-    if (!game.bPlayMusic) return;
+    if (!game.m_playMusic) return;
 
     int iNumber=0;
 
@@ -1787,7 +1787,7 @@ void playMusicByType(int iType) {
     }
 
     // In the end, when mp3, play it:
-    if (game.bMp3) {
+    if (game.m_mp3) {
         char filename[50];
         memset(filename, 0, sizeof(filename));
 
@@ -1955,8 +1955,8 @@ void Shimmer(int r, int x, int y) {
 
             if (x1 < 0) x1 = 0;
             if (y1 < 0) y1 = 0;
-            if (x1 >= game.screen_x) x1 = game.screen_x - 1;
-            if (y1 >= game.screen_y) y1 = game.screen_y - 1;
+            if (x1 >= game.m_screenX) x1 = game.m_screenX - 1;
+            if (y1 >= game.m_screenY) y1 = game.m_screenY - 1;
 
             gp = getpixel(bmp_screen, x1, y1); // use this inline function to speed up things.
             // Now choose random spot to 'switch' with.
@@ -1965,8 +1965,8 @@ void Shimmer(int r, int x, int y) {
 
             if (nx < 0) nx = 0;
             if (ny < 0) ny = 0;
-            if (nx >= game.screen_x) nx = game.screen_x - 1;
-            if (ny >= game.screen_y) ny = game.screen_y - 1;
+            if (nx >= game.m_screenX) nx = game.m_screenX - 1;
+            if (ny >= game.m_screenY) ny = game.m_screenY - 1;
 
             tc = getpixel(bmp_screen, nx, ny);
 


### PR DESCRIPTION
This PR makes sure all member fields in `cGame` use the `m_<camelCaseVariableName>` consistently.

I also went over some functions and grouped them if it made sense, or renamed them where applicable. Making sure all functions are also using the `camelCase()` convention. There are only a few exceptions for now with `state_` or `think[fast/slow]_` prefixes.