### PR TITLE
AI: Respond to base under attack & enemy detected (by turrets)

### DIFF
--- a/gameobjects/projectiles/bullet.cpp
+++ b/gameobjects/projectiles/bullet.cpp
@@ -597,7 +597,7 @@ void cBullet::damageStructure(int idOfStructureAtCell, double factor) {
         return; // invalid pointer!
     }
 
-    pStructure->damage(iDamage);
+    pStructure->damage(iDamage, iOwnerUnit);
 
     if (pStructure->isDead()) {
         if (pUnit) {

--- a/gameobjects/structures/cAbstractStructure.cpp
+++ b/gameobjects/structures/cAbstractStructure.cpp
@@ -13,11 +13,13 @@
 #include "../../include/d2tmh.h"
 #include "cAbstractStructure.h"
 
+#include <fmt/core.h>
+
 #include "utils/cSoundPlayer.h"
 
 // "default" Constructor
-cAbstractStructure::cAbstractStructure() {
-    flags = std::vector<cFlag *>();
+cAbstractStructure::cAbstractStructure() :
+    flags(std::vector<cFlag *>()) {
     frames = 1;
     iHitPoints=-1;      // default = no hitpoints
     iCell=-1;
@@ -62,18 +64,14 @@ cAbstractStructure::cAbstractStructure() {
     dead = false;
 
     if (DEBUGGING) {
-        char msg[255];
-        sprintf(msg, "(cAbstractStructure)(ID %d) Constructor", this->id);
-        logbook(msg);
+        logbook(fmt::format("(cAbstractStructure)(ID {}) Constructor", this->id));
     }
 }
 
 cAbstractStructure::~cAbstractStructure() {
     // destructor
     if (DEBUGGING) {
-        char msg[255];
-        sprintf(msg, "(~cAbstractStructure)(ID %d) Destructor", this->id);
-        logbook(msg);
+        logbook(fmt::format("(cAbstractStructure)(ID {}) Destructor", this->id));
     }
     iHitPoints = -1;
     iCell = -1;
@@ -451,9 +449,7 @@ void cAbstractStructure::damage(int hp) {
 	}
 
 	iHitPoints -= damage; // do damage
-    char msg[255];
-    sprintf(msg, "cAbstractStructure::damage() - Structure [%d] received [%d] damage, HP is now [%d]", id, damage, iHitPoints);
-    logbook(msg);
+    logbook(fmt::format("cAbstractStructure::damage() - Structure [{}] received [{}] damage, HP is now [{}]", id, damage, iHitPoints));
 
     if (iHitPoints < 1) {
         // TODO: update statistics? (structure lost)
@@ -488,9 +484,7 @@ void cAbstractStructure::setHitPoints(int hp) {
 	int maxHp = sStructureInfo[getType()].hp;
 
 	if (iHitPoints > maxHp) {
-		char msg[256];
-		sprintf(msg, "setHitpoints(%d) while max is %d; capped at max.", hp, maxHp);
-		logbook(msg);
+		logbook(fmt::format("setHitpoints({}) while max is {}; capped at max.", hp, maxHp));
 
 		// will fail (uncomment to let it be capped)
 		assert(iHitPoints <= maxHp); // may never be more than the maximum of that structure

--- a/gameobjects/structures/cAbstractStructure.cpp
+++ b/gameobjects/structures/cAbstractStructure.cpp
@@ -440,8 +440,10 @@ void cAbstractStructure::decay(int hp) {
 
 	When the hitpoints drop below 1, the structure will die / cause destroyed animation and set 'dead' flag
     so that the structure can be cleaned up from memory.
+
+    @param originId = ID of unit who damaged me. It can be < 0 meaning unknown unit (or not applicable)
 **/
-void cAbstractStructure::damage(int hp, int unitIdWhoDamagedMe) {
+void cAbstractStructure::damage(int hp, int originId) {
 	int damage = hp;
 	if (damage < 0) {
 		logbook("cAbstractStructure::damage() got negative parameter, wrapped");
@@ -449,7 +451,7 @@ void cAbstractStructure::damage(int hp, int unitIdWhoDamagedMe) {
 	}
 
 	iHitPoints -= damage; // do damage
-    logbook(fmt::format("cAbstractStructure::damage() - Structure [{}] received [{}] damage, HP is now [{}]", id, damage, iHitPoints));
+    logbook(fmt::format("cAbstractStructure::damage() - Structure [{}] received [{}] damage from originId [{}], HP is now [{}]", id, damage, originId, iHitPoints));
 
     if (iHitPoints < 1) {
         // TODO: update statistics? (structure lost)
@@ -470,7 +472,7 @@ void cAbstractStructure::damage(int hp, int unitIdWhoDamagedMe) {
                 .entityID = getStructureId(),
                 .player = getPlayer(),
                 .entitySpecificType = getType(),
-                .originId = unitIdWhoDamagedMe
+                .originId = originId
         };
 
         game.onNotifyGameEvent(event);

--- a/gameobjects/structures/cAbstractStructure.cpp
+++ b/gameobjects/structures/cAbstractStructure.cpp
@@ -441,7 +441,7 @@ void cAbstractStructure::decay(int hp) {
 	When the hitpoints drop below 1, the structure will die / cause destroyed animation and set 'dead' flag
     so that the structure can be cleaned up from memory.
 **/
-void cAbstractStructure::damage(int hp) {
+void cAbstractStructure::damage(int hp, int unitIdWhoDamagedMe) {
 	int damage = hp;
 	if (damage < 0) {
 		logbook("cAbstractStructure::damage() got negative parameter, wrapped");
@@ -469,7 +469,8 @@ void cAbstractStructure::damage(int hp) {
                 .entityType = eBuildType::STRUCTURE,
                 .entityID = getStructureId(),
                 .player = getPlayer(),
-                .entitySpecificType = getType()
+                .entitySpecificType = getType(),
+                .originId = unitIdWhoDamagedMe
         };
 
         game.onNotifyGameEvent(event);

--- a/gameobjects/structures/cAbstractStructure.h
+++ b/gameobjects/structures/cAbstractStructure.h
@@ -214,7 +214,7 @@ class cAbstractStructure {
 		void setBuildingFase(int value) { iBuildFase = value; }
 		void setRepairing(bool value);
 
-		void damage(int hp);
+		void damage(int hp, int unitIdWhoDamagedMe);
 		void decay(int hp);
     	float getHealthNormalized();
 

--- a/gameobjects/structures/cAbstractStructure.h
+++ b/gameobjects/structures/cAbstractStructure.h
@@ -214,7 +214,7 @@ class cAbstractStructure {
 		void setBuildingFase(int value) { iBuildFase = value; }
 		void setRepairing(bool value);
 
-		void damage(int hp, int unitIdWhoDamagedMe);
+		void damage(int hp, int originId);
 		void decay(int hp);
     	float getHealthNormalized();
 

--- a/gameobjects/units/cUnit.cpp
+++ b/gameobjects/units/cUnit.cpp
@@ -351,7 +351,7 @@ void cUnit::createExplosionParticle() {
                     if (pStructure->getHitPoints() > 0) {
 
                         int iDamage = 150 + rnd(100);
-                        pStructure->damage(iDamage);
+                        pStructure->damage(iDamage, -1); // no need to pass unit ID, as it is dead anyway
 
                         int iChance = 10;
 
@@ -2583,7 +2583,7 @@ void cUnit::thinkFast_move() {
                     } else if (intent == eUnitActionIntent::INTENT_CAPTURE || intent == eUnitActionIntent::INTENT_MOVE) {
                         if (isSaboteur()) {
                             // the unit will die and inflict damage
-                            pStructure->damage(getUnitInfo().damageOnEnterStructure);
+                            pStructure->damage(getUnitInfo().damageOnEnterStructure, -1); // no need to pass ID of unit, as it is dead
                             die(true, false);
                         } else {
                             if (pStructure->getHitPoints() < pStructure->getCaptureHP()) {
@@ -2593,7 +2593,7 @@ void cUnit::thinkFast_move() {
                             } else {
                                 // the unit will die and inflict damage
                                 die(true, false);
-                                pStructure->damage(getUnitInfo().damageOnEnterStructure);
+                                pStructure->damage(getUnitInfo().damageOnEnterStructure, -1); // no need to pass ID of unit, as it is dead
                             }
                         }
                         return; // unit is dead, no need to go further

--- a/include/sGameEvent.h
+++ b/include/sGameEvent.h
@@ -35,6 +35,7 @@ struct s_GameEvent {
     bool isReinforce = false;       // only applicable for UNIT and CREATED events. So we can distinguish between 'normal' CREATED units and reinforced units.
     cBuildingListItem *buildingListItem = nullptr; // if buildingListItem is ready (special, or not)
     cBuildingList *buildingList = nullptr; // in case buildingList is available (or not)
+    int originId = -1; // in case damaged event, this is the UNIT id that damaged it
 
     // TODO: figure out a way to have bags of data depending on type of event without the need of expanding this generic GAME_EVENT struct
 

--- a/include/sGameEvent.h
+++ b/include/sGameEvent.h
@@ -1,10 +1,11 @@
-#ifndef D2TM_SGAMEEVENT_H
-#define D2TM_SGAMEEVENT_H
+#pragma once
 
 #include <string>
 #include "enums.h"
-#include <assert.h>
+#include <cassert>
 #include <utils/common.h>
+
+#include <fmt/core.h>
 
 class cPlayer;
 class cBuildingListItem;
@@ -71,19 +72,16 @@ struct s_GameEvent {
     }
 
     static const std::string toString(const s_GameEvent &event) {
-        char msg[255];
-        sprintf(msg, "cGameEvent [type=%s], [entityType=%s], [entityId=%d], [entitySpecificType=%d =%s], [isReinforce=%s], [atCell=%d], [buildingListItem=%s]",
-                toString(event.eventType),
-                eBuildTypeString(event.entityType),
-                event.entityID,
-                event.entitySpecificType,
-                toStringBuildTypeSpecificType(event.entityType, event.entitySpecificType),
-                event.isReinforce ? "true" : "false",
-                event.atCell,
-                event.buildingListItem ? "present" : "nullptr"
-                );
-        return std::string(msg);
+        return fmt::format("cGameEvent [type={}], [entityType={}], [entityId={}], [entitySpecificType={} ={}], [isReinforce={}], [atCell={}], [buildingListItem={}] [originId={}]",
+                           toString(event.eventType),
+                           eBuildTypeString(event.entityType),
+                           event.entityID,
+                           event.entitySpecificType,
+                           toStringBuildTypeSpecificType(event.entityType, event.entitySpecificType),
+                           event.isReinforce ? "true" : "false",
+                           event.atCell,
+                           event.buildingListItem ? "present" : "nullptr",
+                           event.originId
+        );
     }
 };
-
-#endif //D2TM_SGAMEEVENT_H

--- a/player/brains/cPlayerBrain.h
+++ b/player/brains/cPlayerBrain.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAIN_H
-#define D2TM_CPLAYERBRAIN_H
+#pragma once
 
 #include <observers/cScenarioObserver.h>
 #include "cPlayerBrainData.h"
@@ -39,5 +38,3 @@ namespace brains {
 
     };
 }
-
-#endif //D2TM_CPLAYERBRAIN_H

--- a/player/brains/cPlayerBrain.h
+++ b/player/brains/cPlayerBrain.h
@@ -6,6 +6,12 @@
 class cPlayer;
 class cAbstractStructure;
 
+namespace {
+
+    constexpr int kScanRadius = 20; // hard-coded for now, make player property later?
+
+}
+
 namespace brains {
 
     class cPlayerBrain : public cScenarioObserver {

--- a/player/brains/cPlayerBrainCampaign.cpp
+++ b/player/brains/cPlayerBrainCampaign.cpp
@@ -1640,7 +1640,7 @@ namespace brains {
                             m_TIMER_rest = 0; // if we where still 'resting' then stop this now.
                             m_discoveredEnemyAtCell.insert(event.atCell);
 
-                            if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < 20) {
+                            if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
                                 respondToThreat(event.atCell, pUnit.isAirbornUnit());
                             }
                         }
@@ -1692,7 +1692,7 @@ namespace brains {
                     if (event.entityType == eBuildType::UNIT) {
                         cUnit &pUnit = unit[event.entityID];
                         if (pUnit.isValid() && !pUnit.getPlayer()->isSameTeamAs(player)) {
-                            if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < 20) {
+                            if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
                                 respondToThreat(event.atCell, pUnit.isAirbornUnit());
                             }
                         }

--- a/player/brains/cPlayerBrainCampaign.cpp
+++ b/player/brains/cPlayerBrainCampaign.cpp
@@ -3,6 +3,8 @@
 #include "cPlayerBrainCampaign.h"
 #include "enums.h"
 
+#include <fmt/core.h>
+
 #include <algorithm>
 
 namespace brains {

--- a/player/brains/cPlayerBrainCampaign.cpp
+++ b/player/brains/cPlayerBrainCampaign.cpp
@@ -219,7 +219,7 @@ namespace brains {
             int cell = originUnit.getCell();
             bool attackerIsAirUnit = originUnit.isAirbornUnit();
 
-            respondToThreat(cell, attackerIsAirUnit);
+            respondToThreat(cell, attackerIsAirUnit, 2 + rnd(4));
         }
     }
 
@@ -1641,7 +1641,7 @@ namespace brains {
                             m_discoveredEnemyAtCell.insert(event.atCell);
 
                             if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
-                                respondToThreat(event.atCell, pUnit.isAirbornUnit());
+                                respondToThreat(event.atCell, pUnit.isAirbornUnit(), 2 + rnd(4));
                             }
                         }
                     } else if (event.entityType == eBuildType::STRUCTURE) {
@@ -1693,7 +1693,7 @@ namespace brains {
                         cUnit &pUnit = unit[event.entityID];
                         if (pUnit.isValid() && !pUnit.getPlayer()->isSameTeamAs(player)) {
                             if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
-                                respondToThreat(event.atCell, pUnit.isAirbornUnit());
+                                respondToThreat(event.atCell, pUnit.isAirbornUnit(), 2 + rnd(4));
                             }
                         }
                     }
@@ -1716,9 +1716,8 @@ namespace brains {
                 txt)
         );
     }
-    void cPlayerBrainCampaign::respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit) {
+    void cPlayerBrainCampaign::respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit, int maxUnitsToOrder) {
         const std::vector<s_UnitForDistance> &units = player->getAllMyUnitsOrderClosestToCell(cellOriginOfThreat);
-        int maxUnitsToOrder = 2 + rnd(4);
 
         if (attackerIsAirUnit) {
             int unitsOrdered = 0;

--- a/player/brains/cPlayerBrainCampaign.h
+++ b/player/brains/cPlayerBrainCampaign.h
@@ -46,6 +46,8 @@ namespace brains {
         std::vector<S_structurePosition> m_myBase;
         std::vector<S_buildOrder> m_buildOrders;
 
+        int m_centerOfBaseCell;
+
         void onMyStructureDestroyed(const s_GameEvent &event);
 
         void onMyStructureCreated(const s_GameEvent &event);

--- a/player/brains/cPlayerBrainCampaign.h
+++ b/player/brains/cPlayerBrainCampaign.h
@@ -30,6 +30,8 @@ namespace brains {
 
         void addBuildOrder(S_buildOrder order) override;
 
+        void log(const std::string & txt);
+
     private:
         ePlayerBrainState m_state;
 
@@ -119,6 +121,7 @@ namespace brains {
 
         void produceLevel9Missions(int trikeKind, int infantryKind);
 
+        void respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit);
     };
 
 }

--- a/player/brains/cPlayerBrainCampaign.h
+++ b/player/brains/cPlayerBrainCampaign.h
@@ -18,7 +18,7 @@ namespace brains {
     const int SPECIAL_MISSION3 = 52;
 
     public:
-        cPlayerBrainCampaign(cPlayer *player);
+        explicit cPlayerBrainCampaign(cPlayer *player);
 
         ~cPlayerBrainCampaign();
 

--- a/player/brains/cPlayerBrainCampaign.h
+++ b/player/brains/cPlayerBrainCampaign.h
@@ -31,18 +31,18 @@ namespace brains {
         void addBuildOrder(S_buildOrder order) override;
 
     private:
-        ePlayerBrainState state;
+        ePlayerBrainState m_state;
 
-        ePlayerBrainCampaignThinkState thinkState;
+        ePlayerBrainCampaignThinkState m_thinkState;
 
-        int TIMER_rest;
+        int m_TIMER_rest;
 
         // at which cells did we detect an enemy? Remember those.
-        std::set<int> discoveredEnemyAtCell;
+        std::set<int> m_discoveredEnemyAtCell;
 
-        std::vector<cPlayerBrainMission> missions;
-        std::vector<S_structurePosition> myBase;
-        std::vector<S_buildOrder> buildOrders;
+        std::vector<cPlayerBrainMission> m_missions;
+        std::vector<S_structurePosition> m_myBase;
+        std::vector<S_buildOrder> m_buildOrders;
 
         void onMyStructureDestroyed(const s_GameEvent &event);
 

--- a/player/brains/cPlayerBrainCampaign.h
+++ b/player/brains/cPlayerBrainCampaign.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAINCAMPAIGN_H
-#define D2TM_CPLAYERBRAINCAMPAIGN_H
+#pragma once
 
 #include "player/brains/cPlayerBrain.h"
 #include "player/brains/cPlayerBrainData.h"
@@ -123,5 +122,3 @@ namespace brains {
     };
 
 }
-
-#endif //D2TM_CPLAYERBRAINCAMPAIGN_H

--- a/player/brains/cPlayerBrainCampaign.h
+++ b/player/brains/cPlayerBrainCampaign.h
@@ -123,7 +123,7 @@ namespace brains {
 
         void produceLevel9Missions(int trikeKind, int infantryKind);
 
-        void respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit);
+        void respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit, int maxUnitsToOrder);
     };
 
 }

--- a/player/brains/cPlayerBrainData.h
+++ b/player/brains/cPlayerBrainData.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAINDATA_H
-#define D2TM_CPLAYERBRAINDATA_H
+#pragma once
 
 namespace brains {
 
@@ -127,5 +126,3 @@ namespace brains {
     };
 
 }
-
-#endif //D2TM_CPLAYERBRAINDATA_H

--- a/player/brains/cPlayerBrainEmpty.h
+++ b/player/brains/cPlayerBrainEmpty.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAINEMPTY_H
-#define D2TM_CPLAYERBRAINEMPTY_H
+#pragma once
 
 #include "cPlayerBrain.h"
 
@@ -23,5 +22,3 @@ namespace brains {
     };
 
 }
-
-#endif //D2TM_CPLAYERBRAINEMPTY_H

--- a/player/brains/cPlayerBrainEmpty.h
+++ b/player/brains/cPlayerBrainEmpty.h
@@ -7,7 +7,7 @@ namespace brains {
     class cPlayerBrainEmpty : public brains::cPlayerBrain {
 
     public:
-        cPlayerBrainEmpty(cPlayer *player);
+        explicit cPlayerBrainEmpty(cPlayer *player);
 
         ~cPlayerBrainEmpty();
 

--- a/player/brains/cPlayerBrainSandworm.h
+++ b/player/brains/cPlayerBrainSandworm.h
@@ -7,7 +7,7 @@ namespace brains {
     class cPlayerBrainSandworm : public cPlayerBrain {
 
     public:
-        cPlayerBrainSandworm(cPlayer * player);
+        explicit cPlayerBrainSandworm(cPlayer * player);
         ~cPlayerBrainSandworm();
 
         void think() override;

--- a/player/brains/cPlayerBrainSandworm.h
+++ b/player/brains/cPlayerBrainSandworm.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAINSANDWORM_H
-#define D2TM_CPLAYERBRAINSANDWORM_H
+#pragma once
 
 #include "cPlayerBrain.h"
 
@@ -24,4 +23,3 @@ namespace brains {
     };
 
 }
-#endif //D2TM_CPLAYERBRAINSANDWORM_H

--- a/player/brains/cPlayerBrainSkirmish.cpp
+++ b/player/brains/cPlayerBrainSkirmish.cpp
@@ -90,9 +90,9 @@ namespace brains {
 
         log("addBuildOrder() - results into the following build orders:");
 
-        std::string msg;
         int id = 0;
         for (auto &buildOrder : m_buildOrders) {
+            std::string msg;
             if (buildOrder.buildType == eBuildType::UNIT) {
                 msg = fmt::format("[{}] - type = UNIT, buildId = {} (={}), priority = {}, state = {}", id, buildOrder.buildId,
                         sUnitInfo[buildOrder.buildId].name, buildOrder.priority, eBuildOrderStateString(buildOrder.state));

--- a/player/brains/cPlayerBrainSkirmish.cpp
+++ b/player/brains/cPlayerBrainSkirmish.cpp
@@ -1152,7 +1152,7 @@ namespace brains {
                             m_TIMER_rest = 0; // if we were still 'resting' then stop this now.
                             m_discoveredEnemyAtCell.insert(event.atCell);
 
-                            if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < 20) {
+                            if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
                                 respondToThreat(event.atCell, pUnit.isAirbornUnit());
                             }
                         }
@@ -1207,7 +1207,7 @@ namespace brains {
                     if (event.entityType == eBuildType::UNIT) {
                         cUnit &pUnit = unit[event.entityID];
                         if (pUnit.isValid() && !pUnit.getPlayer()->isSameTeamAs(player)) {
-                            if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < 20) {
+                            if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
                                 respondToThreat(event.atCell, pUnit.isAirbornUnit());
                             }
                         }

--- a/player/brains/cPlayerBrainSkirmish.cpp
+++ b/player/brains/cPlayerBrainSkirmish.cpp
@@ -62,12 +62,7 @@ namespace brains {
                 return;
         }
 
-        // now do some real stuff
-
-        char msg[255];
-        memset(msg, 0, sizeof(msg));
-        sprintf(msg, "think() - FINISHED");
-        log(msg);
+        log("think() - FINISHED");
     }
 
     void cPlayerBrainSkirmish::addBuildOrder(S_buildOrder order) {
@@ -93,25 +88,23 @@ namespace brains {
             return lhs.priority > rhs.priority;
         });
 
-        char msg[255];
-        sprintf(msg, "addBuildOrder() - results into the following build orders:");
-        log(msg);
+        log("addBuildOrder() - results into the following build orders:");
 
+        std::string msg;
         int id = 0;
         for (auto &buildOrder : m_buildOrders) {
-            memset(msg, 0, sizeof(msg));
             if (buildOrder.buildType == eBuildType::UNIT) {
-                sprintf(msg, "[%d] - type = UNIT, buildId = %d (=%s), priority = %d, state = %s", id, buildOrder.buildId,
+                msg = fmt::format("[{}] - type = UNIT, buildId = {} (={}), priority = {}, state = {}", id, buildOrder.buildId,
                         sUnitInfo[buildOrder.buildId].name, buildOrder.priority, eBuildOrderStateString(buildOrder.state));
             } else if (buildOrder.buildType == eBuildType::STRUCTURE) {
-                sprintf(msg, "[%d] - type = STRUCTURE, buildId = %d (=%s), priority = %d, place at %d, state = %s", id,
+                msg = fmt::format("[{}] - type = STRUCTURE, buildId = {} (={}), priority = {}, place at {}, state = {}", id,
                         buildOrder.buildId, sStructureInfo[buildOrder.buildId].name, buildOrder.priority,
                         buildOrder.placeAt, eBuildOrderStateString(buildOrder.state));
             } else if (buildOrder.buildType == eBuildType::SPECIAL) {
-                sprintf(msg, "[%d] - type = SPECIAL, buildId = %d (=%s), priority = %d, state = %s", id, buildOrder.buildId,
+                msg = fmt::format("[{}] - type = SPECIAL, buildId = {} (={}), priority = {}, state = {}", id, buildOrder.buildId,
                         sSpecialInfo[buildOrder.buildId].description, buildOrder.priority, eBuildOrderStateString(buildOrder.state));
             } else if (buildOrder.buildType == eBuildType::BULLET) {
-                sprintf(msg, "[%d] - type = SPECIAL, buildId = %d (=NOT YET IMPLEMENTED), priority = %d, state = %s", id,
+                msg = fmt::format("[{}] - type = SPECIAL, buildId = {} (=NOT YET IMPLEMENTED), priority = {}, state = {}", id,
                         buildOrder.buildId, buildOrder.priority, eBuildOrderStateString(buildOrder.state));
             }
             log(msg);
@@ -185,11 +178,8 @@ namespace brains {
         }
 
         if (!foundExistingStructureInBase) {
-            char msg[255];
-            sprintf(msg,
-                    "cPlayerBrainSkirmish::onNotifyGameEvent() - concluded to add structure %s to base register:",
-                    pStructure->getS_StructuresType().name);
-            log(msg);
+            log(fmt::format("cPlayerBrainSkirmish::onNotifyGameEvent() - concluded to add structure {} to base register:",
+                            pStructure->getS_StructuresType().name));
 
             // new structure placed, update base register
             S_structurePosition position = {
@@ -303,9 +293,7 @@ namespace brains {
     }
 
     void cPlayerBrainSkirmish::thinkState_Base() {
-        char msg[255];
-        sprintf(msg, "thinkState_ScanBase()");
-        log(msg);
+        log("thinkState_ScanBase()");
 
         // structure placement is done in thinkState_ProcessBuildOrders() !
 
@@ -368,9 +356,7 @@ namespace brains {
     }
 
     void cPlayerBrainSkirmish::thinkState_Missions() {
-        char msg[255];
-        sprintf(msg, "thinkState_Missions()");
-        log(msg);
+        log("thinkState_Missions()");
 
         if (DEBUGGING) {
             log("Missions - before deleting");
@@ -479,9 +465,7 @@ namespace brains {
 
         // if cooldown is set, do that, so we don't spam missions in a very short amount of time
         if (m_TIMER_produceMissionCooldown > 0) {
-            char msg[255];
-            sprintf(msg, "m_TIMER_produceMissionCooldown [%d] is in effect.", m_TIMER_produceMissionCooldown);
-            log(msg);
+            log(fmt::format("m_TIMER_produceMissionCooldown [{}] is in effect.", m_TIMER_produceMissionCooldown));
             m_TIMER_produceMissionCooldown--;
             return;
         }
@@ -660,9 +644,7 @@ namespace brains {
     }
 
     void cPlayerBrainSkirmish::produceSkirmishGroundAttackMission(int missionId) {
-        char msg[255];
-        sprintf(msg, "produceSkirmishGroundAttackMission for mission id %d - called", missionId);
-        log(msg);
+        log(fmt::format("produceSkirmishGroundAttackMission for mission id %d - called", missionId));
         std::vector<S_groupKind> group = std::vector<S_groupKind>();
         int smallChance = 15;
         int normalChance = 50;
@@ -787,12 +769,10 @@ namespace brains {
             if (item.buildType == eBuildType::UNIT) {
                 if (!player->canBuildUnitBool(item.type)) {
                     item.required = 0; // set it to required 0, so it won't be built
-                    char msg[255];
-                    sprintf(msg, "addMission - cannot build unit [%s] so setting required to 0, for mission kind [%s].",
-                            toStringBuildTypeSpecificType(eBuildType::UNIT, item.type),
-                            ePlayerBrainMissionKindString(kind)
-                            );
-                    log(msg);
+                    log(fmt::format("addMission - cannot build unit [{}] so setting required to 0, for mission kind [{}].",
+                                    toStringBuildTypeSpecificType(eBuildType::UNIT, item.type),
+                                    ePlayerBrainMissionKindString(kind))
+                        );
                 }
             }
         }
@@ -800,23 +780,22 @@ namespace brains {
         cPlayerBrainMission someMission(player, kind, this, group, initialDelay, id);
         m_missions.push_back(someMission);
 
-        char msg[255];
-        // do note the cooldown is whtin the whole cylce of the AI thinking process. So this means the cooldown
+        // do note the cooldown is within the whole cylce of the AI thinking process. So this means the cooldown
         // here is the amount of 'iterations'. Since 1 iteration has a RestTime to wait, this means a cooldown of 10
         // is cooling down in 10 seconds.
         int cooldown = cPlayerBrain::RestTime;
         m_TIMER_produceMissionCooldown += cooldown;
-        sprintf(msg, "addMission - upping cooldown with %d to a total of %d", cooldown, m_TIMER_produceMissionCooldown);
-        log(msg);
+        log(fmt::format("addMission - upping cooldown with {} to a total of {}", cooldown, m_TIMER_produceMissionCooldown));
         // rest for a few seconds before producing a new mission)
 
     }
 
     void cPlayerBrainSkirmish::thinkState_Evaluate() {
-        char msg[255];
-        sprintf(msg, "thinkState_Evaluate() : credits [%d], m_COUNT_badEconomy [%d], m_economyState [%s]", player->getCredits(), m_COUNT_badEconomy,
-                ePlayerBrainSkirmishEconomyStateString(m_economyState));
-        log(msg);
+        log(fmt::format("thinkState_Evaluate() : credits [{}], m_COUNT_badEconomy [{}], m_economyState [{}]",
+                        player->getCredits(),
+                        m_COUNT_badEconomy,
+                        ePlayerBrainSkirmishEconomyStateString(m_economyState))
+            );
 
         if (player->getAmountOfStructuresForType(CONSTYARD) == 0) {
             // no constyards, endgame
@@ -926,9 +905,7 @@ namespace brains {
     }
 
     void cPlayerBrainSkirmish::thinkState_ProcessBuildOrders() {
-        char msg[255];
-        sprintf(msg, "thinkState_ProcessBuildOrders()");
-        log(msg);
+        log("thinkState_ProcessBuildOrders()");
 
         // check if we can find a similar build order
         for (auto &buildOrder : m_buildOrders) {
@@ -1106,29 +1083,25 @@ namespace brains {
     }
 
     void cPlayerBrainSkirmish::changeThinkStateTo(const ePlayerBrainSkirmishThinkState& newState) {
-        char msg[255];
-        sprintf(msg, "changeThinkStateTo(), from %s to %s",
-                ePlayerBrainSkirmishThinkStateString(m_thinkState),
-                ePlayerBrainSkirmishThinkStateString(newState));
-        log(msg);
+        log(fmt::format("changeThinkStateTo(), from {} to {}",
+                        ePlayerBrainSkirmishThinkStateString(m_thinkState),
+                        ePlayerBrainSkirmishThinkStateString(newState))
+            );
         this->m_thinkState = newState;
     }
 
     void cPlayerBrainSkirmish::changeEconomyStateTo(const ePlayerBrainSkirmishEconomyState &newState) {
-        char msg[255];
-        sprintf(msg, "cPlayerBrainSkirmish::changeEconomyStateTo(), from %s to %s",
-                ePlayerBrainSkirmishEconomyStateString(m_economyState),
-                ePlayerBrainSkirmishEconomyStateString(newState));
-        log(msg);
+        log(fmt::format( "cPlayerBrainSkirmish::changeEconomyStateTo(), from {} to {}",
+                         ePlayerBrainSkirmishEconomyStateString(m_economyState),
+                         ePlayerBrainSkirmishEconomyStateString(newState))
+            );
         this->m_economyState = newState;
     }
 
     void cPlayerBrainSkirmish::thinkState_Rest() {
         if (m_TIMER_rest > 0) {
             m_TIMER_rest--;
-            char msg[255];
-            sprintf(msg, "cPlayerBrainSkirmish::thinkState_Rest(), rest %d", m_TIMER_rest);
-            log(msg);
+            log(fmt::format("cPlayerBrainSkirmish::thinkState_Rest(), rest {}", m_TIMER_rest));
             return;
         }
 

--- a/player/brains/cPlayerBrainSkirmish.cpp
+++ b/player/brains/cPlayerBrainSkirmish.cpp
@@ -7,10 +7,11 @@
 
 namespace brains {
 
-    cPlayerBrainSkirmish::cPlayerBrainSkirmish(cPlayer *player) : cPlayerBrain(player) {
-        m_state = ePlayerBrainState::PLAYERBRAIN_PEACEFUL;
-        m_thinkState = ePlayerBrainSkirmishThinkState::PLAYERBRAIN_SKIRMISH_STATE_REST;
-//         timer is substracted every 100 ms with 1 (ie, 10 == 10*100 = 1000ms == 1 second)
+    cPlayerBrainSkirmish::cPlayerBrainSkirmish(cPlayer *player) :
+        cPlayerBrain(player),
+        m_state(ePlayerBrainState::PLAYERBRAIN_PEACEFUL),
+        m_thinkState(ePlayerBrainSkirmishThinkState::PLAYERBRAIN_SKIRMISH_STATE_REST) {
+//         timer is subtracted every 100 ms with 1 (ie, 10 == 10*100 = 1000ms == 1 second)
 //         10*60 -> 1 minute. * 4 -> 4 minutes
 //        m_TIMER_rest = (10 * 60) * 4;
         m_TIMER_rest = rnd(25); // todo: based on difficulty?
@@ -1422,7 +1423,7 @@ namespace brains {
 
     void cPlayerBrainSkirmish::log(const std::string & txt) {
         player->log(fmt::format(
-                "cPlayerBrainSkirmish [state={}, m_thinkState={}, m_economyState={}, m_TIMER_rest={}, m_TIMER_ai={}, m_COUNT_badEconomy={}] | %s",
+                "cPlayerBrainSkirmish [state={}, m_thinkState={}, m_economyState={}, m_TIMER_rest={}, m_TIMER_ai={}, m_COUNT_badEconomy={}] | {}",
                 ePlayerBrainStateString(m_state),
                 ePlayerBrainSkirmishThinkStateString(m_thinkState),
                 ePlayerBrainSkirmishEconomyStateString(m_economyState),

--- a/player/brains/cPlayerBrainSkirmish.cpp
+++ b/player/brains/cPlayerBrainSkirmish.cpp
@@ -3,6 +3,8 @@
 #include "cPlayerBrainSkirmish.h"
 #include "enums.h"
 
+#include <fmt/core.h>
+
 #include <algorithm>
 
 namespace brains {

--- a/player/brains/cPlayerBrainSkirmish.cpp
+++ b/player/brains/cPlayerBrainSkirmish.cpp
@@ -249,13 +249,12 @@ namespace brains {
             int cell = originUnit.getCell();
             bool attackerIsAirUnit = originUnit.isAirbornUnit();
 
-            respondToThreat(cell, attackerIsAirUnit);
+            respondToThreat(cell, attackerIsAirUnit, 2 + rnd(4));
         }
     }
 
-    void cPlayerBrainSkirmish::respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit) {
+    void cPlayerBrainSkirmish::respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit, int maxUnitsToOrder) {
         const std::vector<s_UnitForDistance> &units = player->getAllMyUnitsOrderClosestToCell(cellOriginOfThreat);
-        int maxUnitsToOrder = 2 + rnd(4);
 
         if (attackerIsAirUnit) {
             int unitsOrdered = 0;
@@ -1153,7 +1152,7 @@ namespace brains {
                             m_discoveredEnemyAtCell.insert(event.atCell);
 
                             if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
-                                respondToThreat(event.atCell, pUnit.isAirbornUnit());
+                                respondToThreat(event.atCell, pUnit.isAirbornUnit(), 2 + rnd(4));
                             }
                         }
                     } else if (event.entityType == eBuildType::STRUCTURE) {
@@ -1208,7 +1207,7 @@ namespace brains {
                         cUnit &pUnit = unit[event.entityID];
                         if (pUnit.isValid() && !pUnit.getPlayer()->isSameTeamAs(player)) {
                             if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
-                                respondToThreat(event.atCell, pUnit.isAirbornUnit());
+                                respondToThreat(event.atCell, pUnit.isAirbornUnit(), 2 + rnd(4));
                             }
                         }
                     }

--- a/player/brains/cPlayerBrainSkirmish.h
+++ b/player/brains/cPlayerBrainSkirmish.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAINSKIRMISH_H
-#define D2TM_CPLAYERBRAINSKIRMISH_H
+#pragma once
 
 #include "player/brains/cPlayerBrain.h"
 #include "player/brains/cPlayerBrainData.h"
@@ -189,5 +188,3 @@ namespace brains {
     };
 
 }
-
-#endif //D2TM_CPLAYERBRAINSKIRMISH_H

--- a/player/brains/cPlayerBrainSkirmish.h
+++ b/player/brains/cPlayerBrainSkirmish.h
@@ -71,6 +71,8 @@ namespace brains {
 
         int m_TIMER_ai;
 
+        int m_centerOfBaseCell;
+
         // at which cells did we detect an enemy? Remember those.
         std::set<int> m_discoveredEnemyAtCell;
 
@@ -185,6 +187,8 @@ namespace brains {
         void produceSuperWeaponMissionsWhenApplicable();
 
         void produceEconomyImprovingMissions();
+
+        void respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit);
     };
 
 }

--- a/player/brains/cPlayerBrainSkirmish.h
+++ b/player/brains/cPlayerBrainSkirmish.h
@@ -52,7 +52,7 @@ namespace brains {
 
         void onNotifyGameEvent(const s_GameEvent &event) override;
 
-        void addBuildOrder(S_buildOrder order);
+        void addBuildOrder(S_buildOrder order) override;
 
         void log(const std::string & txt);
 

--- a/player/brains/cPlayerBrainSkirmish.h
+++ b/player/brains/cPlayerBrainSkirmish.h
@@ -55,7 +55,7 @@ namespace brains {
 
         void addBuildOrder(S_buildOrder order);
 
-        void log(const char* txt);
+        void log(const std::string & txt);
 
     private:
         ePlayerBrainState state;

--- a/player/brains/cPlayerBrainSkirmish.h
+++ b/player/brains/cPlayerBrainSkirmish.h
@@ -188,7 +188,7 @@ namespace brains {
 
         void produceEconomyImprovingMissions();
 
-        void respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit);
+        void respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit, int maxUnitsToOrder);
     };
 
 }

--- a/player/brains/cPlayerBrainSkirmish.h
+++ b/player/brains/cPlayerBrainSkirmish.h
@@ -57,26 +57,26 @@ namespace brains {
         void log(const std::string & txt);
 
     private:
-        ePlayerBrainState state;
+        ePlayerBrainState m_state;
 
-        ePlayerBrainSkirmishThinkState thinkState;
+        ePlayerBrainSkirmishThinkState m_thinkState;
 
-        ePlayerBrainSkirmishEconomyState economyState;
+        ePlayerBrainSkirmishEconomyState m_economyState;
 
-        int COUNT_badEconomy;
+        int m_COUNT_badEconomy;
 
-        int TIMER_rest;
+        int m_TIMER_rest;
 
-        int TIMER_produceMissionCooldown;
+        int m_TIMER_produceMissionCooldown;
 
-        int TIMER_ai;
+        int m_TIMER_ai;
 
         // at which cells did we detect an enemy? Remember those.
-        std::set<int> discoveredEnemyAtCell;
+        std::set<int> m_discoveredEnemyAtCell;
 
-        std::vector<cPlayerBrainMission> missions;
-        std::vector<S_structurePosition> myBase;
-        std::vector<S_buildOrder> buildOrders;
+        std::vector<cPlayerBrainMission> m_missions;
+        std::vector<S_structurePosition> m_myBase;
+        std::vector<S_buildOrder> m_buildOrders;
 
         void onMyStructureDestroyed(const s_GameEvent &event);
 

--- a/player/brains/cPlayerBrainSkirmish.h
+++ b/player/brains/cPlayerBrainSkirmish.h
@@ -42,7 +42,7 @@ namespace brains {
     class cPlayerBrainSkirmish : public cPlayerBrain {
 
     public:
-        cPlayerBrainSkirmish(cPlayer *player);
+        explicit cPlayerBrainSkirmish(cPlayer *player);
 
         ~cPlayerBrainSkirmish();
 

--- a/player/brains/missions/cPlayerBrainMission.h
+++ b/player/brains/missions/cPlayerBrainMission.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAINMISSION_H
-#define D2TM_CPLAYERBRAINMISSION_H
+#pragma once
 
 #include <vector>
 #include "player/brains/cPlayerBrainData.h"
@@ -189,5 +188,3 @@ namespace brains {
     };
 
 }
-
-#endif //D2TM_CPLAYERBRAINMISSION_H

--- a/player/brains/missions/cPlayerBrainMissionKind.h
+++ b/player/brains/missions/cPlayerBrainMissionKind.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAINMISSIONKIND_H
-#define D2TM_CPLAYERBRAINMISSIONKIND_H
+#pragma once
 
 #include <observers/cScenarioObserver.h>
 
@@ -104,5 +103,3 @@ namespace brains {
     };
 
 }
-
-#endif //D2TM_CPLAYERBRAINMISSIONKIND_H

--- a/player/brains/missions/cPlayerBrainMissionKindAttack.h
+++ b/player/brains/missions/cPlayerBrainMissionKindAttack.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAINMISSIONKIND_ATTACK_H
-#define D2TM_CPLAYERBRAINMISSIONKIND_ATTACK_H
+#pragma once
 
 #include "player/playerh.h"
 #include "cPlayerBrainMissionKind.h"
@@ -42,5 +41,3 @@ namespace brains {
     };
 
 }
-
-#endif //D2TM_CPLAYERBRAINMISSIONKIND_ATTACK_H

--- a/player/brains/missions/cPlayerBrainMissionKindDeathHand.h
+++ b/player/brains/missions/cPlayerBrainMissionKindDeathHand.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAINMISSIONKIND_DEATHHAND_H
-#define D2TM_CPLAYERBRAINMISSIONKIND_DEATHHAND_H
+#pragma once
 
 #include "player/playerh.h"
 #include "cPlayerBrainMissionKind.h"
@@ -44,5 +43,3 @@ namespace brains {
     };
 
 }
-
-#endif //D2TM_CPLAYERBRAINMISSIONKIND_DEATHHAND_H

--- a/player/brains/missions/cPlayerBrainMissionKindExplore.h
+++ b/player/brains/missions/cPlayerBrainMissionKindExplore.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAINMISSIONKIND_EXPLORE_H
-#define D2TM_CPLAYERBRAINMISSIONKIND_EXPLORE_H
+#pragma once
 
 #include "player/playerh.h"
 #include "cPlayerBrainMissionKind.h"
@@ -33,5 +32,3 @@ namespace brains {
     };
 
 }
-
-#endif //D2TM_CPLAYERBRAINMISSIONKIND_EXPLORE_H

--- a/player/brains/missions/cPlayerBrainMissionKindFremen.h
+++ b/player/brains/missions/cPlayerBrainMissionKindFremen.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAINMISSIONKIND_FREMEN_H
-#define D2TM_CPLAYERBRAINMISSIONKIND_FREMEN_H
+#pragma once
 
 #include "player/playerh.h"
 #include "cPlayerBrainMissionKind.h"
@@ -31,5 +30,3 @@ namespace brains {
     };
 
 }
-
-#endif //D2TM_CPLAYERBRAINMISSIONKIND_FREMEN_H

--- a/player/brains/missions/cPlayerBrainMissionKindSaboteur.h
+++ b/player/brains/missions/cPlayerBrainMissionKindSaboteur.h
@@ -1,5 +1,4 @@
-#ifndef D2TM_CPLAYERBRAINMISSIONKIND_SABOTEUR_H
-#define D2TM_CPLAYERBRAINMISSIONKIND_SABOTEUR_H
+#pragma once
 
 #include "player/playerh.h"
 #include "cPlayerBrainMissionKind.h"
@@ -35,5 +34,3 @@ namespace brains {
     };
 
 }
-
-#endif //D2TM_CPLAYERBRAINMISSIONKIND_SABOTEUR_H

--- a/player/cPlayer.cpp
+++ b/player/cPlayer.cpp
@@ -1894,6 +1894,29 @@ void cPlayer::onMyUnitDestroyed(const s_GameEvent &event) {
 }
 
 /**
+ * Same as getAllMyUnits, but returns units ordered by distance (closest first)
+ * @param cell
+ * @return
+ */
+std::vector<s_UnitForDistance> cPlayer::getAllMyUnitsOrderClosestToCell(int cell) {
+    const std::vector<int> &ids = getAllMyUnitsForType(-1);
+    std::vector<s_UnitForDistance> result = std::vector<s_UnitForDistance>(0);
+
+    for (auto & unitId : ids) {
+        cUnit aUnit = unit[unitId];
+        double dist = map.distance(aUnit.getCell(), cell);
+        const s_UnitForDistance &entry = s_UnitForDistance{
+            .distance = (int)dist,
+            .unitId = unitId
+        };
+        result.push_back(entry);
+    }
+
+    std::sort(result.begin(), result.end());
+    return result;
+}
+
+/**
  * Returns all unit ids belonging to player
  *
  * NOTE: This is a slow method, as it iterates though all possible unit ids

--- a/player/cPlayer.h
+++ b/player/cPlayer.h
@@ -39,6 +39,16 @@
 class cItemBuilder;
 class cBuildingListUpdater;
 
+struct s_UnitForDistance {
+    int distance = 9999;
+    int unitId = -1;
+
+    bool operator<(const s_UnitForDistance& rhs) const
+    {
+        return distance < rhs.distance;
+    }
+};
+
 struct s_PlaceResult {
     bool success = false; // if true, all is ok
 
@@ -225,6 +235,8 @@ public:
 
     int getTeam() { return iTeam; }
 
+
+    std::vector<s_UnitForDistance> getAllMyUnitsOrderClosestToCell(int cell);
 
     std::vector<int> getAllMyUnits();
 


### PR DESCRIPTION
For #293 

- When structure is damaged, the AI will send out units to retaliate
- When enemy unit is detected, it will send out units to defend
- Using fmt where applicable
- Rename member fields to use prefix `m_` 

I know the code is duplicated across the skirmish and campaign AI, this is *intentional*. Currently I don't want to DRY that up yet. I am unsure yet how the AI can be further improved; although I do think a "component" like system would be a way to reduce duplication while keeping flexibility to have Campaign and Skirmish AI behave differently sometimes.