### PR TITLE
modernize cSeedMapGenerator a bit and include it only where used

### DIFF
--- a/ini.cpp
+++ b/ini.cpp
@@ -13,6 +13,7 @@
 #include "include/d2tmh.h"
 
 #include "utils/cLog.h"
+#include "utils/cSeedMapGenerator.h"
 
 #include <allegro.h>
 #include <fmt/core.h>
@@ -1026,21 +1027,18 @@ void INI_Load_seed(int seed) {
 
     logbook(fmt::format("Generating seed map with seed {}.", seed));
 
-    cSeedMapGenerator *seedGenerator = new cSeedMapGenerator(seed);
+    auto seedGenerator = cSeedMapGenerator(seed);
 
-    cSeedMap *seedMap = seedGenerator->generateSeedMap();
+    auto seedMap = seedGenerator.generateSeedMap();
     logbook("Seedmap generated");
 
     for (int mapY = 0; mapY < 64; mapY++) {
         for (int mapX = 0; mapX < 64; mapX++) {
-            int type = seedMap->getCellType(mapX, mapY);
+            int type = seedMap.getCellType(mapX, mapY);
             int iCell = map.makeCell(mapX, mapY);
             mapEditor.createCell(iCell, type, 0);
         }
     }
-
-    delete seedMap;
-    delete seedGenerator;
 
     logbook("Seedmap converted into D2TM map.");
 }

--- a/utils/cSeedMap.cpp
+++ b/utils/cSeedMap.cpp
@@ -4,7 +4,7 @@
 
 #include <cassert>
 
-cSeedMap::cSeedMap() : map{kMapWidth*kMapHeight, TERRAIN_SAND} {
+cSeedMap::cSeedMap() : map(kMapWidth*kMapHeight, TERRAIN_SAND) {
 }
 
 void cSeedMap::setCellType(int x, int y, int type) {

--- a/utils/cSeedMap.cpp
+++ b/utils/cSeedMap.cpp
@@ -1,25 +1,28 @@
-#include "../include/d2tmh.h"
+#include "cSeedMap.h"
 
-cSeedMap::cSeedMap() {
-	memset(map, TERRAIN_SAND, sizeof(map));
+#include "data/gfxdata.h"
+
+#include <cassert>
+
+cSeedMap::cSeedMap() : map{kMapWidth*kMapHeight, TERRAIN_SAND} {
 }
 
 void cSeedMap::setCellType(int x, int y, int type) {
 	assert(x > -1);
-	assert(x < 64);
+	assert(x < kMapWidth);
 	assert(y > -1);
-	assert(y < 64);
+	assert(y < kMapHeight);
 	assert(type > -1);
 	assert(type < TERRAIN_WALL);
-	map[x][y] = type;
+	map[x + kMapWidth * y] = type;
 }
 
 int cSeedMap::getCellType(int x, int y) {
 	assert(x > -1);
-	assert(x < 64);
+	assert(x < kMapWidth);
 	assert(y > -1);
-	assert(y < 64);
-	return map[x][y];
+	assert(y < kMapHeight);
+	return map[x + kMapWidth * y];
 }
 
 char cSeedMap::getCellTypeCharacter(int x, int y) {

--- a/utils/cSeedMap.h
+++ b/utils/cSeedMap.h
@@ -1,23 +1,22 @@
-#ifndef SEEDMAP
-#define SEEDMAP
+#pragma once
 
+#include <vector>
 /**
  * Representation of terrain, called a seed map. This is not per-see generated from seed info. But
  * for now it is used to get the generated seed map into the Map class by D2TM.
  *
  */
 class cSeedMap {
-
-private:
-	int map[64][64];
-
-public:
+  public:
 	cSeedMap();
+
+    static constexpr int kMapWidth = 64;
+    static constexpr int kMapHeight = 64;
 
 	void setCellType(int x, int y, int type);
 	int getCellType(int x, int y);
 	char getCellTypeCharacter(int x, int y);
 
+  private:
+	std::vector<int> map; // 64x64
 };
-
-#endif

--- a/utils/cSeedMapGenerator.cpp
+++ b/utils/cSeedMapGenerator.cpp
@@ -83,7 +83,7 @@ cSeedMapGenerator::cSeedMapGenerator(unsigned long value) {
 }
 
 short cSeedMapGenerator::random() {
-   unsigned char *s = (unsigned char *)&seed, a, b, x, y;
+   unsigned char * s = reinterpret_cast<unsigned char *>(&seed), a, b, x, y;
 
    a = *(s+0);
    x = (a & 0x2) >> 1;
@@ -519,7 +519,7 @@ void cSeedMapGenerator::addNoise2(char *matrix)
  *
  * @return
  */
-cSeedMap *cSeedMapGenerator::generateSeedMap() {
+cSeedMap cSeedMapGenerator::generateSeedMap() {
 	   /* creates the shape of the map */
 	   createMatrix(matrix);
 	   addNoise1(matrix);
@@ -537,10 +537,10 @@ cSeedMap *cSeedMapGenerator::generateSeedMap() {
 //	   /* prints map on the screen */
 //	   printMap(map);
 
-	   cSeedMap * seedmap = new cSeedMap();
+	   cSeedMap seedmap;
 
-	   for (int x = 0; x < 64; x++) {
-		   for (int y = 0; y < 64; y++) {
+	   for (int y = 0; y < cSeedMap::kMapHeight; y++) {
+    	   for (int x = 0; x < cSeedMap::kMapWidth; x++) {
 			   // read out the map, and convert it into the seedmap array
 			   int type = map[y][x].w; // w = type
 			   int d2tmType = TERRAIN_SAND;
@@ -554,7 +554,7 @@ cSeedMap *cSeedMapGenerator::generateSeedMap() {
 				   case SMG_MUCHSPICE: d2tmType = TERRAIN_SPICEHILL; break;
 				}
 
-			   seedmap->setCellType(x, y, d2tmType);
+			   seedmap.setCellType(x, y, d2tmType);
 		   }
 	   }
 

--- a/utils/cSeedMapGenerator.cpp
+++ b/utils/cSeedMapGenerator.cpp
@@ -2,6 +2,13 @@
 
 #include "data/gfxdata.h"
 
+#define SMG_SAND      0
+#define SMG_DUNES     2
+#define SMG_ROCK      4
+#define SMG_MOUNTAINS 6
+#define SMG_SPICE     8
+#define SMG_MUCHSPICE 9
+
 // static initialize
 short cSeedMapGenerator::offsets2[SMG_OFFSET2_SIZE] =
 {
@@ -71,12 +78,6 @@ unsigned char cSeedMapGenerator::spicemap2[256] = {
 0x75,0x76,0x77,0x78,0x79,0x7a,0x7b,0x7b,0x7c,0x7d,0x7d,0x7e,0x7e,0x7e,0x7e,0x7e
 };
 
-
-// constructors
-cSeedMapGenerator::cSeedMapGenerator() {
-	// constructor
-	seed = 0;
-}
 
 cSeedMapGenerator::cSeedMapGenerator(unsigned long value) {
 	seed = value;
@@ -382,7 +383,7 @@ void cSeedMapGenerator::balanceMap(cell map[64][64]) {
               r = currln[x + 1];
 
               if (y < 63) rd = map[y + 1][x + 1].w;
-              if (y > 63) ld = map[y + 1][x - 1].w;
+              if (y < 63) ld = map[y + 1][x - 1].w;
           }
 
           if (y > 1 && y < 63) {
@@ -521,11 +522,13 @@ void cSeedMapGenerator::addNoise2(char *matrix)
  */
 cSeedMap cSeedMapGenerator::generateSeedMap() {
 	   /* creates the shape of the map */
+       char matrix[16*17+1];
 	   createMatrix(matrix);
 	   addNoise1(matrix);
 	   addNoise2(matrix);
 
 	   /* copies the matrix on the map and spreads the numbers */
+       cell map[65][64];
 	   copyMatrix(matrix, map);
 	   spreadMatrix(map);
 	   /* makes the map more smooth */

--- a/utils/cSeedMapGenerator.h
+++ b/utils/cSeedMapGenerator.h
@@ -7,13 +7,6 @@ struct cell
    short w, a, b;
 };
 
-#define SMG_SAND      0
-#define SMG_DUNES     2
-#define SMG_ROCK      4
-#define SMG_MOUNTAINS 6
-#define SMG_SPICE     8
-#define SMG_MUCHSPICE 9
-
 // needed for offset2
 #define  SMG_A  0,0
 #define  SMG_B  2,0
@@ -50,10 +43,6 @@ private:
 	static unsigned char spicemap[256];
 	static unsigned char spicemap2[256];
 
-	char matrix[16*17+1];
-	cell map[65][64];
-	short compact[64][64];
-
 	// methods needed to generate seedmap
 	void convertMap (cell map[64][64], short *iconmap);
 	void addSpice(cell map[64][64]);
@@ -68,7 +57,6 @@ private:
 	void addSpiceAt(cell map[64][64],short x,short y);
 
 public:
-	cSeedMapGenerator();
 	explicit cSeedMapGenerator(unsigned long value);
 
 	cSeedMap generateSeedMap();

--- a/utils/cSeedMapGenerator.h
+++ b/utils/cSeedMapGenerator.h
@@ -71,5 +71,5 @@ public:
 	cSeedMapGenerator();
 	explicit cSeedMapGenerator(unsigned long value);
 
-	cSeedMap *generateSeedMap();
+	cSeedMap generateSeedMap();
 };

--- a/utils/utilsh.h
+++ b/utils/utilsh.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include "common.h"					// commonly used functions
-#include "../ini.h"							// INI loading
+#include "common.h"			// commonly used functions
+#include "../ini.h"			// INI loading
 
-#include "cSeedMap.h"
-#include "cSeedMapGenerator.h"
 #include "cStructureUtils.h"
 
 #include "cTimeManager.h"


### PR DESCRIPTION
Some cleanup. Returning the seedmap from the generator by value, as NRVO (named return value optimization) will construct it in-place and no copy will be done. In case that fails, the seedmap contains only one vector, which supports move semantics, so the data buffer is not copied if the original object is not used anymore.