### PR TITLE
move cTimeManager inside cGame

### DIFF
--- a/cGame.h
+++ b/cGame.h
@@ -17,6 +17,7 @@
 #include "definitions.h"
 #include "observers/cScenarioObserver.h"
 #include "utils/cRectangle.h"
+#include "utils/cTimeManager.h"
 
 #include <memory>
 #include <string>
@@ -239,6 +240,8 @@ private:
 
     cMouse *m_mouse;
     cKeyboard *m_keyboard;
+
+    cTimeManager m_timeManager;
 
     bool m_missionWasWon;               // hack: used for state transitioning :/
 

--- a/cGame_logic.cpp
+++ b/cGame_logic.cpp
@@ -36,7 +36,7 @@ constexpr auto kMaxAlpha = 255;
 
 }
 
-cGame::cGame() {
+cGame::cGame() : m_timeManager(*this) {
     memset(m_states, 0, sizeof(cGameState *));
 
     m_drawFps = false;
@@ -551,7 +551,7 @@ void cGame::run() {
     set_trans_blender(0, 0, 0, 128);
 
     while (m_playing) {
-        TimeManager.processTime();
+        m_timeManager.processTime();
         updateMouseAndKeyboardStateAndGamePlaying();
         handleTimeSlicing(); // handle time diff (needs to change!)
         drawState(); // run game state, includes interaction + drawing

--- a/include/d2tmc.h
+++ b/include/d2tmc.h
@@ -37,7 +37,6 @@ class cUnit;
 class cParticle;
 class cPlayer;
 class cRegion;
-class cTimeManager;
 
 struct sReinforcement;
 
@@ -62,7 +61,6 @@ extern cPlayer        players[MAX_PLAYERS];
 extern cParticle      particle[MAX_PARTICLES];
 extern cBullet        bullet[MAX_BULLETS];
 extern cRegion        world[MAX_REGIONS];
-extern cTimeManager   TimeManager;
 extern cStructureUtils structureUtils;
 extern cDrawManager   *drawManager;
 extern cAllegroDrawer      *allegroDrawer;

--- a/main.cpp
+++ b/main.cpp
@@ -17,7 +17,6 @@ int	iRest = 1;	// default rest value
 // the ultimate game variable(s)
 cGame          				game;
 
-cTimeManager   				TimeManager;
 cStructureUtils 			structureUtils;
 cMap           				map;
 cMapEditor	  				mapEditor;

--- a/utils/cTimeManager.h
+++ b/utils/cTimeManager.h
@@ -14,15 +14,17 @@
 	Time management is done in this class
 */
 
-#ifndef CTIMEMANAGER_H
+#pragma once
+
+class cGame;
 
 class cTimeManager {
 
 private:
 
-	int timerUnits;		/** !!Specificly!! used for units **/
-	int timerSecond;
-	int timerGlobal;
+	int m_timerUnits;		/** !!Specificly!! used for units **/
+	int m_timerSecond;
+	int m_timerGlobal;
 
 	void handleTimerUnits();
 	void handleTimerAllegroTimerSeconds();
@@ -36,11 +38,10 @@ private:
 
 public:
 
-	cTimeManager();
+	explicit cTimeManager(cGame& game);
 
-	int gameTime;		/** Definition of game time (= in seconds) **/
+    cGame& m_game;
+	int m_gameTime;		/** Definition of game time (= in seconds) **/
 
 	void processTime();
 };
-
-#endif

--- a/utils/utilsh.h
+++ b/utils/utilsh.h
@@ -6,5 +6,3 @@
 #include "cSeedMap.h"
 #include "cSeedMapGenerator.h"
 #include "cStructureUtils.h"
-
-#include "cTimeManager.h"


### PR DESCRIPTION
Another global variable gone.
I wonder if we should keep the time manager. Perhaps in a later refactoring, the handling of the allegro timers can be done in the main game loop.