### PR TITLE
add Linux build fix for alfont

### DIFF
--- a/dependencies/alfont/CMakeLists.txt
+++ b/dependencies/alfont/CMakeLists.txt
@@ -48,9 +48,18 @@ target_link_libraries(alfont
     allegro
 )
 
+# Alfont has DOS and Linux specific fixes. Building for DOS is not supported for d2tm, but for
+# Linux, we enable these fixes here.
+if(UNIX)
+  set(ALFONT_PLATFORM "ALFONT_LINUX")
+else() # Default to "Windows" (no fixes)
+  set(ALFONT_PLATFORM "ALFONT_WINDOWS")
+endif()
+
 # Compile & link options are taken from the Makefile. 
 target_compile_options(alfont
   PRIVATE
+    "-D${ALFONT_PLATFORM}"
     "-O2"
     "-march=pentium"
     "-fomit-frame-pointer"

--- a/dependencies/alfont/include/alfont.h
+++ b/dependencies/alfont/include/alfont.h
@@ -4,15 +4,10 @@
             
 /* FreeType 2 is copyright (c) 1996-2000 */
 /* David Turner, Robert Wilhelm, and Werner Lemberg */
-/* AllegroFont is copyright (c) 2001, 2002 Javier Gonz†lez */
+/* AllegroFont is copyright (c) 2001, 2002 Javier Gonz√£lez */
 /* Enhanced by Chernsha since 2004 year */
 
 /* See FTL.txt (FreeType Project License) for license */
-
-
-#define ALFONT_WINDOWS   //When compiling in WINDOWS,please uncomment this line.
-//#define ALFONT_DOS 	 //When compiling in DOS,please uncomment this line. 
-//#define ALFONT_LINUX 	 //When compiling in LINUX,please uncomment this line.
 
 
 #ifndef ALFONT_H


### PR DESCRIPTION
Not tested on Linux yet, as I don't have access to such a system right now.
But this is the CMake trick that can make it build on both MinGW on Windows and on Linux. 