### PR TITLE
Bugfixes & Improvements

### DIFF
--- a/cGame_logic.cpp
+++ b/cGame_logic.cpp
@@ -1076,6 +1076,9 @@ void cGame::setState(int newState) {
         if (m_state == GAME_OPTIONS && newState == GAME_CREDITS) {
             deleteOldState = false; // don't delete credits, so we keep the crawler info
         }
+        if (newState == GAME_OPTIONS) {
+            deleteOldState = true; // delete old options state everytime
+        }
 
         if (deleteOldState) {
             delete m_states[newState];
@@ -1136,7 +1139,12 @@ void cGame::setState(int newState) {
             } else if (newState == GAME_OPTIONS) {
                 m_mouse->setTile(MOUSE_NORMAL);
                 BITMAP *background = create_bitmap(m_screenX, m_screenY);
-                drawManager->drawCombatState(); // TODO: draw combat state directly on background bitmap
+                if (m_state == GAME_PLAYING) {
+                    // so we don't draw mouse cursor
+                    drawManager->drawCombatState();
+                } else {
+                    // we fall back what was on screen, (which includes mouse cursor for now)
+                }
                 allegroDrawer->drawSprite(background, bmp_screen, 0, 0);
                 newStatePtr = new cOptionsState(*this, background, m_state);
             } else if (newState == GAME_PLAYING) {

--- a/cGame_logic.cpp
+++ b/cGame_logic.cpp
@@ -1083,19 +1083,27 @@ void cGame::setState(int newState) {
         }
 
         cGameState *existingStatePtr = m_states[newState];
-        if (existingStatePtr) {
-            if (m_currentState->getType() == GAMESTATE_SELECT_YOUR_NEXT_CONQUEST) {
-                cSelectYourNextConquestState *pState = dynamic_cast<cSelectYourNextConquestState *>(m_currentState);
 
-                if (m_missionWasWon) {
-                    // we won
+        if (existingStatePtr) {
+            // no need for re-creating state
+
+            if (newState == GAME_REGION) {
+                // came from a win/lose brief state, so make sure to set up the next state
+                if (m_state == GAME_WINBRIEF || m_state == GAME_LOSEBRIEF) {
+                    // because `GAME_REGION` == if (existingStatePtr->getType() == GAMESTATE_SELECT_YOUR_NEXT_CONQUEST ||
+                    cSelectYourNextConquestState *pState = dynamic_cast<cSelectYourNextConquestState *>(existingStatePtr);
+
                     if (game.m_mission > 1) {
                         pState->conquerRegions();
                     }
-                    pState->REGION_SETUP_NEXT_MISSION(game.m_mission, players[HUMAN].getHouse());
-                } else {
-                    // OR: did not win
-                    pState->REGION_SETUP_LOST_MISSION();
+
+                    if (m_missionWasWon) {
+                        // we won
+                        pState->REGION_SETUP_NEXT_MISSION(game.m_mission, players[HUMAN].getHouse());
+                    } else {
+                        // OR: did not win
+                        pState->REGION_SETUP_LOST_MISSION();
+                    }
                 }
             }
 

--- a/gamestates/cCreditsState.cpp
+++ b/gamestates/cCreditsState.cpp
@@ -381,5 +381,6 @@ eGameStateType cCreditsState::getType() {
 void cCreditsState::onNotifyKeyboardEvent(const cKeyboardEvent &event) {
     if (event.isType(eKeyEventType::PRESSED) && event.hasKey(KEY_ESC)) {
         game.setNextStateToTransitionTo(GAME_MENU);
+        game.initiateFadingOut();
     }
 }

--- a/gamestates/cSelectYourNextConquestState.cpp
+++ b/gamestates/cSelectYourNextConquestState.cpp
@@ -305,6 +305,17 @@ void cSelectYourNextConquestState::drawStateSelectYourNextConquest() const {
     for (int i = 0; i < 27; i++) {
         REGION_DRAW(world[i]);
     }
+
+    // Animate here (so add regions that are conquered)
+    cMessageDrawer *pDrawer = drawManager->getMessageDrawer();
+    char *cMessage = pDrawer->getMessage();
+
+    bool isNotDisplayingMessage = cMessage[0] == '\0';
+
+    if (isFinishedConqueringRegions && isNotDisplayingMessage) {
+        pDrawer->setMessage("Select your next region.");
+        pDrawer->setKeepMessage(true);
+    }
 }
 
 void cSelectYourNextConquestState::loadScenarioAndTransitionToNextState(int iMission) {// Calculate mission from region:

--- a/gamestates/cSelectYourNextConquestState.cpp
+++ b/gamestates/cSelectYourNextConquestState.cpp
@@ -622,5 +622,10 @@ void cSelectYourNextConquestState::onMouseLeftButtonClicked(const s_MouseEvent &
     }
 }
 
-void cSelectYourNextConquestState::onNotifyKeyboardEvent(const cKeyboardEvent &) {
+void cSelectYourNextConquestState::onNotifyKeyboardEvent(const cKeyboardEvent &event) {
+    if (event.eventType == eKeyEventType::PRESSED) {
+        if (event.hasKey(KEY_ESC)) {
+            game.setNextStateToTransitionTo(GAME_OPTIONS);
+        }
+    }
 }

--- a/gamestates/cSelectYourNextConquestState.cpp
+++ b/gamestates/cSelectYourNextConquestState.cpp
@@ -318,16 +318,17 @@ void cSelectYourNextConquestState::drawStateSelectYourNextConquest() const {
     }
 }
 
-void cSelectYourNextConquestState::loadScenarioAndTransitionToNextState(int iMission) {// Calculate mission from region:
-// region 1 = mission 1
-// region 2, 3, 4 = mission 2
-// region 5, 6, 7 = mission 3
-// region 8, 9, 10 = mission 4
-// region 11,12,13 = mission 5
-// region 14,15,16 = mission 6
-// region 17,18,19 = mission 7
-// region 20,21    = mission 8
-// region 22 = mission 9
+void cSelectYourNextConquestState::loadScenarioAndTransitionToNextState(int iMission) {
+    // Calculate mission from region:
+    // region 1 = mission 1
+    // region 2, 3, 4 = mission 2
+    // region 5, 6, 7 = mission 3
+    // region 8, 9, 10 = mission 4
+    // region 11,12,13 = mission 5
+    // region 14,15,16 = mission 6
+    // region 17,18,19 = mission 7
+    // region 20,21    = mission 8
+    // region 22 = mission 9
 
     // calculate region stuff, and add it up
     int iNewReg = 0;


### PR DESCRIPTION
- fixes #465
- fixes #469 

Also:
- fades out on exit credits state
- add options menu from "select your next conquest" state
- whenever we go to options state from non-combat state, we fall back to 'normal' bmp draw (with mouse cursor there).