### PR TITLE
Bugfix: harvesters only attack infantry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ file(GLOB d2tm_SRC
         "player/*.cpp"
         "player/brains/*.h"
         "player/brains/*.cpp"
+        "player/brains/actions/*.h"
+        "player/brains/actions/*.cpp"
         "player/brains/missions/*.h"
         "player/brains/missions/*.cpp"
         "player/brains/missions/campaign/*.h"

--- a/cGame_logic.cpp
+++ b/cGame_logic.cpp
@@ -1986,7 +1986,7 @@ void cGame::onKeyDownDebugMode(const cKeyboardEvent &event) {
                 cUnit &pUnit = unit[idOfUnitAtCell];
                 int damageToTake = pUnit.getHitPoints() - 25;
                 if (damageToTake > 0) {
-                    pUnit.takeDamage(damageToTake);
+                    pUnit.takeDamage(damageToTake, -1, -1);
                 }
             }
         }

--- a/gameobjects/projectiles/bullet.cpp
+++ b/gameobjects/projectiles/bullet.cpp
@@ -382,7 +382,7 @@ bool cBullet::damageAirUnit(int cell, double factor) const {
     float iDamage = getDamageToInflictToNonInfantry() * factor;
 
     cUnit &airUnit = unit[id];
-    airUnit.takeDamage(iDamage);
+    airUnit.takeDamage(iDamage, iOwnerUnit, iOwnerStructure);
     return true;
 }
 
@@ -400,7 +400,7 @@ bool cBullet::damageGroundUnit(int cell, double factor) const {
     cUnit &groundUnitTakingDamage = unit[id];
 
     float iDamage = getDamageToInflictToUnit(groundUnitTakingDamage) * factor;
-    groundUnitTakingDamage.takeDamage(iDamage);
+    groundUnitTakingDamage.takeDamage(iDamage, iOwnerUnit, iOwnerStructure);
 
     // this unit will think what to do now (he got hit ouchy!)
     groundUnitTakingDamage.think_hit(iOwnerUnit, iOwnerStructure);
@@ -492,7 +492,7 @@ void cBullet::damageSandworm(int cell, double factor) const {
 
     cUnit &worm = unit[id];
     float damage = getDamageToInflictToNonInfantry() * factor;
-    worm.takeDamage(damage);
+    worm.takeDamage(damage, iOwnerUnit, iOwnerStructure);
 }
 
 bool cBullet::isAtDestination() const {

--- a/gameobjects/structures/cAbstractStructure.cpp
+++ b/gameobjects/structures/cAbstractStructure.cpp
@@ -478,7 +478,8 @@ void cAbstractStructure::damage(int hp, int originId) {
                 .entityID = getStructureId(),
                 .player = getPlayer(),
                 .entitySpecificType = getType(),
-                .originId = originId
+                .originId = originId,
+                .originType = eBuildType::UNIT // TODO: What if another structure damaged me!?
         };
 
         game.onNotifyGameEvent(event);

--- a/gameobjects/units/cUnit.cpp
+++ b/gameobjects/units/cUnit.cpp
@@ -3213,12 +3213,15 @@ void cUnit::takeDamage(int damage, int unitWhoDealsDamage, int structureWhoDeals
         } else {
             auto originType = eBuildType::UNKNOWN;
             auto originId = -1;
+            auto originCell = -1;
             if (unitWhoDealsDamage > -1) {
                 originType = eBuildType::UNIT;
                 originId = unitWhoDealsDamage;
+                originCell = unit[unitWhoDealsDamage].iCell;
             } else if (structureWhoDealsDamage > -1) {
                 originId = structureWhoDealsDamage;
                 originType = eBuildType::STRUCTURE;
+                originCell = structure[structureWhoDealsDamage]->getCell();
             }
             s_GameEvent event {
                     .eventType = eGameEventType::GAME_EVENT_DAMAGED,
@@ -3226,6 +3229,7 @@ void cUnit::takeDamage(int damage, int unitWhoDealsDamage, int structureWhoDeals
                     .entityID = iID,
                     .player = getPlayer(),
                     .entitySpecificType = getType(),
+                    .atCell = originCell,
                     .originId = originId,
                     .originType = originType,
             };

--- a/gameobjects/units/cUnit.cpp
+++ b/gameobjects/units/cUnit.cpp
@@ -3574,6 +3574,10 @@ std::string cUnit::getUnitStatusForMessageBar() {
 
 }
 
+bool cUnit::isAttackingUnit() {
+    return getUnitInfo().canAttackAirUnits || getUnitInfo().canAttackUnits;
+}
+
 void cUnit::takeDamage(int damage) {
     takeDamage(damage, -1, -1);
 }

--- a/gameobjects/units/cUnit.cpp
+++ b/gameobjects/units/cUnit.cpp
@@ -3185,7 +3185,7 @@ void cUnit::draw_debug() {
     }
 }
 
-void cUnit::takeDamage(int damage) {
+void cUnit::takeDamage(int damage, int unitWhoDealsDamage, int structureWhoDealsDamage) {
     iHitPoints -= damage;
     if (isDead()) {
         die(true, false);
@@ -3211,13 +3211,23 @@ void cUnit::takeDamage(int damage) {
             // unit does not explode in this case, simply vanishes
             die(false, false);
         } else {
+            auto originType = eBuildType::UNKNOWN;
+            auto originId = -1;
+            if (unitWhoDealsDamage > -1) {
+                originType = eBuildType::UNIT;
+                originId = unitWhoDealsDamage;
+            } else if (structureWhoDealsDamage > -1) {
+                originId = structureWhoDealsDamage;
+                originType = eBuildType::STRUCTURE;
+            }
             s_GameEvent event {
                     .eventType = eGameEventType::GAME_EVENT_DAMAGED,
                     .entityType = eBuildType::UNIT,
                     .entityID = iID,
                     .player = getPlayer(),
                     .entitySpecificType = getType(),
-                    .originId = -1 // for now we don't know
+                    .originId = originId,
+                    .originType = originType,
             };
 
             game.onNotifyGameEvent(event);
@@ -3527,7 +3537,6 @@ void cUnit::think_harvester() {
     }
 }
 
-
 void cUnit::setAction(eActionType action) {
     log(fmt::format("setAction() from current action {} to new action {}", eActionTypeString(m_action),
                         eActionTypeString(action)));
@@ -3565,6 +3574,9 @@ std::string cUnit::getUnitStatusForMessageBar() {
 
 }
 
+void cUnit::takeDamage(int damage) {
+    takeDamage(damage, -1, -1);
+}
 
 // return new valid ID
 int UNIT_NEW() {

--- a/gameobjects/units/cUnit.h
+++ b/gameobjects/units/cUnit.h
@@ -412,6 +412,8 @@ public:
 
     void thinkFast();
 
+    bool isAttackingUnit();
+
     std::string getUnitStatusForMessageBar();
     std::string getHarvesterStatusForMessageBar();
 

--- a/gameobjects/units/cUnit.h
+++ b/gameobjects/units/cUnit.h
@@ -320,7 +320,7 @@ public:
         return m_action == eActionType::GUARD;
     }
 
-    void takeDamage(int damage);
+    void takeDamage(int damage, int unitWhoDealsDamage, int structureWhoDealsDamage);
 
     void setHp(int hp) {
         // debug purposes only
@@ -436,6 +436,8 @@ private:
 
     void forgetAboutCurrentPathAndPrepareToCreateNewOne();
     void forgetAboutCurrentPathAndPrepareToCreateNewOne(int timeToWait);
+
+    void takeDamage(int damage);
 
     int iCell;          // cell of unit
 

--- a/include/enums.h
+++ b/include/enums.h
@@ -109,7 +109,8 @@ enum eBuildType {
     UNIT,      // 1
     UPGRADE,   // 2
     SPECIAL,   // 3
-    BULLET     // 4 (ie, used for super weapon)
+    BULLET,    // 4 (ie, used for super weapon)
+    UNKNOWN    // 5 -> use for unknown
 };
 
 inline const char* eBuildTypeString(const eBuildType &buildType) {
@@ -119,8 +120,9 @@ inline const char* eBuildTypeString(const eBuildType &buildType) {
         case eBuildType::STRUCTURE: return "STRUCTURE";
         case eBuildType::BULLET: return "BULLET";
         case eBuildType::UPGRADE: return "UPGRADE";
+        case eBuildType::UNKNOWN: return "UNKNOWN";
         default:
-            assert(false && "Unknown buildType?");
+            assert(false && "Undefined buildType?");
             break;
     }
     return "";

--- a/include/sGameEvent.h
+++ b/include/sGameEvent.h
@@ -18,8 +18,9 @@ struct s_GameEvent {
     /**
      * kind of entity this applies to.
      * In case of eventType == DISCOVERED, this is the entityType being discovered
+     * In case of eventType == GAME_EVENT_DAMAGED, this is the entityType being damaged
      */
-    eBuildType entityType = eBuildType::SPECIAL;
+    eBuildType entityType = eBuildType::UNKNOWN;
 
     /**
      * which entity? (ID),
@@ -37,7 +38,9 @@ struct s_GameEvent {
     bool isReinforce = false;       // only applicable for UNIT and CREATED events. So we can distinguish between 'normal' CREATED units and reinforced units.
     cBuildingListItem *buildingListItem = nullptr; // if buildingListItem is ready (special, or not)
     cBuildingList *buildingList = nullptr; // in case buildingList is available (or not)
-    int originId = -1; // in case damaged event, this is the UNIT id that damaged it
+
+    int originId = -1; // in case GAME_EVENT_DAMAGED, this is the id that inflicted damage
+    eBuildType originType = eBuildType::UNKNOWN; // in case GAME_EVENT_DAMAGED, this is the kind of entity that inflicted damage
 
     // TODO: figure out a way to have bags of data depending on type of event without the need of expanding this generic GAME_EVENT struct
 

--- a/include/structs.h
+++ b/include/structs.h
@@ -75,6 +75,7 @@ struct s_UnitInfo {
 
   // attack related
   bool canAttackAirUnits;   // ie for rocket typed units
+  bool canAttackUnits;   // a unit used for attacking other units? (ie, mvc or harvester is no)
 
   bool canEnterAndDamageStructure;  // can this unit enter a structure and damage it? (and eventually capture?)
   bool attackIsEnterStructure;      // for saboteur only really

--- a/player/brains/actions/cRespondToThreatAction.cpp
+++ b/player/brains/actions/cRespondToThreatAction.cpp
@@ -1,0 +1,83 @@
+#include "cRespondToThreatAction.h"
+
+#include "player/cPlayer.h"
+#include "d2tmc.h"
+
+#include <vector>
+
+cRespondToThreatAction::cRespondToThreatAction(cPlayer *player, cUnit * threat, cUnit * victim, int cellOriginOfThreat, int maxUnitsToOrder)
+:
+m_player(player),
+m_threat(threat),
+m_cellOriginOfThreat(cellOriginOfThreat),
+m_victim(victim),
+m_maxUnitsToOrder(maxUnitsToOrder)
+{
+
+}
+
+void cRespondToThreatAction::execute() {
+    // be aware: this also returns the victim unit!
+    const std::vector<sEntityForDistance> &units = m_player->getAllMyUnitsOrderClosestToCell(m_cellOriginOfThreat);
+
+    int skipThisUnit = -1;
+    if (m_victim) {
+        if (m_threat && !m_threat->isInfantryUnit()) {
+            if (m_victim->isHarvester()) {
+                if (m_victim->isIdle()) {
+                    eHeadTowardsStructureResult result = m_victim->findBestStructureCandidateAndHeadTowardsItOrWait(
+                            REFINERY,
+                            true,
+                            INTENT_UNLOAD_SPICE);
+
+                    if (result == eHeadTowardsStructureResult::FAILED_NO_STRUCTURE_AVAILABLE) {
+                        m_victim->retreatToNearbyBase();
+                    }
+                }
+            }
+
+            // do not engage this unit
+            skipThisUnit = m_victim->iID;
+        }
+    }
+
+    if (m_threat) {
+        if (m_threat->isAirbornUnit()) {
+            int unitsOrdered = 0;
+            // find units that can counter-attack an air unit
+            for (auto &ufd: units) {
+                cUnit &pUnit = unit[ufd.entityId];
+                if (pUnit.iID == skipThisUnit) continue;
+                if (!pUnit.isIdle()) continue;
+                if (!pUnit.canAttackAirUnits()) continue;
+                if (pUnit.isHarvester()) continue; // harvesters cannot attack air units
+                if (pUnit.isAirbornUnit()) continue; // you cannot order air units
+
+                // move unit to where air unit is/was, so we get close to counter-attack
+                pUnit.move_to(m_cellOriginOfThreat);
+                unitsOrdered++;
+
+                if (unitsOrdered > m_maxUnitsToOrder) break;
+            }
+            return;
+        }
+    }
+
+    int unitsOrdered = 0;
+
+    for (auto & ufd : units) {
+        cUnit &pUnit = unit[ufd.entityId];
+        if (pUnit.iID == skipThisUnit) continue;
+        if (!pUnit.isIdle()) continue;
+        if (!pUnit.isAttackingUnit()) continue; // is a unit that is used generally for attacking
+        if (pUnit.isAirbornUnit()) continue; // you cannot order air units
+
+        // TODO:
+        // we can do more smart things here depending on the kind of unit that attacks us
+        // and thus which unit we should send to counter-attack?
+        pUnit.attackAt(m_cellOriginOfThreat);
+        unitsOrdered++;
+
+        if (unitsOrdered > m_maxUnitsToOrder) break;
+    }
+}

--- a/player/brains/actions/cRespondToThreatAction.h
+++ b/player/brains/actions/cRespondToThreatAction.h
@@ -1,0 +1,45 @@
+#pragma once
+
+class cUnit;
+class cPlayer;
+
+/**
+ * A simple approach instead of having a function lurking somewhere. We might even benefit from having 'actions' to
+ * re-use in AI's. Especially since the Campaign and Skirmish AI's have a lot of overlap.
+ *
+ * However, by then we might want to have an abstraction for "actions" as well. However, lets not over-engineer.
+ *
+ * Keep it simple for now.
+ *
+ * --------
+ *
+ * This class will make a player respond to a certain 'threat'. It will do that by retaliating with an amount of
+ * units (given by 'maxUnitsToOrder' constructor argument). It will take into consideration if a victim unit was
+ * passed in. Meaning, when that is a non-attacking unit (ie a Harvester), it will try to run over infantry units (if
+ * they were a threat) - or it will flee.
+ *
+ * When air units attack, only retaliate with anti-air units.
+ */
+class cRespondToThreatAction {
+
+public:
+    cRespondToThreatAction(cPlayer *player, cUnit * threat, cUnit * victim, int cellOriginOfThreat, int maxUnitsToOrder);
+
+    void execute();
+
+private:
+    // player responding to threat
+    cPlayer *m_player;
+
+    // Cause of threat (currently only a unit can be a threat)
+    // pointer because it can be nullptr! (ie a structure can be a threat)
+    cUnit * m_threat;
+    int m_cellOriginOfThreat;
+
+    // the unit that was damaged by threat
+    cUnit * m_victim;
+
+    // the amount of units to use to retaliate
+    int m_maxUnitsToOrder;
+
+};

--- a/player/brains/cPlayerBrainCampaign.cpp
+++ b/player/brains/cPlayerBrainCampaign.cpp
@@ -1,6 +1,8 @@
 #include "include/d2tmh.h"
 
 #include "cPlayerBrainCampaign.h"
+#include "actions/cRespondToThreatAction.h"
+
 #include "enums.h"
 
 #include <fmt/core.h>
@@ -204,18 +206,20 @@ namespace brains {
     }
 
     void cPlayerBrainCampaign::onMyUnitAttacked(const s_GameEvent &event) {
-        cUnit &pUnit = unit[event.entityID];
-        if (pUnit.isHarvester()) {
-            if (pUnit.isIdle()) {
-                eHeadTowardsStructureResult result = pUnit.findBestStructureCandidateAndHeadTowardsItOrWait(REFINERY,
-                                                                                                            true,
-                                                                                                            INTENT_UNLOAD_SPICE);
+        if (event.originType == eBuildType::UNKNOWN) {
+            // don't know who attacked us; ignore
+            return;
+        }
 
-                if (result == eHeadTowardsStructureResult::FAILED_NO_STRUCTURE_AVAILABLE) {
-                    pUnit.retreatToNearbyBase();
-                }
-            }
-            respondToThreat(event.atCell, false, 2 + rnd(4));
+        cUnit *threat = nullptr;
+        if (event.originType == eBuildType::UNIT) {
+            assert(event.originId > -1);
+            threat = &unit[event.originId];
+        }
+
+        cUnit &victim = unit[event.entityID];
+        if (victim.isHarvester()) {
+            respondToThreat(threat, &victim, event.atCell, 2 + rnd(4));
         }
     }
 
@@ -241,9 +245,7 @@ namespace brains {
             }
 
             int cell = originUnit.getCell();
-            bool attackerIsAirUnit = originUnit.isAirbornUnit();
-
-            respondToThreat(cell, attackerIsAirUnit, 2 + rnd(4));
+            respondToThreat(&originUnit, nullptr, cell, 2 + rnd(4));
         }
     }
 
@@ -1665,7 +1667,7 @@ namespace brains {
                             m_discoveredEnemyAtCell.insert(event.atCell);
 
                             if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
-                                respondToThreat(event.atCell, pUnit.isAirbornUnit(), 2 + rnd(4));
+                                respondToThreat(&pUnit, nullptr, event.atCell, 2 + rnd(4));
                             }
                         }
                     } else if (event.entityType == eBuildType::STRUCTURE) {
@@ -1717,7 +1719,7 @@ namespace brains {
                         cUnit &pUnit = unit[event.entityID];
                         if (pUnit.isValid() && !pUnit.getPlayer()->isSameTeamAs(player)) {
                             if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
-                                respondToThreat(event.atCell, pUnit.isAirbornUnit(), 2 + rnd(4));
+                                respondToThreat(&pUnit, nullptr, event.atCell, 2 + rnd(4));
                             }
                         }
                     }
@@ -1740,40 +1742,8 @@ namespace brains {
                 txt)
         );
     }
-    void cPlayerBrainCampaign::respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit, int maxUnitsToOrder) {
-        const std::vector<sEntityForDistance> &units = player->getAllMyUnitsOrderClosestToCell(cellOriginOfThreat);
 
-        if (attackerIsAirUnit) {
-            int unitsOrdered = 0;
-            // find units that can counter-attack an air unit
-            for (auto & ufd : units) {
-                cUnit &pUnit = unit[ufd.entityId];
-                if (!pUnit.isIdle()) continue;
-                if (!pUnit.canAttackAirUnits()) continue;
-                if (pUnit.isAirbornUnit()) continue; // you cannot order air units
-
-                // move unit to where air unit is/was, so we get close to counter-attack
-                pUnit.move_to(cellOriginOfThreat);
-                unitsOrdered++;
-
-                if (unitsOrdered > maxUnitsToOrder) break;
-            }
-        } else {
-            int unitsOrdered = 0;
-
-            for (auto & ufd : units) {
-                cUnit &pUnit = unit[ufd.entityId];
-                if (!pUnit.isIdle()) continue;
-                if (pUnit.isAirbornUnit()) continue; // you cannot order air units
-
-                // TODO:
-                // we can do more smart things here depending on the kind of unit that attacks us
-                // and thus which unit we should send to counter-attack
-                pUnit.attackAt(cellOriginOfThreat);
-                unitsOrdered++;
-
-                if (unitsOrdered > maxUnitsToOrder) break;
-            }
-        }
+    void cPlayerBrainCampaign::respondToThreat(cUnit *threat, cUnit *victim, int cellOriginOfThreat, int maxUnitsToOrder) {
+        cRespondToThreatAction(this->player, threat, victim, cellOriginOfThreat, maxUnitsToOrder).execute();
     }
 }

--- a/player/brains/cPlayerBrainCampaign.h
+++ b/player/brains/cPlayerBrainCampaign.h
@@ -125,7 +125,7 @@ namespace brains {
 
         void produceLevel9Missions(int trikeKind, int infantryKind);
 
-        void respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit, int maxUnitsToOrder);
+        void respondToThreat(cUnit *threat, cUnit *victim, int cellOriginOfThreat, int maxUnitsToOrder);
     };
 
 }

--- a/player/brains/cPlayerBrainSkirmish.cpp
+++ b/player/brains/cPlayerBrainSkirmish.cpp
@@ -278,9 +278,10 @@ namespace brains {
 
                     if (unitsOrdered > maxUnitsToOrder) break;
                 }
+                return;
             }
-            return;
         }
+
         int unitsOrdered = 0;
 
         for (auto & ufd : units) {

--- a/player/brains/cPlayerBrainSkirmish.h
+++ b/player/brains/cPlayerBrainSkirmish.h
@@ -190,7 +190,7 @@ namespace brains {
 
         void produceEconomyImprovingMissions();
 
-        void respondToThreat(cUnit * victim, int cellOriginOfThreat, cUnit * threat, int maxUnitsToOrder);
+        void respondToThreat(cUnit *threat, cUnit *victim, int cellOriginOfThreat, int maxUnitsToOrder);
     };
 
 }

--- a/player/brains/cPlayerBrainSkirmish.h
+++ b/player/brains/cPlayerBrainSkirmish.h
@@ -190,7 +190,7 @@ namespace brains {
 
         void produceEconomyImprovingMissions();
 
-        void respondToThreat(int cellOriginOfThreat, bool attackerIsAirUnit, int maxUnitsToOrder);
+        void respondToThreat(cUnit * victim, int cellOriginOfThreat, cUnit * threat, int maxUnitsToOrder);
     };
 
 }

--- a/utils/common.cpp
+++ b/utils/common.cpp
@@ -1837,8 +1837,10 @@ const char* toStringBuildTypeSpecificType(const eBuildType &buildType, const int
             return sBulletInfo[specificTypeId].description;
         case eBuildType::UPGRADE:
             return sUpgradeInfo[specificTypeId].description;
+        case eBuildType::UNKNOWN:
+            return "Unknown";
         default:
-            assert(false && "Unknown buildType?");
+            assert(false && "Undefined buildType?");
             break;
     }
     return "";

--- a/utils/common.cpp
+++ b/utils/common.cpp
@@ -145,6 +145,7 @@ void install_units() {
 
         // attack related
         unitInfo.canAttackAirUnits = false;
+        unitInfo.canAttackUnits = false;
 
         // capturing / damage upon entering structure related
         unitInfo.canEnterAndDamageStructure = false;
@@ -210,6 +211,7 @@ void install_units() {
     sUnitInfo[DEVASTATOR].renderSmokeOnUnitWhenThresholdMet = true;
     sUnitInfo[DEVASTATOR].smokeHpFactor = 0.5f;
     sUnitInfo[DEVASTATOR].canGuard = true;
+    sUnitInfo[DEVASTATOR].canAttackUnits = true;
     strcpy(sUnitInfo[DEVASTATOR].name, "Devastator");
 
     // Unit        : Harvester
@@ -245,6 +247,7 @@ void install_units() {
     sUnitInfo[TANK].renderSmokeOnUnitWhenThresholdMet = true;
     sUnitInfo[TANK].smokeHpFactor = 0.5f;
     sUnitInfo[TANK].canGuard = true;
+    sUnitInfo[TANK].canAttackUnits = true;
     strcpy(sUnitInfo[TANK].name, "Tank");
 
 
@@ -265,6 +268,7 @@ void install_units() {
     sUnitInfo[SIEGETANK].renderSmokeOnUnitWhenThresholdMet = true;
     sUnitInfo[SIEGETANK].smokeHpFactor = 0.5f;
     sUnitInfo[SIEGETANK].canGuard = true;
+    sUnitInfo[SIEGETANK].canAttackUnits = true;
     strcpy(sUnitInfo[SIEGETANK].name, "Siege Tank");
 
     // Unit        : MCV
@@ -297,6 +301,7 @@ void install_units() {
     sUnitInfo[DEVIATOR].renderSmokeOnUnitWhenThresholdMet = true;
     sUnitInfo[DEVIATOR].smokeHpFactor = 0.5f;
     sUnitInfo[DEVIATOR].canGuard = true;
+    sUnitInfo[DEVIATOR].canAttackUnits = true;
     strcpy(sUnitInfo[DEVIATOR].name, "Deviator");
 
     // Unit        : Launcher
@@ -317,6 +322,7 @@ void install_units() {
     sUnitInfo[LAUNCHER].renderSmokeOnUnitWhenThresholdMet = true;
     sUnitInfo[LAUNCHER].smokeHpFactor = 0.5f;
     sUnitInfo[LAUNCHER].canGuard = true;
+    sUnitInfo[LAUNCHER].canAttackUnits = true;
     strcpy(sUnitInfo[LAUNCHER].name, "Launcher");
 
     // Unit        : Quad
@@ -336,6 +342,7 @@ void install_units() {
     sUnitInfo[QUAD].renderSmokeOnUnitWhenThresholdMet = true;
     sUnitInfo[QUAD].smokeHpFactor = 0.5f;
     sUnitInfo[QUAD].canGuard = true;
+    sUnitInfo[QUAD].canAttackUnits = true;
     strcpy(sUnitInfo[QUAD].name, "Quad");
 
 
@@ -355,6 +362,7 @@ void install_units() {
     sUnitInfo[TRIKE].renderSmokeOnUnitWhenThresholdMet = true;
     sUnitInfo[TRIKE].smokeHpFactor = 0.5f;
     sUnitInfo[TRIKE].canGuard = true;
+    sUnitInfo[TRIKE].canAttackUnits = true;
     strcpy(sUnitInfo[TRIKE].name, "Trike");
 
     // Unit        : Raider Trike (Ordos trike)
@@ -374,6 +382,7 @@ void install_units() {
     sUnitInfo[RAIDER].renderSmokeOnUnitWhenThresholdMet = true;
     sUnitInfo[RAIDER].smokeHpFactor = 0.5f;
     sUnitInfo[RAIDER].canGuard = true;
+    sUnitInfo[RAIDER].canAttackUnits = true;
 
     // Unit        : Frigate
     // Description : Frigate
@@ -417,6 +426,7 @@ void install_units() {
     sUnitInfo[SONICTANK].renderSmokeOnUnitWhenThresholdMet = true;
     sUnitInfo[SONICTANK].smokeHpFactor = 0.5f;
     sUnitInfo[SONICTANK].canGuard = true;
+    sUnitInfo[SONICTANK].canAttackUnits = true;
 
     strcpy(sUnitInfo[SONICTANK].name, "Sonic Tank");
 
@@ -439,6 +449,7 @@ void install_units() {
     sUnitInfo[SOLDIER].attackIsEnterStructure = false;
     sUnitInfo[SOLDIER].damageOnEnterStructure = 10.0f;
     sUnitInfo[SOLDIER].canGuard = true;
+    sUnitInfo[SOLDIER].canAttackUnits = true;
     strcpy(sUnitInfo[SOLDIER].name, "Soldier");
 
 
@@ -462,6 +473,7 @@ void install_units() {
     sUnitInfo[INFANTRY].attackIsEnterStructure = false;
     sUnitInfo[INFANTRY].damageOnEnterStructure = 25.0f;
     sUnitInfo[INFANTRY].canGuard = true;
+    sUnitInfo[INFANTRY].canAttackUnits = true;
     strcpy(sUnitInfo[INFANTRY].name, "Light Infantry");
 
     // Unit        : Single Trooper
@@ -486,6 +498,7 @@ void install_units() {
     sUnitInfo[TROOPER].bulletTypeSecondary = BULLET_SMALL;
     sUnitInfo[TROOPER].fireSecondaryWithinRange = 2;
     sUnitInfo[TROOPER].canGuard = true;
+    sUnitInfo[TROOPER].canAttackUnits = true;
 
     // Unit        : Group Trooper
     // Description : 3 troopers
@@ -510,6 +523,7 @@ void install_units() {
     sUnitInfo[TROOPERS].bulletTypeSecondary = BULLET_SMALL;
     sUnitInfo[TROOPERS].fireSecondaryWithinRange = 2;
     sUnitInfo[TROOPERS].canGuard = true;
+    sUnitInfo[TROOPERS].canAttackUnits = true;
 
     // Unit        : Fremen
     // Description : A single fremen
@@ -527,6 +541,7 @@ void install_units() {
     sUnitInfo[UNIT_FREMEN_ONE].canBeSquished = true;
     sUnitInfo[UNIT_FREMEN_ONE].canAttackAirUnits = true;
     sUnitInfo[UNIT_FREMEN_ONE].canGuard = true;
+    sUnitInfo[UNIT_FREMEN_ONE].canAttackUnits = true;
 
 //  units[UNIT_FREMEN_ONE].listType=LIST_PALACE;
 //  units[UNIT_FREMEN_ONE].subListId=0;
@@ -547,6 +562,7 @@ void install_units() {
     sUnitInfo[UNIT_FREMEN_THREE].canBeSquished = true;
     sUnitInfo[UNIT_FREMEN_THREE].canAttackAirUnits = true;
     sUnitInfo[UNIT_FREMEN_THREE].canGuard = true;
+    sUnitInfo[UNIT_FREMEN_THREE].canAttackUnits = true;
 //  units[UNIT_FREMEN_THREE].listType=LIST_PALACE;
 //  units[UNIT_FREMEN_THREE].subListId=0;
 
@@ -590,6 +606,7 @@ void install_units() {
     sUnitInfo[SANDWORM].icon = ICON_UNIT_SANDWORM;
     sUnitInfo[SANDWORM].squish = false;
     sUnitInfo[SANDWORM].canGuard = true;
+    sUnitInfo[SANDWORM].canAttackUnits = true;
 
 
     // Unit        : <name>


### PR DESCRIPTION
enhances the #429 ticket and fixes #479

- when a unit is under attack, we pass in the kind of threat and its ID
- we respond to units (not structures) in a more sophisticated manner
   - when victim is a harvester, and it is under attack by an infantry unit. The Harvester will try to squish it.
   - when the harvester encounters a non-infantry unit, the harvester will flee to refinery, or return to base when no refinery present
- when retaliating, do not include harvester when it cannot retaliate (ie squish infantry) - this fixes #479

The only thing I don't like is the amount of null checks, since we have separate classes for each kind of "thing" in the game. ie, a Unit is a class, a Structure is a class. It would be nicer if they both would have shared a base class `Entity`  or something to make things more easy to communicate...

