### PR TITLE
Refactor: Change the way how settings.ini is read and applied within the game

### DIFF
--- a/resources/bin/settings.ini
+++ b/resources/bin/settings.ini
@@ -22,6 +22,9 @@ RocketTurretsDownOnLowPower=true
 # this is the base-dir for [datafile] and [font] entries
 GameDir=data
 
+# this is the game rules file
+GameRules=game.ini
+
 [DATAFILE]
 GFXDATA=sdl_data.dat
 GFXINTER=sdl_inter.dat

--- a/src/cGame.h
+++ b/src/cGame.h
@@ -32,10 +32,11 @@ class cPlatformLayerInit;
 class cPlayer;
 class cSoundPlayer;
 class cScreenInit;
-class cHandleArgument;
+// class cHandleArgument;
 class cHousesInfo;
 class cReinforcements;
 class cPreviewMaps;
+class GameSettings;
 
 // Naming thoughts:
 // member variables, start with m_<camelCasedVariableName>
@@ -59,7 +60,7 @@ public:
         m_gameFilename = filename;
     }
 
-    int handleArguments(int argc, char **argv);
+    // int handleArguments(int argc, char **argv);
 
     bool m_windowed;			    // windowed
     bool m_allowRepeatingReinforcements; // Dune 2 fix: by default false
@@ -269,6 +270,8 @@ public:
     void setDebugMode(bool value) {
         m_debugMode = value;
     }
+    void applySettings(const GameSettings& gs);
+    // GameSettings loadSettingsFromIni(std::shared_ptr<cIniFile> settings);
 
 private:
     /**
@@ -304,7 +307,7 @@ private:
 
     cTimeManager m_timeManager;
 
-    std::unique_ptr<cHandleArgument> m_handleArgument;
+    // std::unique_ptr<cHandleArgument> m_handleArgument;
     std::shared_ptr<cHousesInfo> m_Houses;
 
     bool m_missionWasWon;               // hack: used for state transitioning :/
@@ -341,7 +344,7 @@ private:
 
     cGameState *m_states[GAME_MAX_STATES];
 
-    bool loadSettings(std::shared_ptr<cIniFile> settings);
+    // bool loadSettings(std::shared_ptr<cIniFile> settings);
     void updateMouseAndKeyboardState();
     void updateGamePlaying();
     void drawState();           // draws currentState, or calls any of the other functions which don't have state obj yet

--- a/src/cGame.h
+++ b/src/cGame.h
@@ -32,7 +32,6 @@ class cPlatformLayerInit;
 class cPlayer;
 class cSoundPlayer;
 class cScreenInit;
-// class cHandleArgument;
 class cHousesInfo;
 class cReinforcements;
 class cPreviewMaps;
@@ -59,8 +58,6 @@ public:
     void setGameFilename(const std::string &filename) {
         m_gameFilename = filename;
     }
-
-    // int handleArguments(int argc, char **argv);
 
     bool m_windowed;			    // windowed
     bool m_allowRepeatingReinforcements; // Dune 2 fix: by default false
@@ -270,8 +267,7 @@ public:
     void setDebugMode(bool value) {
         m_debugMode = value;
     }
-    void applySettings(const GameSettings& gs);
-    // GameSettings loadSettingsFromIni(std::shared_ptr<cIniFile> settings);
+    void applySettings(const GameSettings &gs);
 
 private:
     /**
@@ -307,7 +303,6 @@ private:
 
     cTimeManager m_timeManager;
 
-    // std::unique_ptr<cHandleArgument> m_handleArgument;
     std::shared_ptr<cHousesInfo> m_Houses;
 
     bool m_missionWasWon;               // hack: used for state transitioning :/
@@ -344,7 +339,6 @@ private:
 
     cGameState *m_states[GAME_MAX_STATES];
 
-    // bool loadSettings(std::shared_ptr<cIniFile> settings);
     void updateMouseAndKeyboardState();
     void updateGamePlaying();
     void drawState();           // draws currentState, or calls any of the other functions which don't have state obj yet

--- a/src/cGame.h
+++ b/src/cGame.h
@@ -35,7 +35,7 @@ class cScreenInit;
 class cHousesInfo;
 class cReinforcements;
 class cPreviewMaps;
-class GameSettings;
+struct GameSettings;
 
 // Naming thoughts:
 // member variables, start with m_<camelCasedVariableName>
@@ -264,9 +264,11 @@ public:
     bool isDebugMode() {
         return m_debugMode;
     }
+
     void setDebugMode(bool value) {
         m_debugMode = value;
     }
+
     void applySettings(GameSettings *gs);
 
 private:

--- a/src/cGame.h
+++ b/src/cGame.h
@@ -267,7 +267,7 @@ public:
     void setDebugMode(bool value) {
         m_debugMode = value;
     }
-    void applySettings(const GameSettings &gs);
+    void applySettings(GameSettings *gs);
 
 private:
     /**

--- a/src/cGame_logic.cpp
+++ b/src/cGame_logic.cpp
@@ -51,7 +51,6 @@
 #include "utils/Color.hpp"
 
 #include "utils/cFileValidator.h"
-#include "utils/cHandleArgument.h"
 #include "utils/cIniFile.h"
 #include "player/cHousesInfo.h"
 #include "utils/Graphics.hpp"
@@ -87,10 +86,9 @@ cGame::cGame() : m_timeManager(*this)
     m_version = "0.7.0";
 
     m_mentat = nullptr;
-    // m_handleArgument = std::make_unique<cHandleArgument>(this);
 }
 
-void cGame::applySettings(const GameSettings& gs)
+void cGame::applySettings(const GameSettings &gs)
 {
     m_screenW = gs.screenW;
     m_screenH = gs.screenH;
@@ -178,27 +176,6 @@ void cGame::init()
     INI_Install_Game(m_gameFilename);
 }
 
-// bool cGame::loadSettings(std::shared_ptr<cIniFile> settings)
-// {
-//     if (!settings->hasSection(SECTION_SETTINGS)) {
-//         std::cerr << "No [SETTINGS] section found in settings.ini file" << std::endl;
-//         return false;
-//     }
-
-//     const cSection &section = settings->getSection(SECTION_SETTINGS);
-//     game.m_screenW = section.getInt("ScreenWidth");
-//     game.m_screenH = section.getInt("ScreenHeight");
-//     game.m_cameraDragMoveSpeed = section.getDouble("CameraDragMoveSpeed");
-//     game.m_cameraBorderOrKeyMoveSpeed = section.getDouble("CameraBorderOrKeyMoveSpeed");
-//     game.m_cameraEdgeMove = section.getBoolean("CameraEdgeMove");
-//     game.m_windowed = !section.getBoolean("FullScreen");
-//     game.m_allowRepeatingReinforcements = section.getBoolean("AllowRepeatingReinforcements");
-//     game.m_turretsDownOnLowPower = section.getBoolean("AllTurretsDownOnLowPower");
-//     game.m_rocketTurretsDownOnLowPower = section.getBoolean("RocketTurretsDownOnLowPower");
-
-//     return true;
-// }
-
 // TODO: Bad smell (duplicate code)
 // initialize for missions
 void cGame::missionInit()
@@ -229,12 +206,6 @@ void cGame::missionInit()
 
     drawManager->missionInit();
 }
-
-// int cGame::handleArguments(int argc, char **argv)
-// {
-//     return m_handleArgument->handleArguments(argc,argv);
-// }
-
 
 void cGame::initPlayers(bool rememberHouse) const
 {
@@ -847,12 +818,6 @@ bool cGame::setupGame()
     map.setReinforcements(m_reinforcements);
 
     game.init(); // Must be first! (loads game.ini file at the end, which is required before going on...)
-
-    // bool loadSettingsResult = game.loadSettings(settings);
-    // if (!loadSettingsResult) {
-    //     logger->log(LOG_INFO, COMP_INIT, "Loading settings.ini", "Error loading settings.ini", OUTC_FAILED);
-    //     return false;
-    // }
 
     const std::string &gameDir = settings->getStringValue(SECTION_SETTINGS, "GameDir");
     std::unique_ptr<cFileValidator> settingsValidator = std::make_unique<cFileValidator>(gameDir);

--- a/src/cGame_logic.cpp
+++ b/src/cGame_logic.cpp
@@ -55,7 +55,7 @@
 #include "utils/cIniFile.h"
 #include "player/cHousesInfo.h"
 #include "utils/Graphics.hpp"
-
+#include "utils/GameSettings.hpp"
 #include <fmt/core.h>
 
 #include <algorithm>
@@ -87,9 +87,31 @@ cGame::cGame() : m_timeManager(*this)
     m_version = "0.7.0";
 
     m_mentat = nullptr;
-    m_handleArgument = std::make_unique<cHandleArgument>(this);
+    // m_handleArgument = std::make_unique<cHandleArgument>(this);
 }
 
+void cGame::applySettings(const GameSettings& gs)
+{
+    m_screenW = gs.screenW;
+    m_screenH = gs.screenH;
+    m_cameraDragMoveSpeed = gs.cameraDragMoveSpeed;
+    m_cameraBorderOrKeyMoveSpeed = gs.cameraBorderOrKeyMoveSpeed;
+    m_cameraEdgeMove = gs.cameraEdgeMove;
+    m_windowed = gs.windowed;
+    m_allowRepeatingReinforcements = gs.allowRepeatingReinforcements;
+    m_turretsDownOnLowPower = gs.turretsDownOnLowPower;
+    m_rocketTurretsDownOnLowPower = gs.rocketTurretsDownOnLowPower;
+    m_playMusic = gs.playMusic;
+    m_playSound = gs.playSound;
+    m_debugMode = gs.debugMode;
+    m_drawUnitDebug = gs.drawUnitDebug;
+    m_disableAI = gs.disableAI;
+    m_oneAi = gs.oneAi;
+    m_disableWormAi = gs.disableWormAi;
+    m_disableReinforcements = gs.disableReinforcements;
+    m_noAiRest = gs.noAiRest;
+    m_drawUsages = gs.drawUsages;
+}
 
 void cGame::init()
 {
@@ -156,26 +178,26 @@ void cGame::init()
     INI_Install_Game(m_gameFilename);
 }
 
-bool cGame::loadSettings(std::shared_ptr<cIniFile> settings)
-{
-    if (!settings->hasSection(SECTION_SETTINGS)) {
-        std::cerr << "No [SETTINGS] section found in settings.ini file" << std::endl;
-        return false;
-    }
+// bool cGame::loadSettings(std::shared_ptr<cIniFile> settings)
+// {
+//     if (!settings->hasSection(SECTION_SETTINGS)) {
+//         std::cerr << "No [SETTINGS] section found in settings.ini file" << std::endl;
+//         return false;
+//     }
 
-    const cSection &section = settings->getSection(SECTION_SETTINGS);
-    game.m_screenW = section.getInt("ScreenWidth");
-    game.m_screenH = section.getInt("ScreenHeight");
-    game.m_cameraDragMoveSpeed = section.getDouble("CameraDragMoveSpeed");
-    game.m_cameraBorderOrKeyMoveSpeed = section.getDouble("CameraBorderOrKeyMoveSpeed");
-    game.m_cameraEdgeMove = section.getBoolean("CameraEdgeMove");
-    game.m_windowed = !section.getBoolean("FullScreen");
-    game.m_allowRepeatingReinforcements = section.getBoolean("AllowRepeatingReinforcements");
-    game.m_turretsDownOnLowPower = section.getBoolean("AllTurretsDownOnLowPower");
-    game.m_rocketTurretsDownOnLowPower = section.getBoolean("RocketTurretsDownOnLowPower");
+//     const cSection &section = settings->getSection(SECTION_SETTINGS);
+//     game.m_screenW = section.getInt("ScreenWidth");
+//     game.m_screenH = section.getInt("ScreenHeight");
+//     game.m_cameraDragMoveSpeed = section.getDouble("CameraDragMoveSpeed");
+//     game.m_cameraBorderOrKeyMoveSpeed = section.getDouble("CameraBorderOrKeyMoveSpeed");
+//     game.m_cameraEdgeMove = section.getBoolean("CameraEdgeMove");
+//     game.m_windowed = !section.getBoolean("FullScreen");
+//     game.m_allowRepeatingReinforcements = section.getBoolean("AllowRepeatingReinforcements");
+//     game.m_turretsDownOnLowPower = section.getBoolean("AllTurretsDownOnLowPower");
+//     game.m_rocketTurretsDownOnLowPower = section.getBoolean("RocketTurretsDownOnLowPower");
 
-    return true;
-}
+//     return true;
+// }
 
 // TODO: Bad smell (duplicate code)
 // initialize for missions
@@ -208,10 +230,10 @@ void cGame::missionInit()
     drawManager->missionInit();
 }
 
-int cGame::handleArguments(int argc, char **argv)
-{
-    return m_handleArgument->handleArguments(argc,argv);
-}
+// int cGame::handleArguments(int argc, char **argv)
+// {
+//     return m_handleArgument->handleArguments(argc,argv);
+// }
 
 
 void cGame::initPlayers(bool rememberHouse) const
@@ -826,11 +848,11 @@ bool cGame::setupGame()
 
     game.init(); // Must be first! (loads game.ini file at the end, which is required before going on...)
 
-    bool loadSettingsResult = game.loadSettings(settings);
-    if (!loadSettingsResult) {
-        logger->log(LOG_INFO, COMP_INIT, "Loading settings.ini", "Error loading settings.ini", OUTC_FAILED);
-        return false;
-    }
+    // bool loadSettingsResult = game.loadSettings(settings);
+    // if (!loadSettingsResult) {
+    //     logger->log(LOG_INFO, COMP_INIT, "Loading settings.ini", "Error loading settings.ini", OUTC_FAILED);
+    //     return false;
+    // }
 
     const std::string &gameDir = settings->getStringValue(SECTION_SETTINGS, "GameDir");
     std::unique_ptr<cFileValidator> settingsValidator = std::make_unique<cFileValidator>(gameDir);
@@ -947,6 +969,7 @@ bool cGame::setupGame()
     }
     else {
         logger->log(LOG_INFO, COMP_INIT, "Load data", "Hooked datafile: " + settingsValidator->getName(eGameDirFileName::GFXDATA), OUTC_SUCCESS);
+        // memcpy(general_palette, gfxdata[PALETTE_D2TM], sizeof general_palette);
     }
 
     gfxinter = std::make_shared<Graphics>(renderer,settingsValidator->getFullName(eGameDirFileName::GFXINTER));

--- a/src/cGame_logic.cpp
+++ b/src/cGame_logic.cpp
@@ -109,6 +109,7 @@ void cGame::applySettings(GameSettings *gs)
     m_disableReinforcements = gs->disableReinforcements;
     m_noAiRest = gs->noAiRest;
     m_drawUsages = gs->drawUsages;
+    m_gameFilename = gs->gameFilename;
 }
 
 void cGame::init()
@@ -812,7 +813,9 @@ bool cGame::setupGame()
 
     // SETTINGS.INI
     std::shared_ptr<cIniFile> settings = std::make_shared<cIniFile>("settings.ini", m_debugMode);
-    std::shared_ptr<cIniFile> gamesCfg = std::make_shared<cIniFile>("game.ini", m_debugMode);
+
+    // TODO(SETTINGS) -> The game rules file is loaded via here, but *also* via `INSTALL_GAME()`!
+    std::shared_ptr<cIniFile> gamesCfg = std::make_shared<cIniFile>(m_gameFilename, m_debugMode);
 
     m_reinforcements = std::make_shared<cReinforcements>();
     map.setReinforcements(m_reinforcements);

--- a/src/cGame_logic.cpp
+++ b/src/cGame_logic.cpp
@@ -88,27 +88,27 @@ cGame::cGame() : m_timeManager(*this)
     m_mentat = nullptr;
 }
 
-void cGame::applySettings(const GameSettings &gs)
+void cGame::applySettings(GameSettings *gs)
 {
-    m_screenW = gs.screenW;
-    m_screenH = gs.screenH;
-    m_cameraDragMoveSpeed = gs.cameraDragMoveSpeed;
-    m_cameraBorderOrKeyMoveSpeed = gs.cameraBorderOrKeyMoveSpeed;
-    m_cameraEdgeMove = gs.cameraEdgeMove;
-    m_windowed = gs.windowed;
-    m_allowRepeatingReinforcements = gs.allowRepeatingReinforcements;
-    m_turretsDownOnLowPower = gs.turretsDownOnLowPower;
-    m_rocketTurretsDownOnLowPower = gs.rocketTurretsDownOnLowPower;
-    m_playMusic = gs.playMusic;
-    m_playSound = gs.playSound;
-    m_debugMode = gs.debugMode;
-    m_drawUnitDebug = gs.drawUnitDebug;
-    m_disableAI = gs.disableAI;
-    m_oneAi = gs.oneAi;
-    m_disableWormAi = gs.disableWormAi;
-    m_disableReinforcements = gs.disableReinforcements;
-    m_noAiRest = gs.noAiRest;
-    m_drawUsages = gs.drawUsages;
+    m_screenW = gs->screenW;
+    m_screenH = gs->screenH;
+    m_cameraDragMoveSpeed = gs->cameraDragMoveSpeed;
+    m_cameraBorderOrKeyMoveSpeed = gs->cameraBorderOrKeyMoveSpeed;
+    m_cameraEdgeMove = gs->cameraEdgeMove;
+    m_windowed = gs->windowed;
+    m_allowRepeatingReinforcements = gs->allowRepeatingReinforcements;
+    m_turretsDownOnLowPower = gs->turretsDownOnLowPower;
+    m_rocketTurretsDownOnLowPower = gs->rocketTurretsDownOnLowPower;
+    m_playMusic = gs->playMusic;
+    m_playSound = gs->playSound;
+    m_debugMode = gs->debugMode;
+    m_drawUnitDebug = gs->drawUnitDebug;
+    m_disableAI = gs->disableAI;
+    m_oneAi = gs->oneAi;
+    m_disableWormAi = gs->disableWormAi;
+    m_disableReinforcements = gs->disableReinforcements;
+    m_noAiRest = gs->noAiRest;
+    m_drawUsages = gs->drawUsages;
 }
 
 void cGame::init()

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -2107,7 +2107,7 @@ void INI_LOAD_BRIEFING(int iHouse, int iScenarioFind, int iSectionFind, cAbstrac
 // Game.ini loader
 void INI_Install_Game(std::string filename)
 {
-    logbook("[GAME.INI] Opening file");
+    logbook("[GameRules] Opening file");
 
     FILE *stream;
     int section = INI_GAME;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,22 +73,16 @@ TTF_Font *gr_bene_font; // benegesserit font for size XXL
 */
 int main(int argc, char **argv)
 {
-
-    cHandleArgument handleArg;
-
-
-    // game.applyArguments(handleArg);
-    
+    // read file config
     std::shared_ptr<cIniFile> settingsIniFile = std::make_shared<cIniFile>("settings.ini", true);
     GameSettings settings = loadSettingsFromIni(settingsIniFile.get());
+    //read prompt config
+    cHandleArgument handleArg;
     int parseResult = handleArg.handleArguments(argc, argv, settings);
     if (parseResult < 0) return 1; // Affiche l'aide ou erreur
-
+    // apply to game
     game.applySettings(settings);
 
-    // if (game.handleArguments(argc, argv) < 0) {
-    //     return 0;
-    // }
     game.setGameFilename("game.ini");
     try {
         if (game.setupGame()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,19 @@ int main(int argc, char **argv)
     
     //read prompt config
     cHandleArgument handleArg;
+    try {
         int parseResult = handleArg.handleArguments(argc, argv, settings.get());
+        if (parseResult < 0) {
+            cLogger::getInstance()->log(LOG_ERROR, COMP_GAMEINI, "HandleArgument", "Incorrect arguments");
+            return 1;
+        }
+    }
+    catch (std::runtime_error &e) {
+        cLogger::getInstance()->log(LOG_ERROR, eLogComponent::COMP_GAMEINI, "HandleArgument", fmt::format("Runtime_error on parsing : {}", e.what()));
+        std::cerr << fmt::format("Error: {}\n\n", e.what());
+        return 1;
+    }
+
     // apply to game
     game.applySettings(settings.get());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,9 @@
 #include "drawers/SDLDrawer.hpp"
 
 #include "utils/Graphics.hpp"
+
+#include "utils/cHandleArgument.h"
+#include "utils/common.h"
 #include <string>
 
 #include <iostream>
@@ -65,18 +68,28 @@ TTF_Font *bene_font;	// benegesserit font.
 TTF_Font *small_font;	// small font.
 TTF_Font *gr_bene_font; // benegesserit font for size XXL
 
-
 /**
 	Entry point of the game
 */
 int main(int argc, char **argv)
 {
+
+    cHandleArgument handleArg;
+
+
+    // game.applyArguments(handleArg);
+    
+    std::shared_ptr<cIniFile> settingsIniFile = std::make_shared<cIniFile>("settings.ini", true);
+    GameSettings settings = loadSettingsFromIni(settingsIniFile.get());
+    int parseResult = handleArg.handleArguments(argc, argv, settings);
+    if (parseResult < 0) return 1; // Affiche l'aide ou erreur
+
+    game.applySettings(settings);
+
+    // if (game.handleArguments(argc, argv) < 0) {
+    //     return 0;
+    // }
     game.setGameFilename("game.ini");
-
-    if (game.handleArguments(argc, argv) < 0) {
-        return 0;
-    }
-
     try {
         if (game.setupGame()) {
             game.run();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,14 +74,13 @@ TTF_Font *gr_bene_font; // benegesserit font for size XXL
 int main(int argc, char **argv)
 {
     // read file config
-    std::shared_ptr<cIniFile> settingsIniFile = std::make_shared<cIniFile>("settings.ini", true);
-    GameSettings settings = loadSettingsFromIni(settingsIniFile.get());
+    std::unique_ptr<GameSettings> settings = loadSettingsFromIni("settings.ini");
+    
     //read prompt config
     cHandleArgument handleArg;
-    int parseResult = handleArg.handleArguments(argc, argv, settings);
-    if (parseResult < 0) return 1; // Affiche l'aide ou erreur
+        int parseResult = handleArg.handleArguments(argc, argv, settings.get());
     // apply to game
-    game.applySettings(settings);
+    game.applySettings(settings.get());
 
     game.setGameFilename("game.ini");
     try {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,12 +80,12 @@ int main(int argc, char **argv)
     try {
         int parseResult = handleArg.handleArguments(argc, argv, settings.get());
         if (parseResult < 0) {
-            cLogger::getInstance()->log(LOG_ERROR, COMP_GAMEINI, "HandleArgument", "Incorrect arguments");
+            cLogger::getInstance()->log(LOG_ERROR, COMP_GAMERULES, "HandleArgument", "Incorrect arguments");
             return 1;
         }
     }
     catch (std::runtime_error &e) {
-        cLogger::getInstance()->log(LOG_ERROR, eLogComponent::COMP_GAMEINI, "HandleArgument", fmt::format("Runtime_error on parsing : {}", e.what()));
+        cLogger::getInstance()->log(LOG_ERROR, eLogComponent::COMP_GAMERULES, "HandleArgument", fmt::format("Runtime_error on parsing : {}", e.what()));
         std::cerr << fmt::format("Error: {}\n\n", e.what());
         return 1;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,10 +73,9 @@ TTF_Font *gr_bene_font; // benegesserit font for size XXL
 */
 int main(int argc, char **argv)
 {
-    // read file config
     std::unique_ptr<GameSettings> settings = loadSettingsFromIni("settings.ini");
     
-    //read prompt config
+    // read command-line arguments, can override settings.ini
     cHandleArgument handleArg;
     try {
         int parseResult = handleArg.handleArguments(argc, argv, settings.get());
@@ -91,10 +90,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    // apply to game
     game.applySettings(settings.get());
 
-    game.setGameFilename("game.ini");
     try {
         if (game.setupGame()) {
             game.run();

--- a/src/utils/GameSettings.hpp
+++ b/src/utils/GameSettings.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <string>
+
+struct GameSettings {
+    int screenW = 800;
+    int screenH = 600;
+    float cameraDragMoveSpeed = 0.5f;
+    float cameraBorderOrKeyMoveSpeed = 0.5f;
+    bool cameraEdgeMove = true;
+    bool windowed = false;
+    bool allowRepeatingReinforcements = false;
+    bool turretsDownOnLowPower = false;
+    bool rocketTurretsDownOnLowPower = false;
+    bool playMusic = true;
+    bool playSound = true;
+    bool debugMode = false;
+    bool drawUnitDebug = false;
+    bool disableAI = false;
+    bool oneAi = false;
+    bool disableWormAi = false;
+    bool disableReinforcements = false;
+    bool noAiRest = false;
+    bool drawUsages = false;
+    std::string gameFilename;
+};

--- a/src/utils/GameSettings.hpp
+++ b/src/utils/GameSettings.hpp
@@ -21,5 +21,5 @@ struct GameSettings {
     bool disableReinforcements = false;
     bool noAiRest = false;
     bool drawUsages = false;
-    std::string gameFilename;
+    std::string gameFilename = "game.ini";
 };

--- a/src/utils/cHandleArgument.cpp
+++ b/src/utils/cHandleArgument.cpp
@@ -2,6 +2,7 @@
 #include "utils/GameSettings.hpp"
 #include <iostream>
 #include <string>
+#include <fmt/core.h>
 
 int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings *settings)
 {
@@ -14,7 +15,7 @@ int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings *setti
         auto itr = optionStrings.find(command);
         if (itr == optionStrings.end()) {
             std::cerr << "Unknown option " << command << ", use --help for instructions\n";
-            return -1;
+            throw std::runtime_error(fmt::format("invokes game with unknown option {}",command));
         }
 
         switch (itr->second) {
@@ -25,6 +26,8 @@ int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings *setti
                 if ((i + 1) < argc) {
                     i++;
                     settings->gameFilename = std::string(argv[i]);
+                } else {
+                    throw std::runtime_error("invokes game but no value assigned");
                 }
                 break;
             case Options::WINDOWED:
@@ -61,12 +64,16 @@ int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings *setti
                 if ((i + 1) < argc) {
                     i++;
                     settings->screenW = std::stoi(argv[i]);
+                } else {
+                    throw std::runtime_error("invokes screenX but no value assigned");
                 }
                 break;
             case Options::SCREENY:
                 if ((i + 1) < argc) {
                     i++;
                     settings->screenH = std::stoi(argv[i]);
+                } else {
+                    throw std::runtime_error("invokes screenY but no value assigned");
                 }
                 break;
             case Options::USAGES:

--- a/src/utils/cHandleArgument.cpp
+++ b/src/utils/cHandleArgument.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <cstdlib> // pour atoi
 
-int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings& settings)
+int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings &settings)
 {
     if (argc < 2) {
         return 0;

--- a/src/utils/cHandleArgument.cpp
+++ b/src/utils/cHandleArgument.cpp
@@ -1,41 +1,10 @@
 #include "cHandleArgument.h"
-#include "cGame.h"
+#include "utils/GameSettings.hpp"
 #include <iostream>
+#include <cstdlib> // pour atoi
 
-cHandleArgument::cHandleArgument(cGame *game) :
-    m_game(game),
-    m_optionToHandleAfter(),
-    m_argumentScreenX(800),
-    m_argumentScreenY(600)
+int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings& settings)
 {
-
-}
-
-cHandleArgument::~cHandleArgument() {}
-
-/**
- * Parses arguments given. Returns 0 on success or < 0 on failure.
- *
- * @param argc
- * @param argv
- * @return
- */
-int cHandleArgument::handleArguments(int argc, char *argv[])
-{
-    // TODO: make this return a config object, and not be tightly coupled to cGame
-    m_game->m_disableAI = false;
-    m_game->m_disableReinforcements = false;
-    m_game->m_drawUsages = false;
-    m_game->m_drawUnitDebug = false;
-    m_game->m_oneAi = false;
-    m_game->m_disableWormAi = false;
-    m_game->m_windowed = false;
-    m_game->m_allowRepeatingReinforcements = false;
-    m_game->m_noAiRest = false;
-    m_game->setDebugMode(false);
-    m_game->setTurretsDownOnLowPower(false);
-    m_game->setRocketTurretsDownOnLowPower(true);
-
     if (argc < 2) {
         return 0;
     }
@@ -44,7 +13,7 @@ int cHandleArgument::handleArguments(int argc, char *argv[])
         std::string command = argv[i];
         auto itr = optionStrings.find(command);
         if (itr == optionStrings.end()) {
-            std::cerr << fmt::format("Unknown option {}, use --help for instructions", command);
+            std::cerr << "Unknown option " << command << ", use --help for instructions\n";
             return -1;
         }
 
@@ -52,121 +21,100 @@ int cHandleArgument::handleArguments(int argc, char *argv[])
             case Options::HELP:
                 printInstructions();
                 return -2;
-            case Options::GAME :
+            case Options::GAME:
                 if ((i + 1) < argc) {
                     i++;
-                    m_game->setGameFilename(std::string(argv[i]));
+                    settings.gameFilename = std::string(argv[i]);
                 }
                 break;
-            case Options::WINDOWED:  // Windowed flag passed, so use that
-                m_optionToHandleAfter[Options::WINDOWED] = true;
+            case Options::WINDOWED:
+                settings.windowed = true;
                 break;
             case Options::NOMUSIC:
-                m_game->m_playMusic = false;
+                settings.playMusic = false;
                 break;
-            case Options::NOSOUND:   // disable all sound effects
-                m_game->m_playMusic = false;
-                m_game->m_playSound = false;
+            case Options::NOSOUND:
+                settings.playSound = false;
                 break;
-            case Options::DEBUG:   // generic debugging enabled
-                m_game->setDebugMode(true);
+            case Options::DEBUG:
+                settings.debugMode = true;
                 break;
-            case Options::DEBUG_UNITS:   // unit debugging enabled
-                m_game->m_drawUnitDebug = true;
+            case Options::DEBUG_UNITS:
+                settings.drawUnitDebug = true;
                 break;
             case Options::NOAI:
-                m_game->m_disableAI = true;
+                settings.disableAI = true;
                 break;
             case Options::ONEAI:
-                m_game->m_oneAi = true;
+                settings.oneAi = true;
                 break;
             case Options::NOWORMAI:
-                m_game->m_disableWormAi = true;
+                settings.disableWormAi = true;
                 break;
             case Options::NOREINFORCEMENTS:
-                m_game->m_disableReinforcements = true;
+                settings.disableReinforcements = true;
                 break;
             case Options::NOAIREST:
-                m_game->m_noAiRest = true;
+                settings.noAiRest = true;
                 break;
             case Options::SCREENX:
                 if ((i + 1) < argc) {
                     i++;
-                    m_optionToHandleAfter[Options::SCREENX] = true;
-                    m_argumentScreenX = atoi(argv[i]);
+                    settings.screenW = std::atoi(argv[i]);
                 }
                 break;
             case Options::SCREENY:
                 if ((i + 1) < argc) {
                     i++;
-                    m_optionToHandleAfter[Options::SCREENY] = true;
-                    m_argumentScreenY = atoi(argv[i]);
+                    settings.screenH = std::atoi(argv[i]);
                 }
                 break;
             case Options::USAGES:
-            default :
-                m_game->m_drawUsages = true;
-                break;
-        }
-    } // arguments passed
-    return 0;
-}
-
-void cHandleArgument::printInstructions() const
-{
-    std::cout << fmt::format("\n");
-    std::cout << fmt::format("Usage: d2tm[.exe] [-windowed] [-screenWidth <width>] ...\n\n");
-    std::cout << fmt::format("Graphics\n");
-    std::cout << fmt::format("--------\n\n");
-    std::cout << fmt::format("-windowed              - Run game in window instead of fullscreen\n");
-    std::cout << fmt::format("-screenWidth <value>   - Width of screen / window (minimum 800)\n");
-    std::cout << fmt::format("-screenHeight <value>  - Height of screen / window (minimum 600)\n");
-    std::cout << fmt::format("\n\n");
-    std::cout << fmt::format("Sound/Music\n");
-    std::cout << fmt::format("-----------\n\n");
-    std::cout << fmt::format("-no-sound              - Run game without any sounds or music\n");
-    std::cout << fmt::format("-no-music              - Use sound effects only, no music\n");
-    std::cout << fmt::format("\n\n");
-    std::cout << fmt::format("Experimental\n");
-    std::cout << fmt::format("------------\n\n");
-    std::cout << fmt::format("-game <filename>       - Specify which file to use instead of game.ini\n");
-    std::cout << fmt::format("\n\n");
-    std::cout << fmt::format("Debugging\n");
-    std::cout << fmt::format("---------\n\n");
-    std::cout << fmt::format("-debug                 - Run in debug mode\n");
-    std::cout << fmt::format("-debug-units           - Draw additional debug info about units\n");
-    std::cout << fmt::format("-noai                  - Disable player AI's\n");
-    std::cout << fmt::format("-nowormai              - Disable worm AI\n");
-    std::cout << fmt::format("-oneai                 - Disable all but one player AI\n");
-    std::cout << fmt::format("-noreinforcements      - Disable reinforcements (Campaign mode)\n");
-    std::cout << fmt::format("-noairest              - Disable initial delay of player AI before becoming active\n");
-    std::cout << fmt::format("-usages                - Draw used units, structures, particles, etc.\n");
-    std::cout << fmt::format("\n\n");
-    std::cout << fmt::format("Examples (Windows)\n");
-    std::cout << fmt::format("------------------\n\n");
-    std::cout << fmt::format("Run windowed with resolution 1024x768:\n");
-    std::cout << fmt::format("d2tm.exe -windowed -screenWidth 1024 -screenHeight 768\n");
-    std::cout << fmt::format("\n\n");
-    std::cout << fmt::format("Run without any sounds and debugging enabled:\n");
-    std::cout << fmt::format("d2tm.exe -nosound -debug\n");
-    std::cout << fmt::format("\n\n");
-}
-
-void cHandleArgument::applyArguments()
-{
-    for (const auto&[key, value]: m_optionToHandleAfter) {
-        switch (key) {
-            case Options::WINDOWED:
-                m_game->m_windowed = value;
-                break;
-            case Options::SCREENX:
-                m_game->m_screenW = m_argumentScreenX;
-                break;
-            case Options::SCREENY:
-                m_game->m_screenH = m_argumentScreenY;
+                settings.drawUsages = true;
                 break;
             default:
                 break;
         }
     }
+    return 0;
+}
+
+void cHandleArgument::printInstructions() const
+{
+    std::cout << "\n";
+    std::cout << "Usage: d2tm[.exe] [-windowed] [-screenWidth <width>] ...\n\n";
+    std::cout << "Graphics\n";
+    std::cout << "--------\n\n";
+    std::cout << "-windowed              - Run game in window instead of fullscreen\n";
+    std::cout << "-screenWidth <value>   - Width of screen / window (minimum 800)\n";
+    std::cout << "-screenHeight <value>  - Height of screen / window (minimum 600)\n";
+    std::cout << "\n\n";
+    std::cout << "Sound/Music\n";
+    std::cout << "-----------\n\n";
+    std::cout << "-nosound               - Run game without any sounds or music\n";
+    std::cout << "-nomusic               - Use sound effects only, no music\n";
+    std::cout << "\n\n";
+    std::cout << "Experimental\n";
+    std::cout << "------------\n\n";
+    std::cout << "-game <filename>       - Specify which file to use instead of game.ini\n";
+    std::cout << "\n\n";
+    std::cout << "Debugging\n";
+    std::cout << "---------\n\n";
+    std::cout << "-debug                 - Run in debug mode\n";
+    std::cout << "-debug-units           - Draw additional debug info about units\n";
+    std::cout << "-noai                  - Disable player AI's\n";
+    std::cout << "-nowormai              - Disable worm AI\n";
+    std::cout << "-oneai                 - Disable all but one player AI\n";
+    std::cout << "-noreinforcements      - Disable reinforcements (Campaign mode)\n";
+    std::cout << "-noairest              - Disable initial delay of player AI before becoming active\n";
+    std::cout << "-usages                - Draw used units, structures, particles, etc.\n";
+    std::cout << "\n\n";
+    std::cout << "Examples (Windows)\n";
+    std::cout << "------------------\n\n";
+    std::cout << "Run windowed with resolution 1024x768:\n";
+    std::cout << "d2tm.exe -windowed -screenWidth 1024 -screenHeight 768\n";
+    std::cout << "\n\n";
+    std::cout << "Run without any sounds and debugging enabled:\n";
+    std::cout << "d2tm.exe -nosound -debug\n";
+    std::cout << "\n\n";
 }

--- a/src/utils/cHandleArgument.cpp
+++ b/src/utils/cHandleArgument.cpp
@@ -72,8 +72,6 @@ int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings *setti
             case Options::USAGES:
                 settings->drawUsages = true;
                 break;
-            default:
-                break;
         }
     }
     return 0;

--- a/src/utils/cHandleArgument.cpp
+++ b/src/utils/cHandleArgument.cpp
@@ -1,9 +1,9 @@
 #include "cHandleArgument.h"
 #include "utils/GameSettings.hpp"
 #include <iostream>
-#include <cstdlib> // pour atoi
+#include <string>
 
-int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings &settings)
+int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings *settings)
 {
     if (argc < 2) {
         return 0;
@@ -24,53 +24,53 @@ int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings &setti
             case Options::GAME:
                 if ((i + 1) < argc) {
                     i++;
-                    settings.gameFilename = std::string(argv[i]);
+                    settings->gameFilename = std::string(argv[i]);
                 }
                 break;
             case Options::WINDOWED:
-                settings.windowed = true;
+                settings->windowed = true;
                 break;
             case Options::NOMUSIC:
-                settings.playMusic = false;
+                settings->playMusic = false;
                 break;
             case Options::NOSOUND:
-                settings.playSound = false;
+                settings->playSound = false;
                 break;
             case Options::DEBUG:
-                settings.debugMode = true;
+                settings->debugMode = true;
                 break;
             case Options::DEBUG_UNITS:
-                settings.drawUnitDebug = true;
+                settings->drawUnitDebug = true;
                 break;
             case Options::NOAI:
-                settings.disableAI = true;
+                settings->disableAI = true;
                 break;
             case Options::ONEAI:
-                settings.oneAi = true;
+                settings->oneAi = true;
                 break;
             case Options::NOWORMAI:
-                settings.disableWormAi = true;
+                settings->disableWormAi = true;
                 break;
             case Options::NOREINFORCEMENTS:
-                settings.disableReinforcements = true;
+                settings->disableReinforcements = true;
                 break;
             case Options::NOAIREST:
-                settings.noAiRest = true;
+                settings->noAiRest = true;
                 break;
             case Options::SCREENX:
                 if ((i + 1) < argc) {
                     i++;
-                    settings.screenW = std::atoi(argv[i]);
+                    settings->screenW = std::stoi(argv[i]);
                 }
                 break;
             case Options::SCREENY:
                 if ((i + 1) < argc) {
                     i++;
-                    settings.screenH = std::atoi(argv[i]);
+                    settings->screenH = std::stoi(argv[i]);
                 }
                 break;
             case Options::USAGES:
-                settings.drawUsages = true;
+                settings->drawUsages = true;
                 break;
             default:
                 break;

--- a/src/utils/cHandleArgument.h
+++ b/src/utils/cHandleArgument.h
@@ -2,19 +2,14 @@
 
 #include <map>
 #include <string>
-
-class cGame;
+#include "utils/GameSettings.hpp"
 
 class cHandleArgument {
-
 public:
-    explicit cHandleArgument(cGame *game);
+    cHandleArgument() = default;
+    ~cHandleArgument() = default;
 
-    ~cHandleArgument();
-
-    int handleArguments(int argc, char *argv[]);
-
-    void applyArguments();
+    int handleArguments(int argc, char *argv[], GameSettings& settings);
 
 private:
     enum class Options : char {
@@ -53,11 +48,6 @@ private:
         {"--help",            Options::HELP}
     };
 
-    cGame *m_game = nullptr;
-
-    std::map<Options, bool> m_optionToHandleAfter;
-
-    int m_argumentScreenX, m_argumentScreenY;
 
     void printInstructions() const;
 };

--- a/src/utils/cHandleArgument.h
+++ b/src/utils/cHandleArgument.h
@@ -9,7 +9,7 @@ public:
     cHandleArgument() = default;
     ~cHandleArgument() = default;
 
-    int handleArguments(int argc, char *argv[], GameSettings &settings);
+    int handleArguments(int argc, char *argv[], GameSettings *settings);
 
 private:
     enum class Options : char {

--- a/src/utils/cHandleArgument.h
+++ b/src/utils/cHandleArgument.h
@@ -9,7 +9,7 @@ public:
     cHandleArgument() = default;
     ~cHandleArgument() = default;
 
-    int handleArguments(int argc, char *argv[], GameSettings& settings);
+    int handleArguments(int argc, char *argv[], GameSettings &settings);
 
 private:
     enum class Options : char {

--- a/src/utils/cIniFile.cpp
+++ b/src/utils/cIniFile.cpp
@@ -37,7 +37,7 @@ bool cSection::addValue(const std::string &key, const std::string &value, int id
             std::cout << "Key " << key << " / " << realKey << " - already exist on section " << m_sectionName
                       << std::endl;
             cLogger *logger = cLogger::getInstance();
-            logger->log(LOG_INFO, COMP_GAMEINI, "(cSection)",
+            logger->log(LOG_INFO, COMP_GAMERULES, "(cSection)",
                         fmt::format("Key {} already exist on section {}", key, m_sectionName));
         }
         return addValue(key, value, ++id);
@@ -78,7 +78,7 @@ std::string cSection::getStringValue(const std::string &key, int id) const
     else {
         if (m_debugMode) {
             cLogger *logger = cLogger::getInstance();
-            logger->log(LOG_WARN, COMP_GAMEINI, "(cSection)",
+            logger->log(LOG_WARN, COMP_GAMERULES, "(cSection)",
                         fmt::format("Key {} ({}) didn't exist on section {}", key, realKey, m_sectionName));
         }
         return std::string();
@@ -146,7 +146,7 @@ bool cIniFile::load(const std::string &config)
 {
     cLogger *logger = cLogger::getInstance();
     m_fileName = config;
-    logger->log(LOG_INFO, COMP_GAMEINI, "(cIniFile)", fmt::format("Load file {}", m_fileName));
+    logger->log(LOG_INFO, COMP_GAMERULES, "(cIniFile)", fmt::format("Load file {}", m_fileName));
     std::ifstream in(m_fileName.c_str());
     if (!in) {
         // throw and catch so we can dump more information about why it failed
@@ -156,7 +156,7 @@ bool cIniFile::load(const std::string &config)
         }
         catch (std::runtime_error &e) {
             std::cerr << e.what() << std::endl;
-            logger->log(LOG_ERROR, COMP_GAMEINI, "(cIniFile)", e.what());
+            logger->log(LOG_ERROR, COMP_GAMERULES, "(cIniFile)", e.what());
         }
         return false;
     }
@@ -175,7 +175,7 @@ bool cIniFile::load(const std::string &config)
             // test if already exist
             if (m_mapConfig.find(m_actualSection) != m_mapConfig.end()) {
                 if (m_debugMode) {
-                    logger->log(LOG_WARN, COMP_GAMEINI, "(cIniFile)",
+                    logger->log(LOG_WARN, COMP_GAMERULES, "(cIniFile)",
                                 fmt::format("section {} already exist", m_actualSection));
                 }
                 continue;
@@ -194,7 +194,7 @@ bool cIniFile::load(const std::string &config)
             m_mapConfig[m_actualSection].addData(line);
             continue;
         }
-        logger->log(LOG_WARN, COMP_GAMEINI, "(cIniFile)", fmt::format("Error {} or no section found", line));
+        logger->log(LOG_WARN, COMP_GAMERULES, "(cIniFile)", fmt::format("Error {} or no section found", line));
     }
     return true;
 }
@@ -258,7 +258,7 @@ std::string cIniFile::getStringValue(const std::string &section, const std::stri
         if (m_debugMode) {
             std::cout << " getStringValue section " << section << " didn't exist" << std::endl;
             cLogger *logger = cLogger::getInstance();
-            logger->log(LOG_ERROR, COMP_GAMEINI, "(cIniFile)",
+            logger->log(LOG_ERROR, COMP_GAMERULES, "(cIniFile)",
                         fmt::format(" getStringValue section {} didn't exist", section));
         }
         return std::string();

--- a/src/utils/cLog.cpp
+++ b/src/utils/cLog.cpp
@@ -32,8 +32,8 @@ std::string getLogComponentString(eLogComponent component)
             return "UNITS";
         case COMP_STRUCTURES:
             return "STRUCTURES";
-        case COMP_GAMEINI:
-            return "GAMEINI";
+        case COMP_GAMERULES:
+            return "GAMERULES";
         case COMP_SCENARIOINI:
             return "SCENARIOINI";
         case COMP_PARTICLE:

--- a/src/utils/cLog.h
+++ b/src/utils/cLog.h
@@ -15,7 +15,7 @@ enum eLogLevel {
 enum eLogComponent {
     COMP_UNITS,
     COMP_STRUCTURES,
-    COMP_GAMEINI,
+    COMP_GAMERULES,
     COMP_SCENARIOINI,
     COMP_PARTICLE,
     COMP_BULLET,

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -26,7 +26,7 @@
 
 #include <cmath>
 
-GameSettings loadSettingsFromIni(cIniFile* settings)
+GameSettings loadSettingsFromIni(cIniFile *settings)
 {
     GameSettings gs;
     if (!settings->hasSection("SETTINGS")) return gs;

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -22,8 +22,36 @@
 #include "utils/cSoundPlayer.h"
 #include "utils/cIniFile.h"
 #include "utils/Graphics.hpp"
+#include "utils/GameSettings.hpp"
 
 #include <cmath>
+
+GameSettings loadSettingsFromIni(cIniFile* settings)
+{
+    GameSettings gs;
+    if (!settings->hasSection("SETTINGS")) return gs;
+    const cSection &section = settings->getSection("SETTINGS");
+    if (section.hasValue("ScreenWidth"))
+        gs.screenW = section.getInt("ScreenWidth");
+    if (section.hasValue("ScreenHeight"))
+        gs.screenH = section.getInt("ScreenHeight");
+    if (section.hasValue("CameraDragMoveSpeed"))
+        gs.cameraDragMoveSpeed = section.getDouble("CameraDragMoveSpeed");
+    if (section.hasValue("CameraBorderOrKeyMoveSpeed"))
+        gs.cameraBorderOrKeyMoveSpeed = section.getDouble("CameraBorderOrKeyMoveSpeed");
+    if (section.hasValue("CameraEdgeMove"))
+        gs.cameraEdgeMove = section.getBoolean("CameraEdgeMove");
+    if (section.hasValue("FullScreen"))
+        gs.windowed = !section.getBoolean("FullScreen");
+    if (section.hasValue("AllowRepeatingReinforcements"))
+        gs.allowRepeatingReinforcements = section.getBoolean("AllowRepeatingReinforcements");
+    if (section.hasValue("AllTurretsDownOnLowPower"))
+        gs.turretsDownOnLowPower = section.getBoolean("AllTurretsDownOnLowPower");
+    if (section.hasValue("RocketTurretsDownOnLowPower"))
+        gs.rocketTurretsDownOnLowPower = section.getBoolean("RocketTurretsDownOnLowPower");
+    return gs;
+}
+
 
 /**
  * Default printing in logs. Only will be done if game.isDebugMode() is true.

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -32,7 +32,7 @@ std::unique_ptr<GameSettings> loadSettingsFromIni(const std::string& filename)
     std::unique_ptr<GameSettings> gameSettings = std::make_unique<GameSettings>();
 
     if (!file->hasSection("SETTINGS")) {
-        cLogger::getInstance()->log(LOG_ERROR, COMP_GAMEINI, filename, "Expected to find [SETTINGS] in file.ini file");
+        cLogger::getInstance()->log(LOG_ERROR, COMP_GAMERULES, filename, "Expected to find [SETTINGS] in file.ini file");
         return gameSettings;
     }
 

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -26,29 +26,33 @@
 
 #include <cmath>
 
-GameSettings loadSettingsFromIni(cIniFile *settings)
+std::unique_ptr<GameSettings> loadSettingsFromIni(const std::string& settingfileName)
 {
-    GameSettings gs;
-    if (!settings->hasSection("SETTINGS")) return gs;
+    std::shared_ptr<cIniFile> settings = std::make_shared<cIniFile>(settingfileName, true);
+    std::unique_ptr<GameSettings> gs = std::make_unique<GameSettings>();
+    if (!settings->hasSection("SETTINGS")) {
+        cLogger::getInstance()->log(LOG_ERROR, COMP_GAMEINI, settingfileName, "No section SETTIGNS in inifile");
+        return gs;
+    }
     const cSection &section = settings->getSection("SETTINGS");
     if (section.hasValue("ScreenWidth"))
-        gs.screenW = section.getInt("ScreenWidth");
+        gs->screenW = section.getInt("ScreenWidth");
     if (section.hasValue("ScreenHeight"))
-        gs.screenH = section.getInt("ScreenHeight");
+        gs->screenH = section.getInt("ScreenHeight");
     if (section.hasValue("CameraDragMoveSpeed"))
-        gs.cameraDragMoveSpeed = section.getDouble("CameraDragMoveSpeed");
+        gs->cameraDragMoveSpeed = section.getDouble("CameraDragMoveSpeed");
     if (section.hasValue("CameraBorderOrKeyMoveSpeed"))
-        gs.cameraBorderOrKeyMoveSpeed = section.getDouble("CameraBorderOrKeyMoveSpeed");
+        gs->cameraBorderOrKeyMoveSpeed = section.getDouble("CameraBorderOrKeyMoveSpeed");
     if (section.hasValue("CameraEdgeMove"))
-        gs.cameraEdgeMove = section.getBoolean("CameraEdgeMove");
+        gs->cameraEdgeMove = section.getBoolean("CameraEdgeMove");
     if (section.hasValue("FullScreen"))
-        gs.windowed = !section.getBoolean("FullScreen");
+        gs->windowed = !section.getBoolean("FullScreen");
     if (section.hasValue("AllowRepeatingReinforcements"))
-        gs.allowRepeatingReinforcements = section.getBoolean("AllowRepeatingReinforcements");
+        gs->allowRepeatingReinforcements = section.getBoolean("AllowRepeatingReinforcements");
     if (section.hasValue("AllTurretsDownOnLowPower"))
-        gs.turretsDownOnLowPower = section.getBoolean("AllTurretsDownOnLowPower");
+        gs->turretsDownOnLowPower = section.getBoolean("AllTurretsDownOnLowPower");
     if (section.hasValue("RocketTurretsDownOnLowPower"))
-        gs.rocketTurretsDownOnLowPower = section.getBoolean("RocketTurretsDownOnLowPower");
+        gs->rocketTurretsDownOnLowPower = section.getBoolean("RocketTurretsDownOnLowPower");
     return gs;
 }
 

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -56,6 +56,8 @@ std::unique_ptr<GameSettings> loadSettingsFromIni(const std::string& filename)
         gameSettings->turretsDownOnLowPower = section.getBoolean("AllTurretsDownOnLowPower");
     if (section.hasValue("RocketTurretsDownOnLowPower"))
         gameSettings->rocketTurretsDownOnLowPower = section.getBoolean("RocketTurretsDownOnLowPower");
+    if (section.hasValue("GameRules"))
+        gameSettings->gameFilename = section.getStringValue("GameRules");
 
     return gameSettings;
 }

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -26,34 +26,38 @@
 
 #include <cmath>
 
-std::unique_ptr<GameSettings> loadSettingsFromIni(const std::string& settingfileName)
+std::unique_ptr<GameSettings> loadSettingsFromIni(const std::string& filename)
 {
-    std::shared_ptr<cIniFile> settings = std::make_shared<cIniFile>(settingfileName, true);
-    std::unique_ptr<GameSettings> gs = std::make_unique<GameSettings>();
-    if (!settings->hasSection("SETTINGS")) {
-        cLogger::getInstance()->log(LOG_ERROR, COMP_GAMEINI, settingfileName, "No section SETTIGNS in inifile");
-        return gs;
+    std::shared_ptr<cIniFile> file = std::make_shared<cIniFile>(filename, true);
+    std::unique_ptr<GameSettings> gameSettings = std::make_unique<GameSettings>();
+
+    if (!file->hasSection("SETTINGS")) {
+        cLogger::getInstance()->log(LOG_ERROR, COMP_GAMEINI, filename, "Expected to find [SETTINGS] in file.ini file");
+        return gameSettings;
     }
-    const cSection &section = settings->getSection("SETTINGS");
+
+    const cSection &section = file->getSection("SETTINGS");
+
     if (section.hasValue("ScreenWidth"))
-        gs->screenW = section.getInt("ScreenWidth");
+        gameSettings->screenW = section.getInt("ScreenWidth");
     if (section.hasValue("ScreenHeight"))
-        gs->screenH = section.getInt("ScreenHeight");
+        gameSettings->screenH = section.getInt("ScreenHeight");
     if (section.hasValue("CameraDragMoveSpeed"))
-        gs->cameraDragMoveSpeed = section.getDouble("CameraDragMoveSpeed");
+        gameSettings->cameraDragMoveSpeed = section.getDouble("CameraDragMoveSpeed");
     if (section.hasValue("CameraBorderOrKeyMoveSpeed"))
-        gs->cameraBorderOrKeyMoveSpeed = section.getDouble("CameraBorderOrKeyMoveSpeed");
+        gameSettings->cameraBorderOrKeyMoveSpeed = section.getDouble("CameraBorderOrKeyMoveSpeed");
     if (section.hasValue("CameraEdgeMove"))
-        gs->cameraEdgeMove = section.getBoolean("CameraEdgeMove");
+        gameSettings->cameraEdgeMove = section.getBoolean("CameraEdgeMove");
     if (section.hasValue("FullScreen"))
-        gs->windowed = !section.getBoolean("FullScreen");
+        gameSettings->windowed = !section.getBoolean("FullScreen");
     if (section.hasValue("AllowRepeatingReinforcements"))
-        gs->allowRepeatingReinforcements = section.getBoolean("AllowRepeatingReinforcements");
+        gameSettings->allowRepeatingReinforcements = section.getBoolean("AllowRepeatingReinforcements");
     if (section.hasValue("AllTurretsDownOnLowPower"))
-        gs->turretsDownOnLowPower = section.getBoolean("AllTurretsDownOnLowPower");
+        gameSettings->turretsDownOnLowPower = section.getBoolean("AllTurretsDownOnLowPower");
     if (section.hasValue("RocketTurretsDownOnLowPower"))
-        gs->rocketTurretsDownOnLowPower = section.getBoolean("RocketTurretsDownOnLowPower");
-    return gs;
+        gameSettings->rocketTurretsDownOnLowPower = section.getBoolean("RocketTurretsDownOnLowPower");
+
+    return gameSettings;
 }
 
 

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -56,4 +56,4 @@ int distanceBetweenCellAndCenterOfScreen(int iCell);
 
 const char *toStringBuildTypeSpecificType(const eBuildType &buildType, const int &specificTypeId);
 
-std::unique_ptr<GameSettings> loadSettingsFromIni(const std::string& settingfileName);
+std::unique_ptr<GameSettings> loadSettingsFromIni(const std::string& filename);

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -15,9 +15,9 @@
 
 #include <string>
 #include <array>
+#include <memory>
 #include <SDL2/SDL.h>
 
-class cIniFile;
 struct GameSettings;
 
 /**
@@ -56,4 +56,4 @@ int distanceBetweenCellAndCenterOfScreen(int iCell);
 
 const char *toStringBuildTypeSpecificType(const eBuildType &buildType, const int &specificTypeId);
 
-GameSettings loadSettingsFromIni(cIniFile *settings);
+std::unique_ptr<GameSettings> loadSettingsFromIni(const std::string& settingfileName);

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -18,6 +18,7 @@
 #include <SDL2/SDL.h>
 
 class cIniFile;
+struct GameSettings;
 
 /**
  * returns ticks for desired amount of miliseconds (for slow thinking, 1 tick == 100ms)
@@ -54,3 +55,5 @@ int create_bullet(int type, int fromCell, int targetCell, int unitWhichShoots, i
 int distanceBetweenCellAndCenterOfScreen(int iCell);
 
 const char *toStringBuildTypeSpecificType(const eBuildType &buildType, const int &specificTypeId);
+
+GameSettings loadSettingsFromIni(cIniFile *settings);


### PR DESCRIPTION
- There is a structure that fully manages all the game's options.
- This structure is first completed by reading an ini file.
- It is then modified by any command-line directives issued.
- Finally, it is applied to cGame.