### PR TITLE
Let rnd() implementation use std::uniform_int_distribution

### DIFF
--- a/src/building/cItemBuilder.cpp
+++ b/src/building/cItemBuilder.cpp
@@ -13,7 +13,7 @@
 #include "utils/common.h"
 #include "utils/cSoundPlayer.h"
 #include "utils/d2tm_math.h"
-
+#include "utils/RNG.hpp"
 
 
 #include <cassert>
@@ -295,10 +295,10 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
 
                             int x = map.getCellX(iCll);
                             int y = map.getCellY(iCll);
-                            int amount = rnd(2) + 1;
+                            int amount = RNG::rnd(2) + 1;
 
                             // randomly shift the cell one coordinate up/down/left/right
-                            switch (rnd(4)) {
+                            switch (RNG::rnd(4)) {
                                 case 0:
                                     x += amount;
                                     break;

--- a/src/cGame_logic.cpp
+++ b/src/cGame_logic.cpp
@@ -41,7 +41,7 @@
 #include "player/brains/superweapon/cPlayerBrainFremenSuperWeapon.h"
 #include "sidebar/cBuildingListFactory.h"
 #include "sidebar/cSideBarFactory.h"
-
+#include "utils/RNG.hpp"
 #include "utils/cLog.h"
 #include "utils/cPlatformLayerInit.h"
 #include "utils/cSoundPlayer.h"
@@ -599,8 +599,8 @@ void cGame::shakeScreenAndBlitBuffer()
             int shakiness = std::min(m_TIMER_shake, 69);
             float offset = mapCamera->factorZoomLevel(std::min(shakiness / 5, 9));
 
-            m_shakeX = -abs(offset / 2) + rnd(offset);
-            m_shakeY = -abs(offset / 2) + rnd(offset);
+            m_shakeX = -abs(offset / 2) + RNG::rnd(offset);
+            m_shakeY = -abs(offset / 2) + RNG::rnd(offset);
 
             // @Mira recreate shake screen
             //renderDrawer->blit(bmp_screen, bmp_throttle, 0, 0, 0 + m_shakeX, 0 + m_shakeY, m_screenW, m_screenH);
@@ -1323,7 +1323,7 @@ void cGame::prepareMentatForPlayer()
         INI_LOAD_BRIEFING(house, m_region, INI_BRIEFING, m_mentat);
     }
     else if (m_state == GAME_WINBRIEF) {
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             m_mentat->loadScene("win01");
         }
         else {
@@ -1332,7 +1332,7 @@ void cGame::prepareMentatForPlayer()
         INI_LOAD_BRIEFING(house, m_region, INI_WIN, m_mentat);
     }
     else if (m_state == GAME_LOSEBRIEF) {
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             m_mentat->loadScene("lose01");
         }
         else {
@@ -1509,8 +1509,8 @@ void cGame::onEventSpecialLaunch(const s_GameEvent &event)
             int mouseCellX = map.getCellX(iMouseCell) - precision;
             int mouseCellY = map.getCellY(iMouseCell) - precision;
 
-            int posX = mouseCellX + rnd((precision * 2) + 1);
-            int posY = mouseCellY + rnd((precision * 2) + 1);
+            int posX = mouseCellX + RNG::rnd((precision * 2) + 1);
+            int posY = mouseCellY + RNG::rnd((precision * 2) + 1);
             cPoint::split(posX, posY) = map.fixCoordinatesToBeWithinMap(posX, posY);
 
             logbook(fmt::format(
@@ -1957,16 +1957,16 @@ bool cGame::playMusicByType(int iType, int playerId, bool triggerWithVoice)
 
     int sampleId = MIDI_MENU;
     if (iType == MUSIC_WIN) {
-        sampleId = MIDI_WIN01 + rnd(3);
+        sampleId = MIDI_WIN01 + RNG::rnd(3);
     }
     else if (iType == MUSIC_LOSE) {
-        sampleId = MIDI_LOSE01 + rnd(6);
+        sampleId = MIDI_LOSE01 + RNG::rnd(6);
     }
     else if (iType == MUSIC_ATTACK) {
-        sampleId = MIDI_ATTACK01 + rnd(6);
+        sampleId = MIDI_ATTACK01 + RNG::rnd(6);
     }
     else if (iType == MUSIC_PEACE) {
-        sampleId = MIDI_BUILDING01 + rnd(9);
+        sampleId = MIDI_BUILDING01 + RNG::rnd(9);
     }
     else if (iType == MUSIC_MENU) {
         sampleId = MIDI_MENU;

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -7,7 +7,7 @@
 #include "map/cMapCamera.h"
 #include "player/cPlayer.h"
 #include "utils/cSoundPlayer.h"
-
+#include "utils/RNG.hpp"
 #include <fmt/core.h>
 
 #include <algorithm>
@@ -199,11 +199,11 @@ void cMouseUnitsSelectedState::onMouseLeftButtonClicked()
         }
 
         if (infantryAcknowledged) {
-            game.playSound(SOUND_MOVINGOUT + rnd(2));
+            game.playSound(SOUND_MOVINGOUT + RNG::rnd(2));
         }
 
         if (unitAcknowledged) {
-            game.playSound(SOUND_ACKNOWLEDGED + rnd(3));
+            game.playSound(SOUND_ACKNOWLEDGED + RNG::rnd(3));
         }
     }
 

--- a/src/drawers/SDLDrawer.cpp
+++ b/src/drawers/SDLDrawer.cpp
@@ -593,8 +593,8 @@ void SDLDrawer::renderDot(int x, int y, Color color, int size)
 
 //             gp = get_pixel(src, x1, y1); //ALLEGRO // use this inline function to speed up things.
 //             // Now choose random spot to 'switch' with.
-//             nx = (x1 - 1) + rnd(2);
-//             ny = (y1 - 1) + rnd(2);
+//             nx = (x1 - 1) + RNG::rnd(2);
+//             ny = (y1 - 1) + RNG::rnd(2);
 
 //             if (nx < 0) nx = 0;
 //             if (ny < 0) ny = 0;

--- a/src/gameobjects/particles/cParticle.cpp
+++ b/src/gameobjects/particles/cParticle.cpp
@@ -10,7 +10,7 @@
 */
 
 #include "cParticle.h"
-
+#include "utils/RNG.hpp"
 #include "d2tmc.h"
 #include "drawers/SDLDrawer.hpp"
 #include "map/cMapCamera.h"
@@ -214,7 +214,7 @@ void cParticle::thinkFast()
 
         if (TIMER_frame < 0) {
             frameIndex++;
-            TIMER_frame = 100 + rnd(100);
+            TIMER_frame = 100 + RNG::rnd(100);
 
             if (frameIndex > 5) {
                 die();
@@ -337,7 +337,7 @@ void cParticle::thinkFast()
         TIMER_dead--;
         if (TIMER_frame < 0) {
             TIMER_frame = 10;
-            if (rnd(100) < 10 && iAlpha > 192)
+            if (RNG::rnd(100) < 10 && iAlpha > 192)
                 iAlpha--;
 
             if (TIMER_dead > 0) {
@@ -688,8 +688,8 @@ int cParticle::create(long x, long y, int iType, int iHouse, int iFrame, int iUn
     // trike exploding
     if (iType == D2TM_PARTICLE_EXPLOSION_FIRE) {
         pParticle.iAlpha = 255;
-        pParticle.TIMER_dead = 750 + rnd(500);
-        pParticle.iAlpha = rnd(255);
+        pParticle.TIMER_dead = 750 + RNG::rnd(500);
+        pParticle.iAlpha = RNG::rnd(255);
     }
 
     // tanks exploding
@@ -709,7 +709,7 @@ int cParticle::create(long x, long y, int iType, int iHouse, int iFrame, int iUn
     }
 
     if (iType == D2TM_PARTICLE_DEADINF01 || iType == D2TM_PARTICLE_DEADINF02) {
-        pParticle.TIMER_dead = 500 + rnd(500);
+        pParticle.TIMER_dead = 500 + RNG::rnd(500);
         pParticle.iAlpha = 255;
     }
 
@@ -726,7 +726,7 @@ int cParticle::create(long x, long y, int iType, int iHouse, int iFrame, int iUn
 
     if (iType == D2TM_PARTICLE_SIEGEDIE) {
         pParticle.iAlpha = 255;
-        pParticle.TIMER_frame = 500 + rnd(300);
+        pParticle.TIMER_frame = 500 + RNG::rnd(300);
 
         create(x, y - 18, D2TM_PARTICLE_EXPLOSION_FIRE, -1, -1, iUnitID);
         create(x, y - 18, D2TM_PARTICLE_SMOKE, -1, -1, iUnitID);
@@ -735,8 +735,8 @@ int cParticle::create(long x, long y, int iType, int iHouse, int iFrame, int iUn
 
     if (iType == D2TM_PARTICLE_CARRYPUFF) {
         pParticle.frameIndex = 0;
-        pParticle.TIMER_frame = 50 + rnd(50);
-        pParticle.iAlpha = 96 + rnd(64);
+        pParticle.TIMER_frame = 50 + RNG::rnd(50);
+        pParticle.iAlpha = 96 + RNG::rnd(64);
     }
 
     if (iType == D2TM_PARTICLE_EXPLOSION_ROCKET || iType == D2TM_PARTICLE_EXPLOSION_ROCKET_SMALL) {

--- a/src/gameobjects/projectiles/bullet.cpp
+++ b/src/gameobjects/projectiles/bullet.cpp
@@ -21,6 +21,7 @@
 #include "player/cPlayer.h"
 #include "utils/cSoundPlayer.h"
 #include "include/Texture.hpp"
+#include "utils/RNG.hpp"
 #include <fmt/core.h>
 #include <cmath>
 
@@ -301,8 +302,8 @@ void cBullet::arrivedAtDestinationLogic()
             }
 
             int half = 16;
-            int randomX = -8 + rnd(half);
-            int randomY = -8 + rnd(half);
+            int randomX = -8 + RNG::rnd(half);
+            int randomY = -8 + RNG::rnd(half);
             int posX = map.getAbsoluteXPositionFromCellCentered(cellToDamage) + randomX;
             int posY = map.getAbsoluteYPositionFromCellCentered(cellToDamage) + randomY;
 
@@ -332,11 +333,11 @@ void cBullet::arrivedAtDestinationLogic()
             if (iType == ROCKET_BIG) {
                 // HACK HACK: produce sounds here... should be taken from bullet data structure; or via events
                 // so that elsewhere this can be handled.
-                if (rnd(100) < 35) {
-                    game.playSoundWithDistance(SOUND_TANKDIE + rnd(2),
+                if (RNG::rnd(100) < 35) {
+                    game.playSoundWithDistance(SOUND_TANKDIE + RNG::rnd(2),
                                                distanceBetweenCellAndCenterOfScreen(cellToDamage));
                 }
-                if (rnd(100) < 20) {
+                if (RNG::rnd(100) < 20) {
                     cParticle::create(posX, posY, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
                 }
             }
@@ -484,7 +485,7 @@ bool cBullet::damageGroundUnit(int cell, double factor) const
         game.playSoundWithDistance(SOUND_GAS, distanceBetweenCellAndCenterOfScreen(cell));
 
         // take over unit
-        if (rnd(100) < gets_Bullet().deviateProbability) {
+        if (RNG::rnd(100) < gets_Bullet().deviateProbability) {
             cUnit &ownerUnit = unit[iOwnerUnit];
             if (ownerUnit.isValid()) {
                 groundUnitTakingDamage.iPlayer = ownerUnit.iPlayer;
@@ -693,7 +694,7 @@ void cBullet::damageStructure(int idOfStructureAtCell, double factor)
 int cBullet::getRandomY() const
 {
     int half = 16;
-    int randomY = -8 + rnd(half);
+    int randomY = -8 + RNG::rnd(half);
     return pos_y() + half + randomY;
 }
 
@@ -704,7 +705,7 @@ int cBullet::getRandomY() const
 int cBullet::getRandomX() const
 {
     int half = 16;
-    int randomX = -8 + rnd(half);
+    int randomX = -8 + RNG::rnd(half);
     return pos_x() + half + randomX;
 }
 

--- a/src/gameobjects/structures/cAbstractStructure.cpp
+++ b/src/gameobjects/structures/cAbstractStructure.cpp
@@ -21,7 +21,7 @@
 #include "player/cPlayer.h"
 #include "utils/cSoundPlayer.h"
 #include "include/Texture.hpp"
-
+#include "utils/RNG.hpp"
 #include <SDL2/SDL.h>
 #include <fmt/core.h>
 
@@ -214,21 +214,21 @@ void cAbstractStructure::die()
                 map.smudge_increase(SMUDGE_ROCK, iCll);
 
                 // create particle
-                int iType = D2TM_PARTICLE_EXPLOSION_STRUCTURE01 + rnd(2);
+                int iType = D2TM_PARTICLE_EXPLOSION_STRUCTURE01 + RNG::rnd(2);
                 cParticle::create(posX + half, posY + half, iType, -1, -1);
 
                 // create smoke
-                if (rnd(100) < 15) {
-                    int randomX = -8 + rnd(16);
-                    int randomY = -8 + rnd(16);
+                if (RNG::rnd(100) < 15) {
+                    int randomX = -8 + RNG::rnd(16);
+                    int randomY = -8 + RNG::rnd(16);
 
                     cParticle::create(posX + half + randomX, posY + half + randomY, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
                 }
 
                 // create fire
-                if (rnd(100) < 15) {
-                    int randomX = -8 + rnd(16);
-                    int randomY = -8 + rnd(16);
+                if (RNG::rnd(100) < 15) {
+                    int randomX = -8 + RNG::rnd(16);
+                    int randomY = -8 + RNG::rnd(16);
 
                     cParticle::create(posX + half + randomX, posY + half + randomY, D2TM_PARTICLE_EXPLOSION_FIRE, -1,
                                       -1);
@@ -239,7 +239,7 @@ void cAbstractStructure::die()
     }
 
     // play sound
-    game.playSoundWithDistance(SOUND_CRUMBLE01 + rnd(2), distanceBetweenCellAndCenterOfScreen(iCell));
+    game.playSoundWithDistance(SOUND_CRUMBLE01 + RNG::rnd(2), distanceBetweenCellAndCenterOfScreen(iCell));
 
     // remove from the playground
     map.remove_id(id, MAPID_STRUCTURES);
@@ -400,10 +400,10 @@ void cAbstractStructure::think_decay()
         return; // wait until timer is passed
     }
 
-    TIMER_decay = rnd(500) + 500;
+    TIMER_decay = RNG::rnd(500) + 500;
 
     // chance based (so it does not decay all the time)
-    if (rnd(100) < getPercentageNotPaved()) {
+    if (RNG::rnd(100) < getPercentageNotPaved()) {
         if (iHitPoints > (getStructureInfo().hp / 2)) {
             decay(1);
         }
@@ -501,7 +501,7 @@ void cAbstractStructure::damage(int hp, int originId)
         int iChance = getSmokeChance();
 
         // Structure on fire?
-        if (rnd(100) < iChance) {
+        if (RNG::rnd(100) < iChance) {
             long x = getRandomPosX();
             long y = getRandomPosY();
             int particleIndex = cParticle::create(x, y, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
@@ -709,12 +709,12 @@ void cAbstractStructure::getsCapturedBy(cPlayer *pPlayer)
 
 int cAbstractStructure::getRandomPosX()
 {
-    return pos_x() + rnd(getWidthInPixels()); // posX = most left, so just increase
+    return pos_x() + RNG::rnd(getWidthInPixels()); // posX = most left, so just increase
 }
 
 int cAbstractStructure::getRandomPosY()
 {
-    return pos_y() + rnd(getHeightInPixels()); // posY = top coordinate, so just increase
+    return pos_y() + RNG::rnd(getHeightInPixels()); // posY = top coordinate, so just increase
 }
 
 void cAbstractStructure::startRepairing()
@@ -823,7 +823,7 @@ void cAbstractStructure::unitHeadsTowardsStructure(int unitId)
 
 int cAbstractStructure::getRandomStructureCell()
 {
-    return getCell() + rnd(getWidth()) + (rnd(getHeight()) * map.getWidth());
+    return getCell() + RNG::rnd(getWidth()) + (RNG::rnd(getHeight()) * map.getWidth());
 }
 
 /**

--- a/src/gameobjects/structures/cGunTurret.cpp
+++ b/src/gameobjects/structures/cGunTurret.cpp
@@ -6,6 +6,7 @@
 #include "gameobjects/projectiles/bullet.h"
 #include "gameobjects/units/cUnit.h"
 #include "player/cPlayer.h"
+#include "utils/RNG.hpp"
 
 namespace {
 constexpr auto kTurretFacings = 8;
@@ -112,7 +113,7 @@ void cGunTurret::think_turning()
         int clockwiseSteps = abs(counterClockwiseSteps - kTurretFacings);
 
         // it does not matter which way we go, so pick random direction
-        if (clockwiseSteps == counterClockwiseSteps) increment = -1 + (rnd(2));
+        if (clockwiseSteps == counterClockwiseSteps) increment = -1 + (RNG::rnd(2));
 
         // counterClockwise is longer than clockwise, so go clockwise (+1)
         if (counterClockwiseSteps > clockwiseSteps) increment = 1;
@@ -207,7 +208,7 @@ void cGunTurret::think_guard()
     TIMER_guard++;
 
     if (TIMER_guard > 10) {
-        TIMER_guard=0-rnd(20);
+        TIMER_guard=0-RNG::rnd(20);
 
         int c = getCell();
         int iCellX = map.getCellX(c);

--- a/src/gameobjects/structures/cOrderProcesser.cpp
+++ b/src/gameobjects/structures/cOrderProcesser.cpp
@@ -5,7 +5,7 @@
  *      Author: Stefan
  */
 #include "cOrderProcesser.h"
-
+#include "utils/RNG.hpp"
 #include "d2tmc.h"
 #include "managers/cDrawManager.h"
 #include "player/cPlayer.h"
@@ -138,7 +138,7 @@ void cOrderProcesser::updatePricesForStarport()
             int id = item->getBuildId();
             int originalPrice = sUnitInfo[id].cost;
             int slice = originalPrice / 2;
-            int newPrice = (originalPrice - slice) + (rnd(slice * 2));
+            int newPrice = (originalPrice - slice) + (RNG::rnd(slice * 2));
             item->setBuildCost(newPrice);
         }
     }
@@ -213,7 +213,7 @@ void cOrderProcesser::placeOrder()
 
 int cOrderProcesser::getRandomizedSecondsToWait()
 {
-    return (45 + rnd(360));
+    return (45 + RNG::rnd(360));
 }
 
 void cOrderProcesser::sendFrigate()

--- a/src/gameobjects/structures/cStructureFactory.cpp
+++ b/src/gameobjects/structures/cStructureFactory.cpp
@@ -23,7 +23,7 @@
 #include "map/cMapEditor.h"
 #include "player/cPlayer.h"
 #include "utils/cLog.h"
-
+#include "utils/RNG.hpp"
 #include <fmt/core.h>
 
 cStructureFactory::cStructureFactory()
@@ -159,10 +159,10 @@ cAbstractStructure *cStructureFactory::createStructure(int iCell, int iStructure
     str->setOwner(iPlayer);
     str->setBuildingFase(1); // prebuild
     str->TIMER_prebuild = std::min(structureSize/16, 250); // prebuild timer. A structure of 64x64 will result in 256, bigger structure has longer timer
-    str->TIMER_decay = rnd(1000) + 100;
+    str->TIMER_decay = RNG::rnd(1000) + 100;
     str->fConcrete = (1 - fPercent);
     str->setHitPoints((int)fHealth);
-    str->setFrame(rnd(1)); // random start frame (flag)
+    str->setFrame(RNG::rnd(1)); // random start frame (flag)
     str->setStructureId(iNewId);
     str->setWidth(structureInfo.bmp_width / TILESIZE_WIDTH_PIXELS);
     str->setHeight(structureInfo.bmp_height / TILESIZE_HEIGHT_PIXELS);

--- a/src/gameobjects/structures/cWindTrap.cpp
+++ b/src/gameobjects/structures/cWindTrap.cpp
@@ -3,7 +3,7 @@
 #include "d2tmc.h"
 #include "definitions.h"
 #include "player/cPlayer.h"
-
+#include "utils/RNG.hpp"
 #include <fmt/core.h>
 
 // Constructor
@@ -13,7 +13,7 @@ cWindTrap::cWindTrap()
         logbook(fmt::format("(cWindTrap)(ID {}) Constructor", this->id));
     }
     // other variables (class specific)
-    iFade = rnd(63);
+    iFade = RNG::rnd(63);
     bFadeDir = true;
 
     // Timers

--- a/src/gameobjects/units/cReinforcements.cpp
+++ b/src/gameobjects/units/cReinforcements.cpp
@@ -2,8 +2,8 @@
 #include "cReinforcements.h"
 #include "utils/common.h"
 #include "player/cPlayer.h"
+#include "utils/RNG.hpp"
 #include <algorithm>
-
 #include <fmt/core.h>
 
 
@@ -170,7 +170,7 @@ void REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement)
     int iStartCell = iFindCloseBorderCell(iStart);
 
     if (iStartCell < 0) {
-        iStart += rnd(64);
+        iStart += RNG::rnd(64);
         if (iStart >= map.getMaxCells())
             iStart -= 64;
 

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -23,7 +23,7 @@
 #include "player/cPlayer.h"
 #include "utils/cSoundPlayer.h"
 #include "utils/Graphics.hpp"
-
+#include "utils/RNG.hpp"
 #include <SDL2/SDL.h>
 #include <fmt/core.h>
 
@@ -242,7 +242,7 @@ void cUnit::createSquishedParticle()
     int iDieY = pos_y_centered();
     // when we do not 'blow up', we died by something else. Only infantry will be 'squished' here now.
     if (iType == SOLDIER || iType == TROOPER || iType == UNIT_FREMEN_ONE) {
-        int iType1 = D2TM_PARTICLE_SQUISH01 + rnd(2);
+        int iType1 = D2TM_PARTICLE_SQUISH01 + RNG::rnd(2);
         cParticle::create(iDieX, iDieY, iType1, iPlayer, iFrame);
         game.playSoundWithDistance(SOUND_SQUISH, distanceBetweenCellAndCenterOfScreen(iCell));
     }
@@ -264,12 +264,12 @@ void cUnit::createExplosionParticle()
         cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_TRIKE, -1, -1);
         game.playSoundWithDistance(SOUND_TRIKEDIE, distanceBetweenCellAndCenterOfScreen(iCell));
 
-        if (rnd(100) < 30) {
+        if (RNG::rnd(100) < 30) {
             cParticle::create(iDieX, iDieY - 24, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
         }
     }
 
-    if ((iType == SIEGETANK || iType == DEVASTATOR) && rnd(100) < 25) {
+    if ((iType == SIEGETANK || iType == DEVASTATOR) && RNG::rnd(100) < 25) {
         if (iBodyFacing == FACE_UPLEFT || iBodyFacing == FACE_DOWNRIGHT) {
             cParticle::create(iDieX, iDieY, D2TM_PARTICLE_SIEGEDIE, iPlayer, -1);
         }
@@ -278,7 +278,7 @@ void cUnit::createExplosionParticle()
     if (iType == TANK || iType == SIEGETANK || iType == SONICTANK || iType == LAUNCHER || iType == DEVIATOR ||
             iType == HARVESTER || iType == ORNITHOPTER || iType == CARRYALL || iType == MCV || iType == FRIGATE) {
         // play quick 'boom' sound and show animation
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_TANK_ONE, -1, -1);
             game.playSoundWithDistance(SOUND_TANKDIE2, distanceBetweenCellAndCenterOfScreen(iCell));
         }
@@ -287,7 +287,7 @@ void cUnit::createExplosionParticle()
             game.playSoundWithDistance(SOUND_TANKDIE, distanceBetweenCellAndCenterOfScreen(iCell));
         }
 
-        if (rnd(100) < 30) {
+        if (RNG::rnd(100) < 30) {
             cParticle::create(iDieX, iDieY - 24, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
         }
 
@@ -319,12 +319,12 @@ void cUnit::createExplosionParticle()
 
 
                 for (int i = 0; i < 2; i++) {
-                    int iType1 = D2TM_PARTICLE_EXPLOSION_STRUCTURE01 + rnd(2);
+                    int iType1 = D2TM_PARTICLE_EXPLOSION_STRUCTURE01 + RNG::rnd(2);
                     cParticle::create(iDieX + (cx * 32), iDieY + (cy * 32), iType1, -1, -1);
                 }
 
-                if (rnd(100) < 35)
-                    game.playSoundWithDistance(SOUND_TANKDIE + rnd(2), distanceBetweenCellAndCenterOfScreen(iCell));
+                if (RNG::rnd(100) < 35)
+                    game.playSoundWithDistance(SOUND_TANKDIE + RNG::rnd(2), distanceBetweenCellAndCenterOfScreen(iCell));
 
                 // calculate cell and damage stuff around this
                 int cll = map.getCellWithMapBorders((iCellX - 1) + cx, (iCellY - 1) + cy);
@@ -369,7 +369,7 @@ void cUnit::createExplosionParticle()
                     assert(pStructure);
                     if (pStructure->getHitPoints() > 0) {
 
-                        int iDamage = 150 + rnd(100);
+                        int iDamage = 150 + RNG::rnd(100);
                         pStructure->damage(iDamage, -1); // no need to pass unit ID, as it is dead anyway
 
                         int iChance = 10;
@@ -378,9 +378,9 @@ void cUnit::createExplosionParticle()
                             iChance = 30;
                         }
 
-                        if (rnd(100) < iChance) {
-                            long x = pos_x() + (mapCamera->getViewportStartX()) + 16 + (-8 + rnd(16));
-                            long y = pos_y() + (mapCamera->getViewportStartY()) + 16 + (-8 + rnd(16));
+                        if (RNG::rnd(100) < iChance) {
+                            long x = pos_x() + (mapCamera->getViewportStartX()) + 16 + (-8 + RNG::rnd(16));
+                            long y = pos_y() + (mapCamera->getViewportStartY()) + 16 + (-8 + RNG::rnd(16));
                             cParticle::create(x, y, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
                         }
                     }
@@ -394,7 +394,7 @@ void cUnit::createExplosionParticle()
 
                     if (map.getCellHealth(cll) < -25) {
                         map.smudge_increase(SMUDGE_ROCK, cll);
-                        map.cellGiveHealth(cll, rnd(25));
+                        map.cellGiveHealth(cll, RNG::rnd(25));
                     }
                 }
                 else if (cellType == TERRAIN_SAND ||
@@ -406,7 +406,7 @@ void cUnit::createExplosionParticle()
 
                     if (map.getCellHealth(cll) < -25) {
                         map.smudge_increase(SMUDGE_SAND, cll);
-                        map.cellGiveHealth(cll, rnd(25));
+                        map.cellGiveHealth(cll, RNG::rnd(25));
                     }
                 }
             }
@@ -425,7 +425,7 @@ void cUnit::createExplosionParticle()
 
         cParticle::create(iDieX, iDieY, D2TM_PARTICLE_DEADINF02, iPlayer, -1);
 
-        game.playSoundWithDistance(SOUND_DIE01 + rnd(5), distanceBetweenCellAndCenterOfScreen(iCell));
+        game.playSoundWithDistance(SOUND_DIE01 + RNG::rnd(5), distanceBetweenCellAndCenterOfScreen(iCell));
     }
 
     if (iType == TROOPERS || iType == INFANTRY || iType == UNIT_FREMEN_THREE) {
@@ -433,7 +433,7 @@ void cUnit::createExplosionParticle()
 
         cParticle::create(iDieX, iDieY, D2TM_PARTICLE_DEADINF01, iPlayer, -1);
 
-        game.playSoundWithDistance(SOUND_DIE01 + rnd(5), distanceBetweenCellAndCenterOfScreen(iCell));
+        game.playSoundWithDistance(SOUND_DIE01 + RNG::rnd(5), distanceBetweenCellAndCenterOfScreen(iCell));
     }
 }
 
@@ -718,7 +718,7 @@ void cUnit::draw()
 
     if (isSandworm()) {
     //     // randomize drawing shimmer effect, as it is expensive
-    //     if (rnd(100) < 15) {
+    //     if (RNG::rnd(100) < 15) {
     //         renderDrawer->shimmer(bmp_screen,TILESIZE_HEIGHT_PIXELS, center_draw_x(), center_draw_y(), mapCamera->divideByZoomLevel(4));
     //     }
         return;
@@ -791,7 +791,7 @@ void cUnit::draw()
 
     // TODO: Fix this / Draw BLINKING (ie, when targeted unit)
 //	if (TIMER_blink > 0)
-//		if (rnd(100) < 15)
+//		if (RNG::rnd(100) < 15)
 //			mask_to_color(temp, Color{255,255,255));
 
     // when we want to be picked up..
@@ -887,7 +887,7 @@ void cUnit::attack(int goalCell, int unitId, int structureId, int attackCell, bo
     iAttackStructure = structureId;
     iAttackUnit = unitId;
     this->iAttackCell = attackCell;
-    forgetAboutCurrentPathAndPrepareToCreateNewOne(rnd(5));
+    forgetAboutCurrentPathAndPrepareToCreateNewOne(RNG::rnd(5));
 }
 
 void cUnit::attackAt(int cell)
@@ -1004,8 +1004,8 @@ void cUnit::thinkFast_guard()
     TIMER_bored++;
     if (TIMER_bored > 3500) {
         TIMER_bored = 0;
-        iBodyShouldFace = rnd(8);
-        iHeadShouldFace = rnd(8);
+        iBodyShouldFace = RNG::rnd(8);
+        iHeadShouldFace = RNG::rnd(8);
     }
 
     if (TIMER_guard > 0) {
@@ -1021,7 +1021,7 @@ void cUnit::thinkFast_guard()
     }
 
     // scan area
-    TIMER_guard = 20 + rnd(35); // do not scan all at the same time
+    TIMER_guard = 20 + RNG::rnd(35); // do not scan all at the same time
 
     updateCellXAndY();
 
@@ -1362,7 +1362,7 @@ int cUnit::determineNewFacing(int currentFacing, int desiredFacing)
 
     int toright = abs(toleft - 8);
 
-    if (toright == toleft) d = -1 + (rnd(2));
+    if (toright == toleft) d = -1 + (RNG::rnd(2));
     if (toleft > toright) d = 1;
     if (toright > toleft) d = -1;
 
@@ -1686,7 +1686,7 @@ void cUnit::thinkFast_move_airUnit()
             int maxSlowDown = 36;
             float slowDownStep = maxSlowDown / dist;
             if (iLength < dist) {
-                if (rnd(100) < 5) {
+                if (RNG::rnd(100) < 5) {
                     int cellType = map.getCellType(iCell);
                     if (cellType == TERRAIN_SAND ||
                             cellType == TERRAIN_SPICE ||
@@ -2108,7 +2108,7 @@ void cUnit::think_hit(int iShotUnit, int iShotStructure)
 
                 cParticle::create(iDieX, iDieY, D2TM_PARTICLE_DEADINF01, iPlayer, -1);
 
-                game.playSoundWithDistance(SOUND_DIE01 + rnd(5),
+                game.playSoundWithDistance(SOUND_DIE01 + RNG::rnd(5),
                                            distanceBetweenCellAndCenterOfScreen(iCell));
 
             }
@@ -2294,7 +2294,7 @@ void cUnit::think_attack_sandworm()
             takeDamage(1); // get below the thresh-hold to die/vanish
         }
         else {
-            TIMER_guard = (1000/5) * ((5*unitsEaten) + rnd((20*unitsEaten)));
+            TIMER_guard = (1000/5) * ((5*unitsEaten) + RNG::rnd((20*unitsEaten)));
         }
 
         if (game.isDebugMode()) {
@@ -2382,10 +2382,10 @@ bool cUnit::setAngleTowardsTargetAndFireBullets(int distance)
                     int inaccuracy = ((unitType.range - distance) / 3) + 1; // at 'perfect' range, we always have a inaccuracy of 1 at minimum
 
                     dx -= inaccuracy;
-                    dx += rnd((inaccuracy * 2)+1); // we need + 1, because it is 'until'
+                    dx += RNG::rnd((inaccuracy * 2)+1); // we need + 1, because it is 'until'
 
                     dy -= inaccuracy;
-                    dy += rnd((inaccuracy * 2)+1); // we need + 1, because it is 'until'
+                    dy += RNG::rnd((inaccuracy * 2)+1); // we need + 1, because it is 'until'
 
                     shootCell = map.getCellWithMapDimensions(dx, dy);
                 }
@@ -2508,7 +2508,7 @@ void cUnit::thinkFast_move()
                             }
                             else {
                                 setGoalCell(iNewGoal);
-                                TIMER_movewait = rnd(20);
+                                TIMER_movewait = RNG::rnd(20);
                                 log("Found alternative goal");
                                 return;
                             }
@@ -3774,7 +3774,7 @@ void cUnit::think_harvester()
             if (map.getCellCredits(iCell) <= 0) {
                 if (cellType == TERRAIN_SPICEHILL) {
                     map.cellChangeType(iCell, TERRAIN_SPICE);
-                    map.cellGiveCredits(iCell, rnd(100));
+                    map.cellGiveCredits(iCell, RNG::rnd(100));
                 }
                 else {
                     map.cellChangeType(iCell, TERRAIN_SAND);
@@ -3963,8 +3963,8 @@ int UNIT_CREATE(int iCll, int unitType, int iPlayer, bool bOnStart, bool isReinf
     newUnit.init(iNewId);
 
     newUnit.setCell(iCll);
-    newUnit.iBodyFacing = rnd(8);
-    newUnit.iHeadFacing = rnd(8);
+    newUnit.iBodyFacing = RNG::rnd(8);
+    newUnit.iHeadFacing = RNG::rnd(8);
 
     newUnit.iBodyShouldFace = newUnit.iBodyFacing;
     newUnit.iHeadShouldFace = newUnit.iHeadFacing;
@@ -3976,8 +3976,8 @@ int UNIT_CREATE(int iCll, int unitType, int iPlayer, bool bOnStart, bool isReinf
     newUnit.bSelected = false;
     newUnit.bHovered = false;
 
-    newUnit.TIMER_bored = rnd(3000);
-    newUnit.TIMER_guard = 20 + rnd(70);
+    newUnit.TIMER_bored = RNG::rnd(3000);
+    newUnit.TIMER_guard = 20 + RNG::rnd(70);
     newUnit.recreateDimensions();
 
     // set (Correct!?) player id, when type is SANDWORM (!?)
@@ -4068,7 +4068,7 @@ int CREATE_PATH(int iUnitId, int iPathCountUnits)
     // make sure not to create too many paths at once
     if (game.m_pathsCreated > 40) {
         pUnit.log("CREATE_PATH -- END 3");
-        pUnit.TIMER_movewait = (50 + rnd(50));
+        pUnit.TIMER_movewait = (50 + RNG::rnd(50));
         return -3;
     }
 
@@ -4084,7 +4084,7 @@ int CREATE_PATH(int iUnitId, int iPathCountUnits)
     // when all around the unit there is no space, dont even bother
     if (pUnit.isUnableToMove()) {
         pUnit.log("CREATE_PATH -- END 5");
-        pUnit.TIMER_movewait = 30 + rnd(50);
+        pUnit.TIMER_movewait = 30 + RNG::rnd(50);
         return -2;
     }
 
@@ -4710,7 +4710,7 @@ int UNIT_FREE_AROUND_MOVE(int iUnit)
     int iStartX = cUnit.getCellX();
     int iStartY = cUnit.getCellY();
 
-    int iWidth = rnd(4);
+    int iWidth = RNG::rnd(4);
 
     if (cUnit.iType == HARVESTER)
         iWidth = 2;
@@ -4739,5 +4739,5 @@ int UNIT_FREE_AROUND_MOVE(int iUnit)
 
     if (foundCoordinates < 1) return -1;
 
-    return iClls[rnd(foundCoordinates)]; // random cell
+    return iClls[RNG::rnd(foundCoordinates)]; // random cell
 }

--- a/src/gamestates/cSetupSkirmishGameState.cpp
+++ b/src/gamestates/cSetupSkirmishGameState.cpp
@@ -542,11 +542,11 @@ void cSetupSkirmishGameState::prepareSkirmishGameToPlayAndTransitionToCombatStat
 
                 while (bOk == false) {
                     if (p > HUMAN) {
-                        iHouse = rnd(4) + 1;
+                        iHouse = RNG::rnd(4) + 1;
                         // cpu player
                     }
                     else {  // human may not be sardaukar
-                        iHouse = rnd(3) + 1; // hark = 1, atr = 2, ord = 3, sar = 4
+                        iHouse = RNG::rnd(3) + 1; // hark = 1, atr = 2, ord = 3, sar = 4
                     }
 
                     bool houseInUse = false;
@@ -644,7 +644,7 @@ void cSetupSkirmishGameState::prepareSkirmishGameToPlayAndTransitionToCombatStat
     // create units
     while (u < maxAmountOfStartingUnits) {
         // pick a random unit type
-        int iType = rnd(12);
+        int iType = RNG::rnd(12);
 
         for (int p = 0; p < MAX_PLAYERS; p++) {
             cPlayer &pPlayer = players[p];

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -25,7 +25,7 @@
 #include "utils/common.h"
 #include "utils/cSeedMapGenerator.h"
 #include "gameobjects/units/cReinforcements.h"
-
+#include "utils/RNG.hpp"
 
 #include <fmt/core.h>
 #include <filesystem>
@@ -1407,7 +1407,7 @@ void INI_Load_scenario(int iHouse, int iRegion, cAbstractMentat *pMentat, cReinf
                 if (game.isDebugMode()) {
                     logbook(fmt::format("[SCENARIO] Placing spice FIELD at cell : {}", fields[iB]));
                 }
-                mapEditor.createRandomField(fields[iB], TERRAIN_SPICE, 25 + (rnd(50)));
+                mapEditor.createRandomField(fields[iB], TERRAIN_SPICE, 25 + (RNG::rnd(50)));
             }
 
         }

--- a/src/map/cMap.cpp
+++ b/src/map/cMap.cpp
@@ -21,7 +21,7 @@
 #include "gameobjects/structures/cStructureFactory.h"
 #include "player/cPlayer.h"
 #include "gameobjects/units/cReinforcements.h"
-
+#include "utils/RNG.hpp"
 #include <fmt/core.h>
 
 #include <algorithm>
@@ -113,14 +113,14 @@ void cMap::smudge_increase(int iType, int iCell)
 
     if (pCell->smudgetype == SMUDGE_ROCK) {
         if (pCell->smudgetile < 0)
-            pCell->smudgetile = rnd(2);
+            pCell->smudgetile = RNG::rnd(2);
         else if (pCell->smudgetile + 2 < 6)
             pCell->smudgetile += 2;
     }
 
     if (pCell->smudgetype == SMUDGE_SAND) {
         if (pCell->smudgetile < 0)
-            pCell->smudgetile = rnd(2);
+            pCell->smudgetile = RNG::rnd(2);
         else if (pCell->smudgetile + 2 < 6)
             pCell->smudgetile += 2;
     }
@@ -962,7 +962,7 @@ bool cMap::isValidCell(int c) const
  */
 int cMap::getRandomCell()
 {
-    return rnd(maxCells);
+    return RNG::rnd(maxCells);
 }
 
 void cMap::createCell(int cell, int terrainType, int tile)
@@ -991,10 +991,10 @@ void cMap::createCell(int cell, int terrainType, int tile)
     map.cellChangeSmudgeType(cell, -1);
 
     if (terrainType == TERRAIN_SPICE) {
-        map.cellChangeCredits(cell, 50 + rnd(125));
+        map.cellChangeCredits(cell, 50 + RNG::rnd(125));
     }
     else if (terrainType == TERRAIN_SPICEHILL) {
-        map.cellChangeCredits(cell, 75 + rnd(150));
+        map.cellChangeCredits(cell, 75 + RNG::rnd(150));
     }
     else if (terrainType == TERRAIN_MOUNTAIN) {
         map.cellChangePassable(cell, false);
@@ -1049,8 +1049,8 @@ void cMap::resize(int width, int height)
 int cMap::getRandomCellWithinMapWithSafeDistanceFromBorder(int distance)
 {
     return getCellWithMapBorders(
-               distance + rnd(width - (distance * 2)),
-               distance + rnd(height - (distance * 2))
+               distance + RNG::rnd(width - (distance * 2)),
+               distance + RNG::rnd(height - (distance * 2))
            );
 }
 
@@ -1131,7 +1131,7 @@ int cMap::findNearestSpiceBloom(int iCell)
     }
 
     // when finished, return bloom
-    return iTargets[rnd(iT)];
+    return iTargets[RNG::rnd(iT)];
 }
 
 bool cMap::isValidTerrainForStructureAtCell(int cll)
@@ -1158,8 +1158,8 @@ int cMap::getRandomCellFrom(int cell, int distance)
 {
     int startX = getCellX(cell);
     int startY = getCellY(cell);
-    int xDir = rnd(100) < 50 ? -1 : 1;
-    int yDir = rnd(100) < 50 ? -1 : 1;
+    int xDir = RNG::rnd(100) < 50 ? -1 : 1;
+    int yDir = RNG::rnd(100) < 50 ? -1 : 1;
     int newX = (startX - distance) + (xDir * distance);
     int newY = (startY - distance) + (yDir * distance);
     return getCellWithMapBorders(newX, newY);
@@ -1176,8 +1176,8 @@ int cMap::getRandomCellFromWithRandomDistance(int cell, int distance)
 {
     int startX = getCellX(cell);
     int startY = getCellY(cell);
-    int newX = (startX - distance) + (rnd(distance * 2));
-    int newY = (startY - distance) + (rnd(distance * 2));
+    int newX = (startX - distance) + (RNG::rnd(distance * 2));
+    int newY = (startY - distance) + (RNG::rnd(distance * 2));
     return getCellWithMapBorders(newX, newY);
 }
 
@@ -1368,7 +1368,7 @@ void cMap::cellTakeDamage(int cellNr, int damage)
                 smudge_increase(SMUDGE_SAND, cellNr);
             }
 
-            pCell->health += rnd(35);
+            pCell->health += RNG::rnd(35);
         }
     }
 }
@@ -1528,7 +1528,7 @@ void cMap::detonateSpiceBloom(int cell)
     // change type of terrain to sand
     auto mapEditor = cMapEditor(*this);
     mapEditor.createCell(cell, TERRAIN_SAND, 0);
-    int size = 75 + (rnd(100));
+    int size = 75 + (RNG::rnd(100));
     mapEditor.createRandomField(cell, TERRAIN_SPICE, size);
     game.shakeScreen(20);
 
@@ -1554,7 +1554,7 @@ void cMap::onNotifyGameEvent(const s_GameEvent &event)
             if (m_bAutoDetonateSpiceBlooms) {
                 // 1000/5 = taking care of thinkFast 5ms loop. The second part
                 // is the actual amount of seconds we want to delay before blowing up the spice bloom
-                m_mBloomTimers[event.atCell] = (1000 / 5) * (45 + rnd(120));
+                m_mBloomTimers[event.atCell] = (1000 / 5) * (45 + RNG::rnd(120));
             }
             break;
         case eGameEventType::GAME_EVENT_SPICE_BLOOM_BLEW:
@@ -1610,7 +1610,7 @@ void cMap::setSandwormRespawnTimer()
         // is the actual amount of seconds we want to delay
 
         // give at least a minute (max 3) without that sandworm
-        m_iTIMER_respawnSandworms = (1000 / 5) * (60 + rnd(180));
+        m_iTIMER_respawnSandworms = (1000 / 5) * (60 + RNG::rnd(180));
 
         if (game.isDebugMode()) {
             logbook(fmt::format("cMap::setSandwormRespawnTimer set timer to {}", this->m_iTIMER_respawnSandworms));

--- a/src/map/cMapEditor.cpp
+++ b/src/map/cMapEditor.cpp
@@ -3,7 +3,7 @@
 #include "data/gfxdata.h"
 #include "utils/common.h"
 #include "utils/d2tm_math.h"
-
+#include "utils/RNG.hpp"
 #include <fmt/core.h>
 
 #include <cassert>
@@ -17,7 +17,7 @@ void cMapEditor::createCell(int cell, int terrainType, int tile)
 {
     int theTile = tile;
     if (terrainType == TERRAIN_SLAB) {
-        theTile = rnd(5);
+        theTile = RNG::rnd(5);
     }
     m_map.createCell(cell, terrainType, theTile);
 }
@@ -33,11 +33,11 @@ void cMapEditor::createRandomField(int cell, int terrainType, int size)
     int y = m_map.getCellY(cell);
 
     if (x < 0) {
-        x = rnd(m_map.getWidth());
+        x = RNG::rnd(m_map.getWidth());
     }
 
     if (y < 0) {
-        y = rnd(m_map.getHeight());
+        y = RNG::rnd(m_map.getHeight());
     }
 
     if (terrainType == TERRAIN_ROCK && size < 0) {
@@ -58,8 +58,8 @@ void cMapEditor::createRandomField(int cell, int terrainType, int size)
 
         iDist = ABS_length(x, y, iOrgX, iOrgY);
 
-        if (iDist > rnd(4) + 4) {
-            if (rnd(100) < 5) {
+        if (iDist > RNG::rnd(4) + 4) {
+            if (RNG::rnd(100) < 5) {
                 createRandomField(c, terrainType, 100);
             }
         }
@@ -89,14 +89,14 @@ void cMapEditor::createRandomField(int cell, int terrainType, int size)
             }
         }
 
-        if (rnd(100) < 25) {
+        if (RNG::rnd(100) < 25) {
             x = m_map.getCellX(cell);
             y = m_map.getCellY(cell);
         }
 
 
         // randomly shift the cell one coordinate up/down/left/right
-        switch (rnd(4)) {
+        switch (RNG::rnd(4)) {
             case 0:
                 x++;
                 break;

--- a/src/map/cRandomMapGenerator.cpp
+++ b/src/map/cRandomMapGenerator.cpp
@@ -7,6 +7,7 @@
 #include "map/cMapEditor.h"
 #include "drawers/SDLDrawer.hpp"
 #include "utils/Graphics.hpp"
+#include "utils/RNG.hpp"
 
 cRandomMapGenerator::cRandomMapGenerator()
 {
@@ -18,9 +19,9 @@ void cRandomMapGenerator::generateRandomMap(int startingPoints, s_PreviewMap &ra
     map.init(128, 128);
     auto mapEditor = cMapEditor(map);
 
-    int a_spice = rnd((startingPoints * 8)) + (startingPoints * 12);
-    int a_rock = 32 + rnd(startingPoints * 3);
-    int a_hill = 2 + rnd(12);
+    int a_spice = RNG::rnd((startingPoints * 8)) + (startingPoints * 12);
+    int a_rock = 32 + RNG::rnd(startingPoints * 3);
+    int a_hill = 2 + RNG::rnd(12);
 
     // rock terrain is placed not near centre, also, we want 4 plateaus be
     // placed not too near to each other
@@ -78,13 +79,13 @@ void cRandomMapGenerator::generateRandomMap(int startingPoints, s_PreviewMap &ra
 
         if (bOk) {
             progress += piece;
-            mapEditor.createRandomField(iCll, TERRAIN_ROCK, 5500 + rnd(3500));
+            mapEditor.createRandomField(iCll, TERRAIN_ROCK, 5500 + RNG::rnd(3500));
 
             if (iSpot < startingPoints) {
                 randomMapEntry.iStartCell[iSpot] = iCll;
             }
             else {
-                mapEditor.createRandomField(iCll, TERRAIN_MOUNTAIN, 5 + rnd(15));
+                mapEditor.createRandomField(iCll, TERRAIN_MOUNTAIN, 5 + RNG::rnd(15));
             }
 
             if (iSpot < maxRockSpots) {
@@ -133,7 +134,7 @@ void cRandomMapGenerator::generateRandomMap(int startingPoints, s_PreviewMap &ra
 
     while (a_hill > 0) {
         int cell = map.getRandomCellWithinMapWithSafeDistanceFromBorder(0);
-        mapEditor.createRandomField(cell, TERRAIN_HILL, 500 + rnd(500));
+        mapEditor.createRandomField(cell, TERRAIN_HILL, 500 + RNG::rnd(500));
         a_hill--;
         progress += piece;
         // blit on screen

--- a/src/mentat/cAbstractMentat.cpp
+++ b/src/mentat/cAbstractMentat.cpp
@@ -16,7 +16,7 @@
 #include "d2tmc.h"
 #include "definitions.h"
 #include "drawers/SDLDrawer.hpp"
-
+#include "utils/RNG.hpp"
 #include "gui/cGuiButton.h"
 #include "gui/actions/cGuiActionToGameState.h"
 #include "utils/Graphics.hpp"
@@ -179,7 +179,7 @@ void cAbstractMentat::thinkEyes()
         TIMER_Eyes--;
     }
     else {
-        int i = rnd(100);
+        int i = RNG::rnd(100);
 
         int iWas = iMentatEyes;
 
@@ -195,11 +195,11 @@ void cAbstractMentat::thinkEyes()
 
         // its the same
         if (iMentatEyes == iWas) {
-            iMentatEyes = rnd(4);
+            iMentatEyes = RNG::rnd(4);
         }
 
         if (iMentatEyes != 4) {
-            TIMER_Eyes = 90 + rnd(160);
+            TIMER_Eyes = 90 + RNG::rnd(160);
         }
         else {
             TIMER_Eyes = 30;
@@ -220,15 +220,15 @@ void cAbstractMentat::thinkMouth()  // MOUTH
 
             if (iMentatMouth == 0) { // mouth is shut
                 // when mouth is shut, we wait a bit.
-                if (rnd(100) < 45) {
-                    iMentatMouth += (1 + rnd(4));
+                if (RNG::rnd(100) < 45) {
+                    iMentatMouth += (1 + RNG::rnd(4));
                 }
                 else {
                     TIMER_Mouth = 25; // wait
                 }
             }
             else {
-                iMentatMouth += (1 + rnd(4));
+                iMentatMouth += (1 + RNG::rnd(4));
             }
 
             // correct any frame
@@ -256,7 +256,7 @@ void cAbstractMentat::thinkMouth()  // MOUTH
         }
 
         if (TIMER_Mouth <= 0) {
-            TIMER_Mouth = 13 + rnd(15);
+            TIMER_Mouth = 13 + RNG::rnd(15);
         }
     } // Animating mouth
 

--- a/src/player/brains/cPlayerBrainCampaign.cpp
+++ b/src/player/brains/cPlayerBrainCampaign.cpp
@@ -6,7 +6,7 @@
 #include "player/cPlayer.h"
 
 #include <fmt/core.h>
-
+#include "utils/RNG.hpp"
 #include <algorithm>
 
 namespace brains {
@@ -231,7 +231,7 @@ void cPlayerBrainCampaign::onMyUnitAttacked(const s_GameEvent &event)
 
     cUnit &victim = unit[event.entityID];
     if (victim.isHarvester()) {
-        respondToThreat(threat, &victim, event.atCell, 2 + rnd(4));
+        respondToThreat(threat, &victim, event.atCell, 2 + RNG::rnd(4));
     }
 }
 
@@ -258,7 +258,7 @@ void cPlayerBrainCampaign::onMyStructureAttacked(const s_GameEvent &event)
         }
 
         int cell = originUnit.getCell();
-        respondToThreat(&originUnit, nullptr, cell, 2 + rnd(4));
+        respondToThreat(&originUnit, nullptr, cell, 2 + RNG::rnd(4));
     }
 }
 
@@ -311,7 +311,7 @@ void cPlayerBrainCampaign::thinkState_Missions()
                 .produced = 0,
             });
 
-            cPlayerBrainMission someMission(player, ePlayerBrainMissionKind::PLAYERBRAINMISSION_KIND_EXPLORE, this, group, rnd(5), 99);
+            cPlayerBrainMission someMission(player, ePlayerBrainMissionKind::PLAYERBRAINMISSION_KIND_EXPLORE, this, group, RNG::rnd(5), 99);
             m_missions.push_back(someMission);
         }
     }
@@ -349,21 +349,21 @@ void cPlayerBrainCampaign::produceMissions()
             std::vector<S_groupKind> group = std::vector<S_groupKind>();
             // no need to add resources to mission, they are auto-produced.
             // TODO: Think of a way to make this script/configurable
-            addMission(PLAYERBRAINMISSION_KIND_SUPERWEAPON_DEATHHAND, group, rnd(10), SPECIAL_MISSION1);
+            addMission(PLAYERBRAINMISSION_KIND_SUPERWEAPON_DEATHHAND, group, RNG::rnd(10), SPECIAL_MISSION1);
         }
 
         if (player->couldBuildSpecial(SPECIAL_SABOTEUR) && !hasMission(SPECIAL_MISSION2)) {
             std::vector<S_groupKind> group = std::vector<S_groupKind>();
             // no need to add resources to mission, they are auto-produced.
             // TODO: Think of a way to make this script/configurable
-            addMission(PLAYERBRAINMISSION_KIND_SUPERWEAPON_SABOTEUR, group, rnd(10), SPECIAL_MISSION2);
+            addMission(PLAYERBRAINMISSION_KIND_SUPERWEAPON_SABOTEUR, group, RNG::rnd(10), SPECIAL_MISSION2);
         }
 
         if (player->couldBuildSpecial(SPECIAL_FREMEN) && !hasMission(SPECIAL_MISSION3)) {
             std::vector<S_groupKind> group = std::vector<S_groupKind>();
             // no need to add resources to mission, they are auto-produced.
             // TODO: Think of a way to make this script/configurable
-            addMission(PLAYERBRAINMISSION_KIND_SUPERWEAPON_FREMEN, group, rnd(10), SPECIAL_MISSION3);
+            addMission(PLAYERBRAINMISSION_KIND_SUPERWEAPON_FREMEN, group, RNG::rnd(10), SPECIAL_MISSION3);
         }
     }
 
@@ -423,7 +423,7 @@ void cPlayerBrainCampaign::produceLevel5Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
-                .required = 1 + rnd(2),
+                .required = 1 + RNG::rnd(2),
                 .ordered = 0,
                 .produced = 0,
             });
@@ -432,17 +432,17 @@ void cPlayerBrainCampaign::produceLevel5Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
-                .required = 1 + rnd(3),
+                .required = 1 + RNG::rnd(3),
                 .ordered = 0,
                 .produced = 0,
             });
         }
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), 0);
     }
 
     if (!hasMission(1)) {
         group = std::vector<S_groupKind>();
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
@@ -452,11 +452,11 @@ void cPlayerBrainCampaign::produceLevel5Missions(int trikeKind, int infantryKind
             });
         }
         if (player->getHouse() != ORDOS) {
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = LAUNCHER,
-                    .required = 1 + rnd(2),
+                    .required = 1 + RNG::rnd(2),
                     .ordered = 0,
                     .produced = 0,
                 });
@@ -464,7 +464,7 @@ void cPlayerBrainCampaign::produceLevel5Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = TANK,
-                .required = 1 + rnd(4),
+                .required = 1 + RNG::rnd(4),
                 .ordered = 0,
                 .produced = 0,
             });
@@ -473,17 +473,17 @@ void cPlayerBrainCampaign::produceLevel5Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = TANK,
-                .required = 4 + rnd(2),
+                .required = 4 + RNG::rnd(2),
                 .ordered = 0,
                 .produced = 0,
             });
         }
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 1);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), 1);
     }
 
     if (!hasMission(2)) {
         // 25% chance we want another different attack force
-        if (rnd(100) < 25) {
+        if (RNG::rnd(100) < 25) {
             group = std::vector<S_groupKind>();
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
@@ -493,30 +493,30 @@ void cPlayerBrainCampaign::produceLevel5Missions(int trikeKind, int infantryKind
                 .produced = 0,
             });
             if (player->getHouse() != ORDOS) {
-                if (rnd(100) < 75) {
+                if (RNG::rnd(100) < 75) {
                     group.push_back(S_groupKind{
                         .buildType = eBuildType::UNIT,
                         .type = LAUNCHER,
-                        .required = 1 + rnd(2),
+                        .required = 1 + RNG::rnd(2),
                         .ordered = 0,
                         .produced = 0,
                     });
                 }
             }
-            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + rnd(10), 2);
+            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + RNG::rnd(10), 2);
         }
     }
     if (!hasMission(3)) {
         group = std::vector<S_groupKind>();
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = infantryKind,
-                .required = 2 + rnd(4),
+                .required = 2 + RNG::rnd(4),
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 3);
+            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(10), 3);
         }
     }
     // build additional harvester (we want 2 harvesters in total)
@@ -531,7 +531,7 @@ void cPlayerBrainCampaign::produceLevel5Missions(int trikeKind, int infantryKind
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 4);
+            addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(25), 4);
         }
         else {
             // we already have mission 4, meaning we have the additional harvester.
@@ -548,7 +548,7 @@ void cPlayerBrainCampaign::produceLevel5Missions(int trikeKind, int infantryKind
                         .produced = 0,
                     });
                     // different mission ID
-                    addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 5);
+                    addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(25), 5);
                 }
             }
         }
@@ -570,7 +570,7 @@ void cPlayerBrainCampaign::produceLevel6Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
-                .required = 1 + rnd(2),
+                .required = 1 + RNG::rnd(2),
                 .ordered = 0,
                 .produced = 0,
             });
@@ -579,17 +579,17 @@ void cPlayerBrainCampaign::produceLevel6Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
-                .required = 1 + rnd(3),
+                .required = 1 + RNG::rnd(3),
                 .ordered = 0,
                 .produced = 0,
             });
         }
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), 0);
     }
 
     if (!hasMission(1)) {
         group = std::vector<S_groupKind>();
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
@@ -599,29 +599,29 @@ void cPlayerBrainCampaign::produceLevel6Missions(int trikeKind, int infantryKind
             });
         }
         if (player->getHouse() != ORDOS) {
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = LAUNCHER,
-                    .required = 1 + rnd(3),
+                    .required = 1 + RNG::rnd(3),
                     .ordered = 0,
                     .produced = 0,
                 });
             }
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = TANK,
-                    .required = 2 + rnd(4),
+                    .required = 2 + RNG::rnd(4),
                     .ordered = 0,
                     .produced = 0,
                 });
             }
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = SIEGETANK,
-                    .required = 3 + rnd(4),
+                    .required = 3 + RNG::rnd(4),
                     .ordered = 0,
                     .produced = 0,
                 });
@@ -631,24 +631,24 @@ void cPlayerBrainCampaign::produceLevel6Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = TANK,
-                .required = 2 + rnd(4),
+                .required = 2 + RNG::rnd(4),
                 .ordered = 0,
                 .produced = 0,
             });
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = SIEGETANK,
-                .required = 3 + rnd(3),
+                .required = 3 + RNG::rnd(3),
                 .ordered = 0,
                 .produced = 0,
             });
         }
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 1);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), 1);
     }
 
     if (!hasMission(2)) {
         // 25% chance we want another different attack force
-        if (rnd(100) < 25) {
+        if (RNG::rnd(100) < 25) {
             group = std::vector<S_groupKind>();
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
@@ -657,40 +657,40 @@ void cPlayerBrainCampaign::produceLevel6Missions(int trikeKind, int infantryKind
                 .ordered = 0,
                 .produced = 0,
             });
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = SIEGETANK,
-                    .required = 1 + rnd(2),
+                    .required = 1 + RNG::rnd(2),
                     .ordered = 0,
                     .produced = 0,
                 });
             }
             if (player->getHouse() != ORDOS) {
-                if (rnd(100) < 75) {
+                if (RNG::rnd(100) < 75) {
                     group.push_back(S_groupKind{
                         .buildType = eBuildType::UNIT,
                         .type = LAUNCHER,
-                        .required = 1 + rnd(2),
+                        .required = 1 + RNG::rnd(2),
                         .ordered = 0,
                         .produced = 0,
                     });
                 }
             }
-            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + rnd(10), 2);
+            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + RNG::rnd(10), 2);
         }
     }
     if (!hasMission(3)) {
         group = std::vector<S_groupKind>();
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = infantryKind,
-                .required = 1 + rnd(2),
+                .required = 1 + RNG::rnd(2),
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 3);
+            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(10), 3);
         }
     }
     // build additional harvester (we want 2 harvesters in total)
@@ -705,7 +705,7 @@ void cPlayerBrainCampaign::produceLevel6Missions(int trikeKind, int infantryKind
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 4);
+            addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(25), 4);
         }
         else {
             // we already have mission 4, meaning we have the additional harvester.
@@ -723,7 +723,7 @@ void cPlayerBrainCampaign::produceLevel6Missions(int trikeKind, int infantryKind
                         .produced = 0,
                     });
                     // different mission ID
-                    addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 5);
+                    addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(25), 5);
                 }
             }
         }
@@ -745,7 +745,7 @@ void cPlayerBrainCampaign::produceLevel7Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
-                .required = 1 + rnd(2),
+                .required = 1 + RNG::rnd(2),
                 .ordered = 0,
                 .produced = 0,
             });
@@ -754,17 +754,17 @@ void cPlayerBrainCampaign::produceLevel7Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
-                .required = 1 + rnd(3),
+                .required = 1 + RNG::rnd(3),
                 .ordered = 0,
                 .produced = 0,
             });
         }
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), 0);
     }
 
     if (!hasMission(1)) {
         group = std::vector<S_groupKind>();
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
@@ -774,29 +774,29 @@ void cPlayerBrainCampaign::produceLevel7Missions(int trikeKind, int infantryKind
             });
         }
         if (player->getHouse() != ORDOS) {
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = LAUNCHER,
-                    .required = 1 + rnd(3),
+                    .required = 1 + RNG::rnd(3),
                     .ordered = 0,
                     .produced = 0,
                 });
             }
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = TANK,
-                    .required = 2 + rnd(4),
+                    .required = 2 + RNG::rnd(4),
                     .ordered = 0,
                     .produced = 0,
                 });
             }
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = SIEGETANK,
-                    .required = 3 + rnd(4),
+                    .required = 3 + RNG::rnd(4),
                     .ordered = 0,
                     .produced = 0,
                 });
@@ -806,24 +806,24 @@ void cPlayerBrainCampaign::produceLevel7Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = TANK,
-                .required = 2 + rnd(4),
+                .required = 2 + RNG::rnd(4),
                 .ordered = 0,
                 .produced = 0,
             });
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = SIEGETANK,
-                .required = 3 + rnd(3),
+                .required = 3 + RNG::rnd(3),
                 .ordered = 0,
                 .produced = 0,
             });
         }
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 1);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), 1);
     }
 
     if (!hasMission(2)) {
         // 25% chance we want another different attack force
-        if (rnd(100) < 25) {
+        if (RNG::rnd(100) < 25) {
             group = std::vector<S_groupKind>();
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
@@ -832,40 +832,40 @@ void cPlayerBrainCampaign::produceLevel7Missions(int trikeKind, int infantryKind
                 .ordered = 0,
                 .produced = 0,
             });
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = SIEGETANK,
-                    .required = 1 + rnd(2),
+                    .required = 1 + RNG::rnd(2),
                     .ordered = 0,
                     .produced = 0,
                 });
             }
             if (player->getHouse() != ORDOS) {
-                if (rnd(100) < 75) {
+                if (RNG::rnd(100) < 75) {
                     group.push_back(S_groupKind{
                         .buildType = eBuildType::UNIT,
                         .type = LAUNCHER,
-                        .required = 1 + rnd(2),
+                        .required = 1 + RNG::rnd(2),
                         .ordered = 0,
                         .produced = 0,
                     });
                 }
             }
-            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + rnd(10), 2);
+            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + RNG::rnd(10), 2);
         }
     }
     if (!hasMission(3)) {
         group = std::vector<S_groupKind>();
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = infantryKind,
-                .required = 1 + rnd(2),
+                .required = 1 + RNG::rnd(2),
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 3);
+            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(10), 3);
         }
     }
     // build additional harvester (we want 2 harvesters in total)
@@ -880,7 +880,7 @@ void cPlayerBrainCampaign::produceLevel7Missions(int trikeKind, int infantryKind
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 4);
+            addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(25), 4);
         }
         else {
             // we already have mission 4, meaning we have the additional harvester.
@@ -898,7 +898,7 @@ void cPlayerBrainCampaign::produceLevel7Missions(int trikeKind, int infantryKind
                         .produced = 0,
                     });
                     // different mission ID
-                    addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 5);
+                    addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(25), 5);
                 }
             }
         }
@@ -908,15 +908,15 @@ void cPlayerBrainCampaign::produceLevel7Missions(int trikeKind, int infantryKind
         if (player->hasAtleastOneStructure(HIGHTECH)) {
             if (!hasMission(6)) {
                 group = std::vector<S_groupKind>();
-                if (rnd(100) < 10) {
+                if (RNG::rnd(100) < 10) {
                     group.push_back(S_groupKind{
                         .buildType = eBuildType::UNIT,
                         .type = ORNITHOPTER,
-                        .required = 1 + rnd(2),
+                        .required = 1 + RNG::rnd(2),
                         .ordered = 0,
                         .produced = 0,
                     });
-                    addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 6);
+                    addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(10), 6);
                 }
             }
         }
@@ -925,7 +925,7 @@ void cPlayerBrainCampaign::produceLevel7Missions(int trikeKind, int infantryKind
     if (player->hasAtleastOneStructure(HIGHTECH)) {
         if (!hasMission(7)) {
             group = std::vector<S_groupKind>();
-            if (rnd(100) < 10) {
+            if (RNG::rnd(100) < 10) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = CARRYALL,
@@ -933,7 +933,7 @@ void cPlayerBrainCampaign::produceLevel7Missions(int trikeKind, int infantryKind
                     .ordered = 0,
                     .produced = 0,
                 });
-                addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(10), 7);
+                addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(10), 7);
             }
         }
     }
@@ -954,7 +954,7 @@ void cPlayerBrainCampaign::produceLevel8Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
-                .required = 1 + rnd(2),
+                .required = 1 + RNG::rnd(2),
                 .ordered = 0,
                 .produced = 0,
             });
@@ -963,17 +963,17 @@ void cPlayerBrainCampaign::produceLevel8Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
-                .required = 1 + rnd(3),
+                .required = 1 + RNG::rnd(3),
                 .ordered = 0,
                 .produced = 0,
             });
         }
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), 0);
     }
 
     if (!hasMission(1)) {
         group = std::vector<S_groupKind>();
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
@@ -983,29 +983,29 @@ void cPlayerBrainCampaign::produceLevel8Missions(int trikeKind, int infantryKind
             });
         }
         if (player->getHouse() != ORDOS) {
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = LAUNCHER,
-                    .required = 1 + rnd(3),
+                    .required = 1 + RNG::rnd(3),
                     .ordered = 0,
                     .produced = 0,
                 });
             }
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = TANK,
-                    .required = 2 + rnd(4),
+                    .required = 2 + RNG::rnd(4),
                     .ordered = 0,
                     .produced = 0,
                 });
             }
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = SIEGETANK,
-                    .required = 3 + rnd(4),
+                    .required = 3 + RNG::rnd(4),
                     .ordered = 0,
                     .produced = 0,
                 });
@@ -1015,24 +1015,24 @@ void cPlayerBrainCampaign::produceLevel8Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = TANK,
-                .required = 2 + rnd(4),
+                .required = 2 + RNG::rnd(4),
                 .ordered = 0,
                 .produced = 0,
             });
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = SIEGETANK,
-                .required = 3 + rnd(3),
+                .required = 3 + RNG::rnd(3),
                 .ordered = 0,
                 .produced = 0,
             });
         }
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 1);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), 1);
     }
 
     if (!hasMission(2)) {
         // 25% chance we want another different attack force
-        if (rnd(100) < 25) {
+        if (RNG::rnd(100) < 25) {
             group = std::vector<S_groupKind>();
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
@@ -1041,40 +1041,40 @@ void cPlayerBrainCampaign::produceLevel8Missions(int trikeKind, int infantryKind
                 .ordered = 0,
                 .produced = 0,
             });
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = SIEGETANK,
-                    .required = 1 + rnd(2),
+                    .required = 1 + RNG::rnd(2),
                     .ordered = 0,
                     .produced = 0,
                 });
             }
             if (player->getHouse() != ORDOS) {
-                if (rnd(100) < 75) {
+                if (RNG::rnd(100) < 75) {
                     group.push_back(S_groupKind{
                         .buildType = eBuildType::UNIT,
                         .type = LAUNCHER,
-                        .required = 1 + rnd(2),
+                        .required = 1 + RNG::rnd(2),
                         .ordered = 0,
                         .produced = 0,
                     });
                 }
             }
-            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + rnd(10), 2);
+            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + RNG::rnd(10), 2);
         }
     }
     if (!hasMission(3)) {
         group = std::vector<S_groupKind>();
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = infantryKind,
-                .required = 1 + rnd(2),
+                .required = 1 + RNG::rnd(2),
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 3);
+            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(10), 3);
         }
     }
     // build additional harvester (we want 2 harvesters in total)
@@ -1089,7 +1089,7 @@ void cPlayerBrainCampaign::produceLevel8Missions(int trikeKind, int infantryKind
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 4);
+            addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(25), 4);
         }
         else {
             // we already have mission 4, meaning we have the additional harvester.
@@ -1107,7 +1107,7 @@ void cPlayerBrainCampaign::produceLevel8Missions(int trikeKind, int infantryKind
                         .produced = 0,
                     });
                     // different mission ID
-                    addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 5);
+                    addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(25), 5);
                 }
             }
         }
@@ -1117,15 +1117,15 @@ void cPlayerBrainCampaign::produceLevel8Missions(int trikeKind, int infantryKind
         if (player->hasAtleastOneStructure(HIGHTECH)) {
             if (!hasMission(6)) {
                 group = std::vector<S_groupKind>();
-                if (rnd(100) < 10) {
+                if (RNG::rnd(100) < 10) {
                     group.push_back(S_groupKind{
                         .buildType = eBuildType::UNIT,
                         .type = ORNITHOPTER,
-                        .required = 1 + rnd(2),
+                        .required = 1 + RNG::rnd(2),
                         .ordered = 0,
                         .produced = 0,
                     });
-                    addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 6);
+                    addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(10), 6);
                 }
             }
         }
@@ -1134,7 +1134,7 @@ void cPlayerBrainCampaign::produceLevel8Missions(int trikeKind, int infantryKind
     if (player->hasAtleastOneStructure(HIGHTECH)) {
         if (!hasMission(7)) {
             group = std::vector<S_groupKind>();
-            if (rnd(100) < 10) {
+            if (RNG::rnd(100) < 10) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = CARRYALL,
@@ -1142,7 +1142,7 @@ void cPlayerBrainCampaign::produceLevel8Missions(int trikeKind, int infantryKind
                     .ordered = 0,
                     .produced = 0,
                 });
-                addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(10), 7);
+                addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(10), 7);
             }
         }
     }
@@ -1177,12 +1177,12 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
                 .produced = 0,
             });
         }
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), 0);
     }
 
     if (!hasMission(1)) {
         group = std::vector<S_groupKind>();
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
@@ -1195,15 +1195,15 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = LAUNCHER,
-                .required = 1 + rnd(3),
+                .required = 1 + RNG::rnd(3),
                 .ordered = 0,
                 .produced = 0,
             });
-            if (rnd(100) < 35) {
+            if (RNG::rnd(100) < 35) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = TANK,
-                    .required = 2 + rnd(4),
+                    .required = 2 + RNG::rnd(4),
                     .ordered = 0,
                     .produced = 0,
                 });
@@ -1211,7 +1211,7 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = SIEGETANK,
-                .required = 3 + rnd(4),
+                .required = 3 + RNG::rnd(4),
                 .ordered = 0,
                 .produced = 0,
             });
@@ -1239,14 +1239,14 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = TANK,
-                .required = 2 + rnd(4),
+                .required = 2 + RNG::rnd(4),
                 .ordered = 0,
                 .produced = 0,
             });
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = SIEGETANK,
-                .required = 3 + rnd(3),
+                .required = 3 + RNG::rnd(3),
                 .ordered = 0,
                 .produced = 0,
             });
@@ -1258,12 +1258,12 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
                 .produced = 0,
             });
         }
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 1);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), 1);
     }
 
     if (!hasMission(2)) {
         // 25% chance we want another different attack force
-        if (rnd(100) < 25) {
+        if (RNG::rnd(100) < 25) {
             group = std::vector<S_groupKind>();
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
@@ -1272,11 +1272,11 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
                 .ordered = 0,
                 .produced = 0,
             });
-            if (rnd(100) < 75) {
+            if (RNG::rnd(100) < 75) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = SIEGETANK,
-                    .required = 1 + rnd(2),
+                    .required = 1 + RNG::rnd(2),
                     .ordered = 0,
                     .produced = 0,
                 });
@@ -1285,25 +1285,25 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = LAUNCHER,
-                    .required = 1 + rnd(2),
+                    .required = 1 + RNG::rnd(2),
                     .ordered = 0,
                     .produced = 0,
                 });
             }
-            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + rnd(10), 2);
+            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + RNG::rnd(10), 2);
         }
     }
     if (!hasMission(3)) {
         group = std::vector<S_groupKind>();
-        if (rnd(100) < 5) {
+        if (RNG::rnd(100) < 5) {
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = infantryKind,
-                .required = 1 + rnd(2),
+                .required = 1 + RNG::rnd(2),
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 3);
+            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(10), 3);
         }
     }
     // build additional harvester (we want 2 harvesters in total)
@@ -1318,7 +1318,7 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 4);
+            addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(25), 4);
         }
         else {
             // we already have mission 4, meaning we have the additional harvester.
@@ -1336,7 +1336,7 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
                         .produced = 0,
                     });
                     // different mission ID
-                    addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 5);
+                    addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(25), 5);
                 }
             }
         }
@@ -1346,15 +1346,15 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
         if (player->hasAtleastOneStructure(HIGHTECH)) {
             if (!hasMission(6)) {
                 group = std::vector<S_groupKind>();
-                if (rnd(100) < 10) {
+                if (RNG::rnd(100) < 10) {
                     group.push_back(S_groupKind{
                         .buildType = eBuildType::UNIT,
                         .type = ORNITHOPTER,
-                        .required = 1 + rnd(2),
+                        .required = 1 + RNG::rnd(2),
                         .ordered = 0,
                         .produced = 0,
                     });
-                    addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 6);
+                    addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(10), 6);
                 }
             }
         }
@@ -1363,7 +1363,7 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
     if (player->hasAtleastOneStructure(HIGHTECH)) {
         if (!hasMission(7)) {
             group = std::vector<S_groupKind>();
-            if (rnd(100) < 10) {
+            if (RNG::rnd(100) < 10) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = CARRYALL,
@@ -1371,7 +1371,7 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
                     .ordered = 0,
                     .produced = 0,
                 });
-                addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(10), 7);
+                addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(10), 7);
             }
         }
     }
@@ -1380,15 +1380,15 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
         if (player->hasAtleastOneStructure(HIGHTECH)) {
             if (!hasMission(6)) {
                 group = std::vector<S_groupKind>();
-                if (rnd(100) < 10) {
+                if (RNG::rnd(100) < 10) {
                     group.push_back(S_groupKind{
                         .buildType = eBuildType::UNIT,
                         .type = ORNITHOPTER,
-                        .required = 1 + rnd(2),
+                        .required = 1 + RNG::rnd(2),
                         .ordered = 0,
                         .produced = 0,
                     });
-                    addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 6);
+                    addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(10), 6);
                 }
             }
         }
@@ -1397,7 +1397,7 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
     if (player->hasAtleastOneStructure(HIGHTECH)) {
         if (!hasMission(7)) {
             group = std::vector<S_groupKind>();
-            if (rnd(100) < 10) {
+            if (RNG::rnd(100) < 10) {
                 group.push_back(S_groupKind{
                     .buildType = eBuildType::UNIT,
                     .type = CARRYALL,
@@ -1405,7 +1405,7 @@ void cPlayerBrainCampaign::produceLevel9Missions(int trikeKind, int infantryKind
                     .ordered = 0,
                     .produced = 0,
                 });
-                addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(10), 7);
+                addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(10), 7);
             }
         }
     }
@@ -1419,14 +1419,14 @@ void cPlayerBrainCampaign::produceLevel4Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = trikeKind,
-                .required = 1 + rnd(1),
+                .required = 1 + RNG::rnd(1),
                 .ordered = 0,
                 .produced = 0,
             });
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
-                .required = 1 + rnd(3),
+                .required = 1 + RNG::rnd(3),
                 .ordered = 0,
                 .produced = 0,
             });
@@ -1435,19 +1435,19 @@ void cPlayerBrainCampaign::produceLevel4Missions(int trikeKind, int infantryKind
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
-                .required = 2 + rnd(2),
+                .required = 2 + RNG::rnd(2),
                 .ordered = 0,
                 .produced = 0,
             });
         }
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), 0);
     }
     if (!hasMission(1)) {
         group = std::vector<S_groupKind>();
         group.push_back(S_groupKind{
             .buildType = eBuildType::UNIT,
             .type = TANK,
-            .required = 1 + rnd(3),
+            .required = 1 + RNG::rnd(3),
             .ordered = 0,
             .produced = 0,
         });
@@ -1458,19 +1458,19 @@ void cPlayerBrainCampaign::produceLevel4Missions(int trikeKind, int infantryKind
             .ordered = 0,
             .produced = 0,
         });
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + rnd(10), 1);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, 10 + RNG::rnd(10), 1);
     }
     if (!hasMission(2)) {
         group = std::vector<S_groupKind>();
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = infantryKind,
-                .required = 2 + rnd(4),
+                .required = 2 + RNG::rnd(4),
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 2);
+            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(10), 2);
         }
     }
 
@@ -1486,7 +1486,7 @@ void cPlayerBrainCampaign::produceLevel4Missions(int trikeKind, int infantryKind
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 3);
+            addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(25), 3);
         }
         else {
             // we already have mission 3, meaning we have the additional harvester.
@@ -1503,7 +1503,7 @@ void cPlayerBrainCampaign::produceLevel4Missions(int trikeKind, int infantryKind
                         .produced = 0,
                     });
                     // different mission ID
-                    addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(25), 4);
+                    addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(25), 4);
                 }
             }
         }
@@ -1518,14 +1518,14 @@ void cPlayerBrainCampaign::produceLevel3Missions(int trikeKind, int soldierKind,
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
-                .required = 1 + rnd(2),
+                .required = 1 + RNG::rnd(2),
                 .ordered = 0,
                 .produced = 0,
             });
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = trikeKind,
-                .required = 1 + rnd(1),
+                .required = 1 + RNG::rnd(1),
                 .ordered = 0,
                 .produced = 0,
             });
@@ -1534,12 +1534,12 @@ void cPlayerBrainCampaign::produceLevel3Missions(int trikeKind, int soldierKind,
             group.push_back(S_groupKind{
                 .buildType = eBuildType::UNIT,
                 .type = QUAD,
-                .required = 2 + rnd(3),
+                .required = 2 + RNG::rnd(3),
                 .ordered = 0,
                 .produced = 0,
             });
         }
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), 0);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), 0);
     }
     if (!hasMission(1)) {
         group = std::vector<S_groupKind>();
@@ -1547,18 +1547,18 @@ void cPlayerBrainCampaign::produceLevel3Missions(int trikeKind, int soldierKind,
         group.push_back(S_groupKind{
             .buildType = eBuildType::UNIT,
             .type = soldierKind,
-            .required = 1 + rnd(3),
+            .required = 1 + RNG::rnd(3),
             .ordered = 0,
             .produced = 0,
         });
         group.push_back(S_groupKind{
             .buildType = eBuildType::UNIT,
             .type = infantryKind,
-            .required = 1 + rnd(2),
+            .required = 1 + RNG::rnd(2),
             .ordered = 0,
             .produced = 0,
         });
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 1);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(10), 1);
     }
 }
 
@@ -1569,18 +1569,18 @@ void cPlayerBrainCampaign::produceLevel2Missions(int soldierKind, int infantryKi
         group.push_back(S_groupKind{
             .buildType = eBuildType::UNIT,
             .type = soldierKind,
-            .required = 2 + rnd(1),
+            .required = 2 + RNG::rnd(1),
             .ordered = 0,
             .produced = 0,
         });
         group.push_back(S_groupKind{
             .buildType = eBuildType::UNIT,
             .type = infantryKind,
-            .required = 1 + rnd(1),
+            .required = 1 + RNG::rnd(1),
             .ordered = 0,
             .produced = 0,
         });
-        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(10), 0);
+        addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(10), 0);
     }
 }
 
@@ -1729,7 +1729,7 @@ void cPlayerBrainCampaign::onEntityDiscoveredEvent(const s_GameEvent &event)
                         m_discoveredEnemyAtCell.insert(event.atCell);
 
                         if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
-                            respondToThreat(&pUnit, nullptr, event.atCell, 2 + rnd(4));
+                            respondToThreat(&pUnit, nullptr, event.atCell, 2 + RNG::rnd(4));
                         }
                     }
                 }
@@ -1788,7 +1788,7 @@ void cPlayerBrainCampaign::onEntityDiscoveredEvent(const s_GameEvent &event)
                     cUnit &pUnit = unit[event.entityID];
                     if (pUnit.isValid() && !pUnit.getPlayer()->isSameTeamAs(player)) {
                         if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
-                            respondToThreat(&pUnit, nullptr, event.atCell, 2 + rnd(4));
+                            respondToThreat(&pUnit, nullptr, event.atCell, 2 + RNG::rnd(4));
                         }
                     }
                 }

--- a/src/player/brains/cPlayerBrainSkirmish.cpp
+++ b/src/player/brains/cPlayerBrainSkirmish.cpp
@@ -4,7 +4,7 @@
 #include "enums.h"
 #include "d2tmc.h"
 #include "player/cPlayer.h"
-
+#include "utils/RNG.hpp"
 #include <fmt/core.h>
 
 #include <algorithm>
@@ -19,7 +19,7 @@ cPlayerBrainSkirmish::cPlayerBrainSkirmish(cPlayer *player) :
 //         timer is subtracted every 100 ms with 1 (ie, 10 == 10*100 = 1000ms == 1 second)
 //         10*60 -> 1 minute. * 4 -> 4 minutes
 //        m_TIMER_rest = (10 * 60) * 4;
-    m_TIMER_rest = rnd(25); // todo: based on difficulty?
+    m_TIMER_rest = RNG::rnd(25); // todo: based on difficulty?
     if (game.m_noAiRest) {
         m_TIMER_rest = 10;
     }
@@ -27,16 +27,16 @@ cPlayerBrainSkirmish::cPlayerBrainSkirmish(cPlayer *player) :
     m_TIMER_ai = 0; // increased every 100 ms with 1. (ie 10 ticks is 1 second)
 
     // These are all kinds of things we can use to influence AI's behavior
-    int multiplier = 1 + rnd(3); // TODO: base this on difficulty setting?
+    int multiplier = 1 + RNG::rnd(3); // TODO: base this on difficulty setting?
     m_MOMENT_whenToBuildAdditionalRefinery = MOMENT_CONSIDER_ADDITIONAL_REFINERY * multiplier;
-    int randomizer = -400 + (rnd(800)); // TODO: base this on difficulty setting?
+    int randomizer = -400 + (RNG::rnd(800)); // TODO: base this on difficulty setting?
     m_TIMER_mayBuildAdditionalUnits = MOMENT_PRODUCE_ADDITIONAL_UNITS + randomizer;
     m_TIMER_additionalUnitsCooldown = 0;
     m_eagernessToBuildRandomUnits = 15; // TODO: base this on difficulty setting?
-    m_idealRefineriesCount = 2 + rnd(2); // TODO: base this on difficulty setting?
-    m_idealHarvesterCount = m_idealRefineriesCount * 2 + rnd(2); // TODO: base this on difficulty setting?
-    m_idealCarryallCount = 2 + rnd(2); // TODO: base this on difficulty setting?
-    m_idealOrnisCount = rnd(5); // TODO: base this on difficulty setting?
+    m_idealRefineriesCount = 2 + RNG::rnd(2); // TODO: base this on difficulty setting?
+    m_idealHarvesterCount = m_idealRefineriesCount * 2 + RNG::rnd(2); // TODO: base this on difficulty setting?
+    m_idealCarryallCount = 2 + RNG::rnd(2); // TODO: base this on difficulty setting?
+    m_idealOrnisCount = RNG::rnd(5); // TODO: base this on difficulty setting?
 
     m_myBase = std::vector<S_structurePosition>();
     m_buildOrders = std::vector<S_buildOrder>();
@@ -274,7 +274,7 @@ void cPlayerBrainSkirmish::onMyStructureAttacked(const s_GameEvent &event)
 
         int cell = originUnit.getCell();
 
-        respondToThreat(&originUnit, nullptr, cell, 2 + rnd(4));
+        respondToThreat(&originUnit, nullptr, cell, 2 + RNG::rnd(4));
     }
 }
 
@@ -419,49 +419,49 @@ void cPlayerBrainSkirmish::thinkState_Missions()
                 int chance = m_eagernessToBuildRandomUnits + (m_economyState == PLAYERBRAIN_ECONOMY_STATE_GOOD ? 15 : 5);
 
                 // time to try again... randomized (TODO: Can be difficulty setting?)
-                m_TIMER_additionalUnitsCooldown += rnd(15);
+                m_TIMER_additionalUnitsCooldown += RNG::rnd(15);
 
                 log(fmt::format("mayBuildAdditionalResources(): Will attempt to build additional resources. Chance = {}, new coolDown = {}", chance, m_TIMER_additionalUnitsCooldown));
 
                 // build units, as long as we have some money on the bank.
                 // these units are produced without a mission.
-                if (rnd(100) < chance) {
+                if (RNG::rnd(100) < chance) {
                     // when the player has it, it will be build
                     buildUnitIfICanAndNotAlreadyQueued(SONICTANK);
                     buildUnitIfICanAndNotAlreadyQueued(DEVIATOR);
                     buildUnitIfICanAndNotAlreadyQueued(DEVASTATOR);
                 }
-                if (rnd(100) < chance) {
+                if (RNG::rnd(100) < chance) {
                     if (player->getAmountOfUnitsForType(SIEGETANK) < 8) {
                         buildUnitIfICanAndNotAlreadyQueued(SIEGETANK);
                     }
                 }
-                if (rnd(100) < chance) {
+                if (RNG::rnd(100) < chance) {
                     if (player->getAmountOfUnitsForType(LAUNCHER) < 6) {
                         buildUnitIfICanAndNotAlreadyQueued(LAUNCHER);
                     }
                 }
-                if (rnd(100) < chance) {
+                if (RNG::rnd(100) < chance) {
                     if (player->getAmountOfUnitsForType(QUAD) < 5) {
                         buildUnitIfICanAndNotAlreadyQueued(QUAD);
                     }
                 }
-                if (rnd(100) < chance) {
+                if (RNG::rnd(100) < chance) {
                     if (player->getAmountOfUnitsForType(TANK) < 4) {
                         buildUnitIfICanAndNotAlreadyQueued(TANK);
                     }
                 }
-                if (rnd(100) < chance) {
+                if (RNG::rnd(100) < chance) {
                     if (player->getAmountOfUnitsForType(ORNITHOPTER) < m_idealOrnisCount) {
                         buildUnitIfICanAndNotAlreadyQueued(ORNITHOPTER);
                     }
                 }
-                if (rnd(100) < chance) {
+                if (RNG::rnd(100) < chance) {
                     if (player->getAmountOfUnitsForType(HARVESTER) < m_idealHarvesterCount) {
                         buildUnitIfICanAndNotAlreadyQueued(HARVESTER);
                     }
                 }
-                if (rnd(100) < chance) {
+                if (RNG::rnd(100) < chance) {
                     if (player->getAmountOfUnitsForType(CARRYALL) < m_idealCarryallCount) {
                         buildUnitIfICanAndNotAlreadyQueued(CARRYALL);
                     }
@@ -545,7 +545,7 @@ void cPlayerBrainSkirmish::produceEconomyImprovingMissions()
                     .ordered = 0,
                     .produced = 0,
                 });
-                addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(15), MISSION_IMPROVE_ECONOMY_BUILD_ADDITIONAL_HARVESTER);
+                addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(15), MISSION_IMPROVE_ECONOMY_BUILD_ADDITIONAL_HARVESTER);
             }
         }
     }
@@ -563,7 +563,7 @@ void cPlayerBrainSkirmish::produceEconomyImprovingMissions()
                     .ordered = 0,
                     .produced = 0,
                 });
-                addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, rnd(15), MISSION_IMPROVE_ECONOMY_BUILD_ADDITIONAL_CARRYALL);
+                addMission(PLAYERBRAINMISSION_IMPROVE_ECONOMY, group, RNG::rnd(15), MISSION_IMPROVE_ECONOMY_BUILD_ADDITIONAL_CARRYALL);
             }
         }
     }
@@ -576,21 +576,21 @@ void cPlayerBrainSkirmish::produceSuperWeaponMissionsWhenApplicable()
         std::vector<S_groupKind> group = std::vector<S_groupKind>();
         // no need to add resources to mission, they are auto-produced.
         // TODO: Think of a way to make this script/configurable
-        addMission(PLAYERBRAINMISSION_KIND_SUPERWEAPON_DEATHHAND, group, rnd(10), SPECIAL_MISSION1);
+        addMission(PLAYERBRAINMISSION_KIND_SUPERWEAPON_DEATHHAND, group, RNG::rnd(10), SPECIAL_MISSION1);
     }
 
     if (player->couldBuildSpecial(SPECIAL_SABOTEUR) && !hasMission(SPECIAL_MISSION2)) {
         std::vector<S_groupKind> group = std::vector<S_groupKind>();
         // no need to add resources to mission, they are auto-produced.
         // TODO: Think of a way to make this script/configurable
-        addMission(PLAYERBRAINMISSION_KIND_SUPERWEAPON_SABOTEUR, group, rnd(10), SPECIAL_MISSION2);
+        addMission(PLAYERBRAINMISSION_KIND_SUPERWEAPON_SABOTEUR, group, RNG::rnd(10), SPECIAL_MISSION2);
     }
 
     if (player->couldBuildSpecial(SPECIAL_FREMEN) && !hasMission(SPECIAL_MISSION3)) {
         std::vector<S_groupKind> group = std::vector<S_groupKind>();
         // no need to add resources to mission, they are auto-produced.
         // TODO: Think of a way to make this script/configurable
-        addMission(PLAYERBRAINMISSION_KIND_SUPERWEAPON_FREMEN, group, rnd(10), SPECIAL_MISSION3);
+        addMission(PLAYERBRAINMISSION_KIND_SUPERWEAPON_FREMEN, group, RNG::rnd(10), SPECIAL_MISSION3);
     }
 }
 
@@ -626,7 +626,7 @@ void cPlayerBrainSkirmish::produceMissionsWhenEnemyDetected()
             .ordered = 0,
             .produced = 0,
         });
-        addMission(PLAYERBRAINMISSION_KIND_DEFEND, group, rnd(15), MISSION_GUARDFORCE);
+        addMission(PLAYERBRAINMISSION_KIND_DEFEND, group, RNG::rnd(15), MISSION_GUARDFORCE);
     }
 
     // separate mission for air attacks
@@ -636,11 +636,11 @@ void cPlayerBrainSkirmish::produceMissionsWhenEnemyDetected()
             group.push_back(S_groupKind{
                 .buildType = UNIT,
                 .type = ORNITHOPTER,
-                .required = 1 + rnd(3),
+                .required = 1 + RNG::rnd(3),
                 .ordered = 0,
                 .produced = 0,
             });
-            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15),
+            addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15),
                        MISSION_ATTACK5);
         }
     }
@@ -660,7 +660,7 @@ void cPlayerBrainSkirmish::produceMissionsDuringPeacetime(int scoutingUnitType)
                 .produced = 0,
             });
 
-            addMission(PLAYERBRAINMISSION_KIND_EXPLORE, group, rnd(15),
+            addMission(PLAYERBRAINMISSION_KIND_EXPLORE, group, RNG::rnd(15),
                        MISSION_SCOUT1);
         }
         else if (!hasMission(MISSION_SCOUT2)) {
@@ -674,7 +674,7 @@ void cPlayerBrainSkirmish::produceMissionsDuringPeacetime(int scoutingUnitType)
                 .produced = 0,
             });
 
-            addMission(PLAYERBRAINMISSION_KIND_EXPLORE, group, rnd(15),
+            addMission(PLAYERBRAINMISSION_KIND_EXPLORE, group, RNG::rnd(15),
                        MISSION_SCOUT2);
         }
         else if (!hasMission(MISSION_SCOUT3)) {
@@ -688,7 +688,7 @@ void cPlayerBrainSkirmish::produceMissionsDuringPeacetime(int scoutingUnitType)
                 .produced = 0,
             });
 
-            addMission(PLAYERBRAINMISSION_KIND_EXPLORE, group, rnd(15), MISSION_SCOUT3);
+            addMission(PLAYERBRAINMISSION_KIND_EXPLORE, group, RNG::rnd(15), MISSION_SCOUT3);
         }
     }
 
@@ -709,7 +709,7 @@ void cPlayerBrainSkirmish::produceMissionsDuringPeacetime(int scoutingUnitType)
             .ordered = 0,
             .produced = 0,
         });
-        addMission(PLAYERBRAINMISSION_KIND_DEFEND, group, rnd(15), MISSION_GUARDFORCE);
+        addMission(PLAYERBRAINMISSION_KIND_DEFEND, group, RNG::rnd(15), MISSION_GUARDFORCE);
     }
 }
 
@@ -734,17 +734,17 @@ void cPlayerBrainSkirmish::produceSkirmishGroundAttackMission(int missionId)
         bigChance *= 1.25;
     }
 
-    if (rnd(100) < normalChance && player->canBuildUnitBool(SIEGETANK)) {
+    if (RNG::rnd(100) < normalChance && player->canBuildUnitBool(SIEGETANK)) {
         group.push_back(S_groupKind{
             .buildType = UNIT,
             .type = SIEGETANK,
-            .required = 1+rnd(4),
+            .required = 1+RNG::rnd(4),
             .ordered = 0,
             .produced = 0,
         });
     }
 
-    if (rnd(100) < smallChance && player->hasAtleastOneStructure(WOR)) {
+    if (RNG::rnd(100) < smallChance && player->hasAtleastOneStructure(WOR)) {
         int trooperUnit = TROOPER;
         if (player->canBuildUnitBool(TROOPERS)) {
             trooperUnit = TROOPERS;
@@ -752,13 +752,13 @@ void cPlayerBrainSkirmish::produceSkirmishGroundAttackMission(int missionId)
         group.push_back(S_groupKind{
             .buildType = UNIT,
             .type = trooperUnit,
-            .required = 1 + rnd(2),
+            .required = 1 + RNG::rnd(2),
             .ordered = 0,
             .produced = 0,
         });
     }
 
-    if (rnd(100) < smallChance && player->hasAtleastOneStructure(BARRACKS)) {
+    if (RNG::rnd(100) < smallChance && player->hasAtleastOneStructure(BARRACKS)) {
         int infantryUnit = INFANTRY;
         if (player->canBuildUnitBool(INFANTRY)) {
             infantryUnit = INFANTRY;
@@ -766,65 +766,65 @@ void cPlayerBrainSkirmish::produceSkirmishGroundAttackMission(int missionId)
         group.push_back(S_groupKind{
             .buildType = UNIT,
             .type = infantryUnit,
-            .required = 1 + rnd(2),
+            .required = 1 + RNG::rnd(2),
             .ordered = 0,
             .produced = 0,
         });
     }
 
-    if (rnd(100) < bigChance && player->canBuildUnitBool(LAUNCHER)) {
+    if (RNG::rnd(100) < bigChance && player->canBuildUnitBool(LAUNCHER)) {
         group.push_back(S_groupKind{
             .buildType = UNIT,
             .type = LAUNCHER,
-            .required = 1+rnd(3),
+            .required = 1+RNG::rnd(3),
             .ordered = 0,
             .produced = 0,
         });
     }
 
-    if (rnd(100) < bigChance && player->canBuildUnitBool(TANK)) {
+    if (RNG::rnd(100) < bigChance && player->canBuildUnitBool(TANK)) {
         group.push_back(S_groupKind{
             .buildType = UNIT,
             .type = TANK,
-            .required = 1+rnd(4),
+            .required = 1+RNG::rnd(4),
             .ordered = 0,
             .produced = 0,
         });
     }
 
     int scoutingUnitType = player->getScoutingUnitType();
-    if (rnd(100) < smallChance && player->canBuildUnitBool(scoutingUnitType)) {
+    if (RNG::rnd(100) < smallChance && player->canBuildUnitBool(scoutingUnitType)) {
         group.push_back(S_groupKind{
             .buildType = UNIT,
             .type = scoutingUnitType,
-            .required = 1+rnd(2),
+            .required = 1+RNG::rnd(2),
             .ordered = 0,
             .produced = 0,
         });
     }
 
-    if (QUAD != scoutingUnitType && player->canBuildUnitBool(QUAD) && rnd(100) < normalChance) {
+    if (QUAD != scoutingUnitType && player->canBuildUnitBool(QUAD) && RNG::rnd(100) < normalChance) {
         group.push_back(S_groupKind{
             .buildType = UNIT,
             .type = QUAD,
-            .required = 1+rnd(3),
+            .required = 1+RNG::rnd(3),
             .ordered = 0,
             .produced = 0,
         });
     }
 
     int specialType = player->getSpecialUnitType();
-    if (rnd(100) < normalChance && player->canBuildUnitBool(specialType)) {
+    if (RNG::rnd(100) < normalChance && player->canBuildUnitBool(specialType)) {
         group.push_back(S_groupKind{
             .buildType = UNIT,
             .type = specialType,
-            .required = 1+rnd(2),
+            .required = 1+RNG::rnd(2),
             .ordered = 0,
             .produced = 0,
         });
     }
 
-    addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, rnd(15), missionId);
+    addMission(PLAYERBRAINMISSION_KIND_ATTACK, group, RNG::rnd(15), missionId);
 }
 
 bool cPlayerBrainSkirmish::hasMission(const int id)
@@ -965,7 +965,7 @@ void cPlayerBrainSkirmish::thinkState_EndGame()
     }
 
     int cellToAttack = -1;
-    if (rnd(100) < 50) {
+    if (RNG::rnd(100) < 50) {
         for (int i = 0; i < MAX_UNITS; i++) {
             cUnit &cUnit = unit[i];
             if (!cUnit.isValid()) continue;
@@ -973,7 +973,7 @@ void cPlayerBrainSkirmish::thinkState_EndGame()
             if (!cUnit.isAttackingUnit()) continue; // skip units that cannot 'attack' stuff
             // enemy structure
             cellToAttack = cUnit.getCell();
-            if (rnd(100) < 5) {
+            if (RNG::rnd(100) < 5) {
                 break; // this way we kind of have randomly another target...
             }
         }
@@ -986,7 +986,7 @@ void cPlayerBrainSkirmish::thinkState_EndGame()
             if (theStructure->getPlayer()->isSameTeamAs(player)) continue; // skip allies and self
             // enemy structure
             cellToAttack = theStructure->getCell();
-            if (rnd(100) < 10) {
+            if (RNG::rnd(100) < 10) {
                 break; // this way we kind of have randomly another target...
             }
         }
@@ -1244,7 +1244,7 @@ void cPlayerBrainSkirmish::onEntityDiscoveredEvent(const s_GameEvent &event)
                         m_discoveredEnemyAtCell.insert(event.atCell);
 
                         if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
-                            respondToThreat(&pUnit, nullptr, event.atCell, 2 + rnd(4));
+                            respondToThreat(&pUnit, nullptr, event.atCell, 2 + RNG::rnd(4));
                         }
                     }
                 }
@@ -1306,7 +1306,7 @@ void cPlayerBrainSkirmish::onEntityDiscoveredEvent(const s_GameEvent &event)
                     cUnit &pUnit = unit[event.entityID];
                     if (pUnit.isValid() && !pUnit.getPlayer()->isSameTeamAs(player)) {
                         if (m_centerOfBaseCell > -1 && map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
-                            respondToThreat(&pUnit, nullptr, event.atCell, 2 + rnd(4));
+                            respondToThreat(&pUnit, nullptr, event.atCell, 2 + RNG::rnd(4));
                         }
                     }
                 }
@@ -1427,13 +1427,13 @@ int cPlayerBrainSkirmish::getStructureIdToBuildWithoutConsideringPowerUsage() co
 
     if (m_TIMER_ai > m_MOMENT_whenToBuildAdditionalRefinery) {
         // time to think about an additional refinery
-        if (rnd(100) < 50 && player->getAmountOfStructuresForType(REFINERY) < m_idealRefineriesCount) {
+        if (RNG::rnd(100) < 50 && player->getAmountOfStructuresForType(REFINERY) < m_idealRefineriesCount) {
             // build one
             return REFINERY;
         }
     }
 
-    if (player->hasAlmostReachMaxSpiceStorageCapacity() && rnd(100) < 15) {
+    if (player->hasAlmostReachMaxSpiceStorageCapacity() && RNG::rnd(100) < 15) {
         return SILO;
     }
 
@@ -1442,7 +1442,7 @@ int cPlayerBrainSkirmish::getStructureIdToBuildWithoutConsideringPowerUsage() co
 
     // randomize the order a bit, but do make sure that we have both before continueing
     if (!player->hasAtleastOneStructure(RADAR) && !player->hasAtleastOneStructure(HEAVYFACTORY)) {
-        if (rnd(100) < 50) {
+        if (RNG::rnd(100) < 50) {
             return RADAR;
         }
         else {
@@ -1454,7 +1454,7 @@ int cPlayerBrainSkirmish::getStructureIdToBuildWithoutConsideringPowerUsage() co
         if (!player->hasAtleastOneStructure(HEAVYFACTORY)) return HEAVYFACTORY;
     }
 
-    if (rnd(100) < 15) {
+    if (RNG::rnd(100) < 15) {
         if (player->isStructureTypeAvailableForConstruction(WOR)) {
             if (!player->hasAtleastOneStructure(WOR)) return WOR;
         }
@@ -1464,57 +1464,57 @@ int cPlayerBrainSkirmish::getStructureIdToBuildWithoutConsideringPowerUsage() co
     }
 
     // low chance on early palace (could be a specific "build profile" property?)
-    if (rnd(100) < 5) {
+    if (RNG::rnd(100) < 5) {
         if (!player->hasAtleastOneStructure(PALACE)) return PALACE;
     }
 
-    if (rnd(100) < 35) {
+    if (RNG::rnd(100) < 35) {
         if (player->getAmountOfStructuresForType(TURRET) < 2) {
             return TURRET;
         }
     }
 
-    if (rnd(100) < 40) {
+    if (RNG::rnd(100) < 40) {
         if (player->isStructureTypeAvailableForConstruction(HIGHTECH)) {
             if (!player->hasAtleastOneStructure(HIGHTECH))  return HIGHTECH;
         }
     }
 
     int chanceToBuildRocketTurrets = 60 - (player->getAmountOfStructuresForType(RTURRET) * 10);
-    if (rnd(100) < chanceToBuildRocketTurrets) {
+    if (RNG::rnd(100) < chanceToBuildRocketTurrets) {
         return RTURRET;
     }
 
     int chanceToBuildTurrets = 40 - (player->getAmountOfStructuresForType(TURRET) * 5);
-    if (rnd(100) < chanceToBuildTurrets)  {
+    if (RNG::rnd(100) < chanceToBuildTurrets)  {
         return TURRET;
     }
 
     if (!player->hasAtleastOneStructure(HIGHTECH))  return HIGHTECH;
     if (!player->hasAtleastOneStructure(STARPORT))  return STARPORT;
 
-    if (rnd(100) < 15) {
+    if (RNG::rnd(100) < 15) {
         if (!player->hasAtleastOneStructure(PALACE)) return PALACE;
     }
 
     if (!player->hasAtleastOneStructure(IX))  return IX;
 
     // take a shot at building the palace
-    if (rnd(100) < 15) {
+    if (RNG::rnd(100) < 15) {
         if (!player->hasAtleastOneStructure(PALACE)) return PALACE;
     }
 
     if (player->getAmountOfStructuresForType(RTURRET) < 8)  return RTURRET;
 
     // take another shot at building the palace
-    if (rnd(100) < 15) {
+    if (RNG::rnd(100) < 15) {
         if (!player->hasAtleastOneStructure(PALACE)) return PALACE;
     }
 
     if (!player->hasAtleastOneStructure(REPAIR))  return REPAIR;
 
     if (m_economyState == PLAYERBRAIN_ECONOMY_STATE_NORMAL) {
-        if (rnd(100) < 30) {
+        if (RNG::rnd(100) < 30) {
             if (player->getAmountOfStructuresForType(HEAVYFACTORY) < 2) return HEAVYFACTORY;
         }
 
@@ -1573,7 +1573,7 @@ bool cPlayerBrainSkirmish::mayBuildAdditionalResources()
     bool goodEconomy = m_economyState == PLAYERBRAIN_ECONOMY_STATE_NORMAL ||
                        m_economyState == PLAYERBRAIN_ECONOMY_STATE_GOOD;
 
-    return goodEconomy && rnd(100) < m_eagernessToBuildRandomUnits;
+    return goodEconomy && RNG::rnd(100) < m_eagernessToBuildRandomUnits;
 }
 
 void cPlayerBrainSkirmish::thinkFast()
@@ -1612,7 +1612,7 @@ void cPlayerBrainSkirmish::onMyUnitAttacked(const s_GameEvent &event)
 
     cUnit &victim = unit[event.entityID];
     if (victim.isHarvester()) {
-        respondToThreat(threat, &victim, event.atCell, 2 + rnd(4));
+        respondToThreat(threat, &victim, event.atCell, 2 + RNG::rnd(4));
     }
 }
 

--- a/src/player/brains/missions/cPlayerBrainMissionKindAttack.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKindAttack.cpp
@@ -4,7 +4,7 @@
 #include "definitions.h"
 #include "utils/d2tm_math.h"
 #include "player/cPlayer.h"
-
+#include "utils/RNG.hpp"
 #include <fmt/core.h>
 
 namespace brains {
@@ -22,7 +22,7 @@ cPlayerBrainMissionKindAttack::~cPlayerBrainMissionKindAttack()
 
 bool cPlayerBrainMissionKindAttack::think_SelectTarget()
 {
-    if (rnd(100) < 50) {
+    if (RNG::rnd(100) < 50) {
         targetStructureID = -1;
         targetUnitID = findEnemyUnit();
         if (targetUnitID < 0) {
@@ -52,7 +52,7 @@ int cPlayerBrainMissionKindAttack::findEnemyStructure() const
 
         // enemy structure
         target =  theStructure->getStructureId();
-        if (rnd(100) < 10) {
+        if (RNG::rnd(100) < 10) {
             break; // this way we kind of have randomly another target...
         }
     }
@@ -72,7 +72,7 @@ int cPlayerBrainMissionKindAttack::findEnemyUnit() const
 
         // enemy unit
         target = i;
-        if (rnd(100) < 5) {
+        if (RNG::rnd(100) < 5) {
             break; // this way we kind of have randomly another target...
         }
     }

--- a/src/player/brains/missions/cPlayerBrainMissionKindDeathHand.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKindDeathHand.cpp
@@ -3,7 +3,7 @@
 #include "d2tmc.h"
 #include "definitions.h"
 #include "player/cPlayer.h"
-
+#include "utils/RNG.hpp"
 #include <fmt/core.h>
 
 namespace brains {
@@ -36,7 +36,7 @@ bool cPlayerBrainMissionKindDeathHand::think_SelectTarget()
 
         // enemy structure
         target = theStructure->getCell();
-        if (rnd(100) < 25) {
+        if (RNG::rnd(100) < 25) {
             break; // this way we kind of have randomly another target...
         }
     }
@@ -51,7 +51,7 @@ bool cPlayerBrainMissionKindDeathHand::think_SelectTarget()
             if (!map.isVisible(pUnit.getCell(), player)) continue; // skip non visible targets
             // enemy unit
             target = i;
-            if (rnd(100) < 5) {
+            if (RNG::rnd(100) < 5) {
                 break; // this way we kind of have randomly another target...
             }
         }

--- a/src/player/brains/missions/cPlayerBrainMissionKindSaboteur.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKindSaboteur.cpp
@@ -1,7 +1,7 @@
 #include "cPlayerBrainMissionKindSaboteur.h"
 
 #include "d2tmc.h"
-
+#include "utils/RNG.hpp"
 #include <fmt/core.h>
 
 namespace brains {
@@ -34,7 +34,7 @@ bool cPlayerBrainMissionKindSaboteur::think_SelectTarget()
 
         // enemy structure
         targetStructureID = theStructure->getStructureId();
-        if (rnd(100) < 25) {
+        if (RNG::rnd(100) < 25) {
             break; // this way we kind of have randomly another target...
         }
     }

--- a/src/player/brains/superweapon/cPlayerBrainFremenSuperWeapon.cpp
+++ b/src/player/brains/superweapon/cPlayerBrainFremenSuperWeapon.cpp
@@ -2,7 +2,7 @@
 
 #include "d2tmc.h"
 #include "player/cPlayer.h"
-
+#include "utils/RNG.hpp"
 #include <fmt/core.h>
 
 #include <algorithm>
@@ -47,7 +47,7 @@ void cPlayerBrainFremenSuperWeapon::think()
         if (pPlayer->isSameTeamAs(player)) continue; // skip same team players
 
         // some chance to skip this player...
-        if (rnd(100) > 70) {
+        if (RNG::rnd(100) > 70) {
             continue;
         }
 
@@ -56,7 +56,7 @@ void cPlayerBrainFremenSuperWeapon::think()
         if (!unitIds.empty()) {
             std::shuffle(unitIds.begin(), unitIds.end(), g);
             cellToAttack = unit[unitIds.front()].getCell();
-            if (rnd(100) > 30) break;
+            if (RNG::rnd(100) > 30) break;
         }
 
         // or which structure
@@ -65,7 +65,7 @@ void cPlayerBrainFremenSuperWeapon::think()
             // pick structure to attack
             std::shuffle(structureIds.begin(), structureIds.end(), g);
             cellToAttack = structure[structureIds.front()]->getCell();
-            if (rnd(100) > 30) break;
+            if (RNG::rnd(100) > 30) break;
         }
     }
 

--- a/src/player/cPlayer.cpp
+++ b/src/player/cPlayer.cpp
@@ -1242,7 +1242,7 @@ int cPlayer::findCellToPlaceStructure(int structureType)
 
         // if we have found any we randomly abort
         if (!potentialCells.empty()) {
-            if (rnd(100) < 33) {
+            if (RNG::rnd(100) < 33) {
                 break;
             }
         }
@@ -1413,7 +1413,7 @@ int cPlayer::findRandomUnitTarget(int playerIndexToAttack)
         log(fmt::format("Targets {}", maxTargets));
     }
 
-    return iTargets[rnd(maxTargets)];
+    return iTargets[RNG::rnd(maxTargets)];
 }
 
 int cPlayer::findRandomStructureTarget(int iAttackPlayer)
@@ -1441,7 +1441,7 @@ int cPlayer::findRandomStructureTarget(int iAttackPlayer)
         log(fmt::format("STR] Targets {}", iT));
     }
 
-    return (iTargets[rnd(iT)]);
+    return (iTargets[RNG::rnd(iT)]);
 }
 
 eCantBuildReason cPlayer::canBuildStructure(int iStructureType)

--- a/src/utils/RNG.cpp
+++ b/src/utils/RNG.cpp
@@ -1,0 +1,28 @@
+#include "utils/RNG.hpp"
+
+std::mt19937& RNG::getGenerator()
+{
+    static std::random_device rd;
+    static std::mt19937 s_generator(rd());
+    return s_generator;
+}
+
+int RNG::genInt(int min, int max)
+{
+    std::uniform_int_distribution<int> dist(min, max);
+    return dist(getGenerator());
+}
+
+int RNG::rnd(int max)
+{
+    if (max<1)
+        return 0;
+    std::uniform_int_distribution<int> dist(0, max);
+        return dist(getGenerator());
+}
+
+double RNG::genDouble(double min, double max)
+{
+    std::uniform_real_distribution<double> dist(min, max);
+    return dist(getGenerator());
+}

--- a/src/utils/RNG.hpp
+++ b/src/utils/RNG.hpp
@@ -3,28 +3,13 @@
 
 class RNG {
 public:
-    static std::mt19937& getGenerator() {
-        static std::random_device rd;
-        static std::mt19937 s_generator(rd());
-        return s_generator;
-    }
+    static std::mt19937& getGenerator();
 
-    static int genInt(int min, int max) {
-        std::uniform_int_distribution<int> dist(min, max);
-        return dist(getGenerator());
-    }
+    static int genInt(int min, int max);
 
-    static int rnd(int max) {
-        if (max<1)
-            return 0;
-        std::uniform_int_distribution<int> dist(0, max);
-        return dist(getGenerator());
-    }
+    static int rnd(int max);
 
-    static double genDouble(double min, double max) {
-        std::uniform_real_distribution<double> dist(min, max);
-        return dist(getGenerator());
-    }
+    static double genDouble(double min, double max);
 
 private:
     RNG() = default;

--- a/src/utils/RNG.hpp
+++ b/src/utils/RNG.hpp
@@ -14,6 +14,13 @@ public:
         return dist(getGenerator());
     }
 
+    static int rnd(int max) {
+        if (max<0)
+            return 0;
+        std::uniform_int_distribution<int> dist(0, max);
+        return dist(getGenerator());
+    }
+
     static double genDouble(double min, double max) {
         std::uniform_real_distribution<double> dist(min, max);
         return dist(getGenerator());

--- a/src/utils/RNG.hpp
+++ b/src/utils/RNG.hpp
@@ -15,7 +15,7 @@ public:
     }
 
     static int rnd(int max) {
-        if (max<0)
+        if (max<1)
             return 0;
         std::uniform_int_distribution<int> dist(0, max);
         return dist(getGenerator());

--- a/src/utils/RNG.hpp
+++ b/src/utils/RNG.hpp
@@ -1,16 +1,18 @@
 #pragma once
 #include <random>
 
+// Class that centralizes all requests for random numbers
+
 class RNG {
 public:
+    //initialization of the number generator
     static std::mt19937& getGenerator();
-
+    //Returns an integer between min (included) and max (included)
     static int genInt(int min, int max);
-
+    //Returns an integer between 0 (included) and max(included)
     static int rnd(int max);
-
+    // Returns a decimal number between min (included) and max (included)
     static double genDouble(double min, double max);
-
 private:
     RNG() = default;
     RNG(const RNG&) = delete;

--- a/src/utils/d2tm_math.cpp
+++ b/src/utils/d2tm_math.cpp
@@ -220,11 +220,11 @@ int convertAngleToDrawIndex(int faceAngle, bool clockWiseBitmap, int offset, int
 }
 
 // return random number between 0 and 'max'
-int rnd(int max)
-{
-    if (max < 1) return 0;
-    return std::rand() % max;
-}
+// int rnd(int max)
+// {
+//     if (max < 1) return 0;
+//     return std::rand() % max;
+// }
 
 /**
  * returns length between 2 points, always > 0. If x and y match, distance is 1.

--- a/src/utils/d2tm_math.cpp
+++ b/src/utils/d2tm_math.cpp
@@ -219,13 +219,6 @@ int convertAngleToDrawIndex(int faceAngle, bool clockWiseBitmap, int offset, int
     }
 }
 
-// return random number between 0 and 'max'
-// int rnd(int max)
-// {
-//     if (max < 1) return 0;
-//     return std::rand() % max;
-// }
-
 /**
  * returns length between 2 points, always > 0. If x and y match, distance is 1.
  * @param x1

--- a/src/utils/d2tm_math.h
+++ b/src/utils/d2tm_math.h
@@ -10,7 +10,5 @@ int convertAngleToDrawIndex(int faceAngle, bool clockWiseBitmap = false, int off
 // bullet only
 int bullet_face_angle(float angle);
 
-// int rnd(int max);
-
 // length calculation
 double ABS_length(int x1, int y1, int x2, int y2); // returns only value > -1

--- a/src/utils/d2tm_math.h
+++ b/src/utils/d2tm_math.h
@@ -10,7 +10,7 @@ int convertAngleToDrawIndex(int faceAngle, bool clockWiseBitmap = false, int off
 // bullet only
 int bullet_face_angle(float angle);
 
-int rnd(int max);
+// int rnd(int max);
 
 // length calculation
 double ABS_length(int x1, int y1, int x2, int y2); // returns only value > -1


### PR DESCRIPTION
This PR replaces the current `rnd()` function with a new RNG::rnd() using https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution.html

This is a more modern way of generating random numbers.

The uniform implementation has less bias, [see a possible explanation here](https://stackoverflow.com/a/32860886).
