### PR TITLE
bug/#653/game_crash_state_playing

### DIFF
--- a/src/drawers/CreditsDrawer.cpp
+++ b/src/drawers/CreditsDrawer.cpp
@@ -13,8 +13,8 @@ CreditsDrawer::CreditsDrawer(cPlayer *thePlayer) : player(thePlayer)
 {
     assert(thePlayer);
     // bmp = NULL;
-    offset_credit.fill(0.0f);
-    offset_direction.fill(0);
+    memset(offset_credit, 0, sizeof(offset_credit));
+    memset(offset_direction, 0, sizeof(offset_direction));
     initial = true;
     soundType = -1;
     rollSpeed = 0.0F;
@@ -44,8 +44,8 @@ void CreditsDrawer::setCredits(int amount)
     initial = true;
     previousCredits = amount;
     currentCredits = amount;
-    offset_credit.fill(0.0f);
-    offset_direction.fill(0);
+    memset(offset_credit, 0, sizeof(offset_credit));
+    memset(offset_direction, 0, sizeof(offset_direction));
 }
 
 // timer based method
@@ -55,8 +55,9 @@ void CreditsDrawer::thinkFast()
     if (hasDrawnCurrentCredits() || initial) {
         soundsMade = 0;
 
-        offset_credit.fill(0.0f);
-        offset_direction.fill(0);
+        memset(offset_credit, 0, sizeof(offset_credit));
+        memset(offset_direction, 0, sizeof(offset_direction));
+
         // determine new currentCredits
         // TODO: make it 'roll' instead of 'jump' to the newest credits?
         previousCredits = currentCredits;
@@ -114,8 +115,12 @@ void CreditsDrawer::thinkFast()
 // it has to go 'up' or 'down'
 void CreditsDrawer::thinkAboutIndividualCreditOffsets()
 {
-    std::string current_credits = std::to_string(currentCredits);
-    std::string previous_credits = std::to_string(previousCredits);
+    char current_credits[9];
+    char previous_credits[9];
+    memset(current_credits, 0, sizeof(current_credits));
+    memset(previous_credits, 0, sizeof(previous_credits));
+    sprintf(current_credits, "%d", currentCredits);
+    sprintf(previous_credits, "%d", previousCredits);
 
     for (int i = 0; i < 6; i++) {
         int currentId = getCreditDrawId(current_credits[i]);
@@ -154,7 +159,7 @@ void CreditsDrawer::thinkAboutIndividualCreditOffsets()
             }
             // it is fully 'moved'. Now update the array.
             previous_credits[i] = current_credits[i];
-            previousCredits = std::stoi(previous_credits);
+            previousCredits = atoi(previous_credits);
         }
         else {
             offset_credit[i] += 1.0F * rollSpeed;

--- a/src/drawers/CreditsDrawer.h
+++ b/src/drawers/CreditsDrawer.h
@@ -6,7 +6,6 @@
  */
 
 #pragma once
-#include <array>
 
 class cPlayer;
 struct SDL_Surface;
@@ -43,8 +42,8 @@ private:
     int previousCredits;	// previous credits we wanted to draw
 
     // the offset of the current 'credit' being drawn (the Y offset)
-    std::array<float, 7> offset_credit;
-    std::array<int, 7> offset_direction; // direction (0 = not yet determined / finished, 1 = UP, 2 = DOWN , 3 = DO NOTHING
+    float offset_credit[7];
+    int offset_direction[7]; // direction (0 = not yet determined / finished, 1 = UP, 2 = DOWN , 3 = DO NOTHING
 
     bool hasDrawnCurrentCredits();	// returns true whenever the new state has been finalized.
 


### PR DESCRIPTION
Fix bug on str::string for money drawer.
This reverts commit e3956b3fb808a578c2e6a168bd01a3806d5d2882.