### PR TITLE
Attempt increasing pagesize to make Windows builds more stable

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -17,6 +17,12 @@ jobs:
           msystem: MINGW64 # D2TM is built within a MinGW64 bit environment
           update: true
           install: mingw-w64-x86_64-toolchain mingw64/mingw-w64-x86_64-SDL2 mingw64/mingw-w64-x86_64-SDL2_mixer mingw64/mingw-w64-x86_64-SDL2_image mingw64/mingw-w64-x86_64-SDL2_ttf mingw64/mingw-w64-x86_64-cmake
+      - name: configure Pagefile
+        uses: al-cheb/configure-pagefile-action@v1.2
+        with:
+          minimum-size: 16GB
+          maximum-size: 16GB
+          disk-root: "C:"
       - name: Checkout
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Sometimes windows builds fail with:
```
cc1plus.exe: out of memory allocating 65536 bytes
```

[On GH I saw someone was able to fix this by increasing the pagesize on windows](https://github.com/actions/runner-images/issues/5140#issuecomment-1051356860), so this PR attempts to do that.