### PR TITLE
Fix M_PI redefined

### DIFF
--- a/src/utils/d2tm_math.h
+++ b/src/utils/d2tm_math.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#ifndef M_PI 
 // Taken from cmath.h - An easy way to be cross-platform compatible, see also https://stackoverflow.com/a/6563891/214597
 #define M_PI        3.14159265358979323846264338327950288   /* pi             */
+#endif // M_PI
 
 // Angle stuff for unit facing
 float fDegrees(int x1, int y1, int x2, int y2);


### PR DESCRIPTION
- avoid tons of warning from g++ on Ubuntu