### PR TITLE
improvement/ Settings.ini covers all command-line options

### DIFF
--- a/resources/bin/settings.ini
+++ b/resources/bin/settings.ini
@@ -25,8 +25,32 @@ GameDir=data
 # disable AI
 #NoAI = true
 
+# Fix OneAi
+#oneAi = True
+
+# activate NoAiRest
+#noAiRest = True
+
+# disable WormAI
+#disableWormAi = True
+
+# disable Reinforcements
+#disableReinforcements = True
+
 # activate DebugMode
 #Debug = true
+
+# activate UnitDebugMode
+#drawUnitDebug = True
+
+# activate drawUsages
+#drawUsages = True
+
+# disable Music
+#playMusic = false
+
+# disable sound 
+#playSound = false
 
 # this is the game rules file
 GameRules=game.ini

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -64,6 +64,28 @@ std::unique_ptr<GameSettings> loadSettingsFromIni(const std::string& filename)
         gameSettings->disableAI = section.getBoolean("NoAI");
     if (section.hasValue("Debug"))
         gameSettings->debugMode = section.getBoolean("Debug");
+
+    if (section.hasValue("playMusic"))
+        gameSettings->playMusic = section.getBoolean("playMusic");
+    if (section.hasValue("playSound"))
+        gameSettings->playSound = section.getBoolean("playSound");
+    if (section.hasValue("Debug"))
+        gameSettings->debugMode = section.getBoolean("Debug");
+
+    if (section.hasValue("drawUnitDebug"))
+        gameSettings->drawUnitDebug = section.getBoolean("drawUnitDebug");
+    if (section.hasValue("oneAi"))
+        gameSettings->oneAi = section.getBoolean("oneAi");
+    if (section.hasValue("disableWormAi"))
+        gameSettings->disableWormAi = section.getBoolean("disableWormAi");
+
+    if (section.hasValue("disableReinforcements"))
+        gameSettings->disableReinforcements = section.getBoolean("disableReinforcements");
+    if (section.hasValue("noAiRest"))
+        gameSettings->noAiRest = section.getBoolean("noAiRest");
+    if (section.hasValue("drawUsages"))
+        gameSettings->drawUsages = section.getBoolean("drawUsages");
+
     return gameSettings;
 }
 

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -69,8 +69,6 @@ std::unique_ptr<GameSettings> loadSettingsFromIni(const std::string& filename)
         gameSettings->playMusic = section.getBoolean("playMusic");
     if (section.hasValue("playSound"))
         gameSettings->playSound = section.getBoolean("playSound");
-    if (section.hasValue("Debug"))
-        gameSettings->debugMode = section.getBoolean("Debug");
 
     if (section.hasValue("drawUnitDebug"))
         gameSettings->drawUnitDebug = section.getBoolean("drawUnitDebug");


### PR DESCRIPTION
All options in command-line are covered by `settings.ini`
- First hard coded values are stored in `cGame`
- Then `settings.ini` is readed and overwrites the hard coded settings
- After command-line options overwrites the settings
- `cGame` is now ready.

close #655 