### PR TITLE
Add back button to credits state

### DIFF
--- a/src/gamestates/cCreditsState.cpp
+++ b/src/gamestates/cCreditsState.cpp
@@ -31,6 +31,23 @@ cCreditsState::cCreditsState(cGame &theGame, GameContext* ctx) :
     m_titleX = centerOfScreen - (titleWidth / 2);
     resetCrawler();
 
+    int backButtonWidth = m_textDrawer->getTextLength(" BACK");
+    int backButtonHeight = 21;
+    int backButtonY = m_game.m_screenH - 21;
+    int backButtonX = 0;
+    cRectangle backButtonRect(backButtonX, backButtonY, backButtonWidth, backButtonHeight);
+    backButton = GuiButtonBuilder()
+            .withRect(backButtonRect)
+            .withLabel("BACK")
+            .withTextDrawer(m_textDrawer)
+            .withTheme(GuiTheme::Light())
+            .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
+            .onClick([this]() {
+                m_game.setNextStateToTransitionTo(GAME_MENU);
+                m_game.initiateFadingOut();
+            })
+            .build();
+
     m_lines = std::vector<s_CreditLine>();
     prepareCrawlerLines();
 }
@@ -382,12 +399,16 @@ void cCreditsState::draw() const
         textCrawlY += line.height;
     }
 
+    backButton->draw();
+
     // MOUSE
     m_game.getMouse()->draw();
 }
 
 void cCreditsState::onNotifyMouseEvent(const s_MouseEvent &event)
 {
+    backButton->onNotifyMouseEvent(event);
+
     if (event.eventType == eMouseEventType::MOUSE_LEFT_BUTTON_PRESSED) {
         m_moveSpeed = 1.0f; // speed up
     }

--- a/src/gamestates/cCreditsState.h
+++ b/src/gamestates/cCreditsState.h
@@ -3,6 +3,7 @@
 #include "cGameState.h"
 #include "controls/cKeyboardEvent.h"
 #include "drawers/cTextDrawer.h"
+#include "gui/GuiButton.h"
 #include "sMouseEvent.h"
 #include "utils/cPoint.h"
 
@@ -47,6 +48,7 @@ private:
     cPoint m_duneCoordinates;
     Texture *m_duneBmp;
     Texture *m_titleBmp;
+    GuiButton *backButton;
 
     void resetCrawler();
     void prepareCrawlerLines();


### PR DESCRIPTION
Fixes #751 

## **Goal**

This PR adds a back button to the credit state.

### Changes

- Added back button gui button, let it render and respond to events to handle 'go back to main menu state'.

## Testing Steps
Go to credits score, see "back" at bottom right and click it

## Screenshots (optional)
<img width="1294" height="908" alt="image" src="https://github.com/user-attachments/assets/282402d1-d879-4daa-9ac4-8b078d97ec0e" />
