### PR TITLE
Bugfix: SILO should be available from techlevel 2

### DIFF
--- a/src/sidebar/cBuildingListFactory.cpp
+++ b/src/sidebar/cBuildingListFactory.cpp
@@ -31,14 +31,6 @@ int cBuildingListFactory::getButtonDrawXStart()
 }
 
 
-/**
- * Initialize list according to techlevel. This will also remove all previously set icons.
- *
- * @param list
- * @param listType
- * @param techlevel
- * @param house
- */
 void cBuildingListFactory::initializeList(cBuildingList *list, eListType listType)
 {
     assert(list != NULL);

--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -296,7 +296,9 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
             listConstYard->addStructureToList(RADAR, 0);
         }
 
-        listConstYard->addStructureToList(SILO, 0);
+        if (techLevel >= 2) {
+            listConstYard->addStructureToList(SILO, 0);
+        }
     }
 
 


### PR DESCRIPTION
Fixes #635 

## **Goal**

Make sure SILO is present from mission 2 and onwards.

### Changes

- Made change in `cBuildinglistUpdater` to only allow `SILO` to be there when techlevel is 2 or higher.
 
## Testing Steps
- Mission 1, no SILO should be present at start, build Refinery, and still no SILO should be present
- Mission 2, no SILO should be present at start, build Refinery, only then SILO should be present to build
