### PR TITLE
technical / step 6.3: Working gamestate gameplaying keys migration

### DIFF
--- a/src/building/cItemBuilder.cpp
+++ b/src/building/cItemBuilder.cpp
@@ -252,7 +252,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
             }
 
             // notify game that the item just has been finished
-            s_GameEvent newEvent {
+            s_GameEvent event {
                 .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_FINISHED,
                 .entityType = eBuildType,
                 .entityID = -1,
@@ -263,7 +263,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                 .buildingListItem = nullptr
             };
 
-            game.onNotifyGameEvent(newEvent);
+            game.onNotifyGameEvent(event);
         }
         else if (eBuildType == SPECIAL) {
             m_buildingListUpdater->onBuildItemCompleted(item);
@@ -325,7 +325,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                 }
 
                 // notify game that the item just has been finished
-                s_GameEvent newEvent {
+                s_GameEvent event {
                     .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_FINISHED,
                     .entityType = eBuildType,
                     .entityID = -1,
@@ -336,7 +336,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                     .buildingListItem = nullptr
                 };
 
-                game.onNotifyGameEvent(newEvent);
+                game.onNotifyGameEvent(event);
             }
             else if (special.providesType == BULLET) {
                 // Case: Deathhand, it is finished, and the player should select a target first.
@@ -369,7 +369,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
         }
         else if (eBuildType == UPGRADE) {
             // notify game that the item just has been finished
-            s_GameEvent newEvent {
+            s_GameEvent event {
                 .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_FINISHED,
                 .entityType = eBuildType,
                 .entityID = -1,
@@ -380,7 +380,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                 .buildingListItem = item
             };
 
-            game.onNotifyGameEvent(newEvent);
+            game.onNotifyGameEvent(event);
 
             // these destroy the data..
             m_buildingListUpdater->onUpgradeCompleted(item);

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -106,7 +106,6 @@ public:
     bool setupGame();               // only call once, to initialize game object (TODO: in constructor?)
     void shutdown();
     void initSkirmish() const;      // initialize combat state to start a skirmish game
-    //void createAndPrepareMentatForHumanPlayer(bool allowMissionSelect = true);
     void loadSkirmishMaps() const;
     void loadScenario();
 

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -336,7 +336,9 @@ private:
     // Combat state specific event handling for now
     [[deprecated]] void onNotifyKeyboardEventGamePlaying(const cKeyboardEvent &event);
     [[deprecated]] void onKeyDownGamePlaying(const cKeyboardEvent &event);
+    void onKeyDownGame(const cKeyboardEvent &event);
     [[deprecated]] void onKeyPressedGamePlaying(const cKeyboardEvent &event);
+    void onKeyPressedGame(const cKeyboardEvent &event);
 
     [[deprecated]] void thinkSlow_state();
 

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -106,7 +106,7 @@ public:
     bool setupGame();               // only call once, to initialize game object (TODO: in constructor?)
     void shutdown();
     void initSkirmish() const;      // initialize combat state to start a skirmish game
-    void createAndPrepareMentatForHumanPlayer(bool allowMissionSelect = true);
+    //void createAndPrepareMentatForHumanPlayer(bool allowMissionSelect = true);
     void loadSkirmishMaps() const;
     void loadScenario();
 

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1457,6 +1457,17 @@ void cGame::onNotifyKeyboardEvent(const cKeyboardEvent &event)
         m_currentState->onNotifyKeyboardEvent(event);
     }
 
+    switch (event.eventType) {
+        case eKeyEventType::HOLD:
+            onKeyDownGame(event);
+            break;
+        case eKeyEventType::PRESSED:
+            onKeyPressedGame(event);
+            break;
+        default:
+            break;
+    }
+
     // take screenshot
     if (event.isType(eKeyEventType::PRESSED) && event.hasKey(SDL_SCANCODE_F12)) {
         saveBmpScreenToDisk();
@@ -1526,6 +1537,16 @@ void cGame::onNotifyKeyboardEventGamePlaying(const cKeyboardEvent &event)
             break;
     }
 }
+
+void cGame::onKeyDownGame(const cKeyboardEvent &event)
+{
+}
+
+void cGame::onKeyPressedGame(const cKeyboardEvent &event)
+{
+
+}
+
 
 void cGame::onKeyDownGamePlaying(const cKeyboardEvent &event)
 {

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1540,11 +1540,55 @@ void cGame::onNotifyKeyboardEventGamePlaying(const cKeyboardEvent &event)
 
 void cGame::onKeyDownGame(const cKeyboardEvent &event)
 {
+    
 }
 
 void cGame::onKeyPressedGame(const cKeyboardEvent &event)
 {
+    // take screenshot
+    if (event.hasKey(SDL_SCANCODE_F11)) {
+        saveBmpScreenToDisk();
+    }
 
+    if (event.hasKey(SDL_SCANCODE_M) || event.hasKey(SDL_SCANCODE_MUTE)) {
+        game.m_playMusic = !game.m_playMusic;
+        if (!game.m_playMusic) {
+            m_soundPlayer->stopMusic();
+            //@mira regression humanPlayer.addNotification("Music muted", eNotificationType::NEUTRAL);
+        }
+        else {
+            m_soundPlayer->playMusic(m_newMusicSample);
+            //@mira regression humanPlayer.addNotification("Music enabled", eNotificationType::NEUTRAL);
+        }
+    }
+
+    if (event.hasKey(SDL_SCANCODE_O) || event.hasKey(SDL_SCANCODE_VOLUMEDOWN)) {
+        m_soundPlayer->changeMusicVolume(-10);
+    }
+
+    if (event.hasKey(SDL_SCANCODE_P) || event.hasKey(SDL_SCANCODE_VOLUMEUP) ) {
+        m_soundPlayer->changeMusicVolume(10);
+    }
+
+    if (event.hasKey(SDL_SCANCODE_KP_PLUS)) {
+        auto timerManager = ctx->getTimeManager();
+        timerManager->setGlobalSpeedVariation(-1);
+    }
+
+    if (event.hasKey(SDL_SCANCODE_KP_MINUS)) {
+        auto timerManager = ctx->getTimeManager();
+        timerManager->setGlobalSpeedVariation(1);
+    }
+
+    if (event.hasKeys(SDL_SCANCODE_LALT,SDL_SCANCODE_RETURN)) {
+        if (m_windowed) {
+            m_Screen->setFullScreenMode();
+            m_windowed = false;
+        } else {
+            m_Screen->setWindowMode();
+            m_windowed = true;
+        }
+    }
 }
 
 
@@ -1626,37 +1670,8 @@ void cGame::onKeyPressedGamePlaying(const cKeyboardEvent &event)
         }
     }
 
-    if (event.hasKey(SDL_SCANCODE_M) || event.hasKey(SDL_SCANCODE_MUTE)) {
-        game.m_playMusic = !game.m_playMusic;
-        if (!game.m_playMusic) {
-            m_soundPlayer->stopMusic();
-            humanPlayer.addNotification("Music muted", eNotificationType::NEUTRAL);
-        }
-        else {
-            m_soundPlayer->playMusic(m_newMusicSample);
-            humanPlayer.addNotification("Music enabled", eNotificationType::NEUTRAL);
-        }
-    }
-
-    if (event.hasKey(SDL_SCANCODE_O) || event.hasKey(SDL_SCANCODE_VOLUMEDOWN)) {
-        m_soundPlayer->changeMusicVolume(-10);
-    }
-
-    if (event.hasKey(SDL_SCANCODE_P) || event.hasKey(SDL_SCANCODE_VOLUMEUP) ) {
-        m_soundPlayer->changeMusicVolume(10);
-    }
-
     if (event.hasKey(SDL_SCANCODE_H)) {
         mapCamera->centerAndJumpViewPortToCell(humanPlayer.getFocusCell());
-    }
-
-    if (event.hasKey(SDL_SCANCODE_KP_PLUS)) {
-        auto timerManager = ctx->getTimeManager();
-        timerManager->setGlobalSpeedVariation(-1);
-    }
-    if (event.hasKey(SDL_SCANCODE_KP_MINUS)) {
-        auto timerManager = ctx->getTimeManager();
-        timerManager->setGlobalSpeedVariation(1);
     }
 
     // Center on the selected structure
@@ -1664,16 +1679,6 @@ void cGame::onKeyPressedGamePlaying(const cKeyboardEvent &event)
         cAbstractStructure *selectedStructure = humanPlayer.getSelectedStructure();
         if (selectedStructure) {
             mapCamera->centerAndJumpViewPortToCell(selectedStructure->getCell());
-        }
-    }
-
-    if (event.hasKeys(SDL_SCANCODE_LALT,SDL_SCANCODE_RETURN)) {
-        if (m_windowed) {
-            m_Screen->setFullScreenMode();
-            m_windowed = false;
-        } else {
-            m_Screen->setWindowMode();
-            m_windowed = true;
         }
     }
 

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1363,7 +1363,7 @@ void cGame::onEventSpecialLaunch(const s_GameEvent &event) const {
                     createBullet(special.providesTypeId, pStructure->getCell(), deployCell, -1, structureId);
 
                     // notify game that the item just has been finished!
-                    s_GameEvent newEvent{
+                    s_GameEvent event{
                         .eventType = eGameEventType::GAME_EVENT_SPECIAL_LAUNCHED,
                         .entityType = itemToDeploy->getBuildType(),
                         .entityID = -1,
@@ -1374,7 +1374,7 @@ void cGame::onEventSpecialLaunch(const s_GameEvent &event) const {
                         .buildingListItem = itemToDeploy
                     };
 
-                    game.onNotifyGameEvent(newEvent);
+                    game.onNotifyGameEvent(event);
                 }
             }
         }
@@ -1393,7 +1393,7 @@ void cGame::onEventSpecialLaunch(const s_GameEvent &event) const {
     }
 
     // notify game that the item just has been finished!
-    s_GameEvent newEvent{
+    s_GameEvent eventT{
         .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_FINISHED,
         .entityType = itemToDeploy->getBuildType(),
         .entityID = -1,
@@ -1404,7 +1404,7 @@ void cGame::onEventSpecialLaunch(const s_GameEvent &event) const {
         .buildingListItem = nullptr
     };
 
-    game.onNotifyGameEvent(newEvent);
+    game.onNotifyGameEvent(eventT);
 }
 
 void cGame::reduceShaking() const {
@@ -1689,13 +1689,13 @@ void cGame::onKeyPressedGamePlaying(const cKeyboardEvent &event)
         // and then perform?
         if (event.hasKey(SDL_SCANCODE_D)) {
             if (selectedStructure->getType() == REPAIR) { // this should be done differently?
-                s_GameEvent e{
+                s_GameEvent event {
                     .eventType = eGameEventType::GAME_EVENT_DEPLOY_UNIT,
                     .entityType = eBuildType::UNKNOWN,
                     .entityID = -1,
                     .player = &humanPlayer
                 };
-                selectedStructure->onNotifyGameEvent(e);
+                selectedStructure->onNotifyGameEvent(event);
             }
         }
         // other keys for other structures?

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1095,11 +1095,6 @@ void cGame::prepareMentatForPlayer()
     }
 }
 
-// void cGame::createAndPrepareMentatForHumanPlayer(bool allowMissionSelect)
-// {
-//     prepareMentatForPlayer();
-// }
-
 void cGame::prepareMentatToTellAboutHouse(int house)
 {
     players[HUMAN].setHouse(house);

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -453,7 +453,7 @@ void cGame::drawState()
     }
 
     // this makes fade-in happen after fade-out automatically
-    if (m_cScreenFader->getAlpha()  == 0) {
+    if (m_cScreenFader->getAction()  == eFadeAction::None) {
         m_cScreenFader->startFadeIn();
     }
 
@@ -1034,6 +1034,43 @@ void cGame::setState(int newState)
 void cGame::thinkFast_fading()
 {
     m_cScreenFader->update();
+    //@mira_fader
+    
+    /*
+    // Fading of the entire screen
+    if (m_fadeAction == eFadeAction::FADE_OUT) {
+        m_fadeAlpha -= 2;
+        if (m_fadeAlpha < kMinAlpha) {
+            m_fadeAlpha = kMinAlpha;
+            m_fadeAction = eFadeAction::FADE_NONE;
+        }
+    }
+    else if (m_fadeAction == eFadeAction::FADE_IN) {
+        m_fadeAlpha += 2;
+        if (m_fadeAlpha > kMaxAlpha) {
+            m_fadeAlpha = kMaxAlpha;
+            m_fadeAction = eFadeAction::FADE_NONE;
+        }
+    }
+
+    // Fading / pulsating of selected stuff
+    static constexpr float fadeSelectIncrement = 1 / 256.0f;
+    if (m_fadeSelectDir) {
+        m_fadeSelect += fadeSelectIncrement;
+        // when 255, then fade back
+        if (m_fadeSelect > 0.99) {
+            m_fadeSelect = 1.0f;
+            m_fadeSelectDir = false;
+        }
+
+        return;
+    }
+
+    m_fadeSelect -= fadeSelectIncrement;
+    // not too dark, 0.03125
+    if (m_fadeSelect < 0.3125f) {
+        m_fadeSelectDir = true;
+    }*/
 }
 
 cGame::~cGame()

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1095,10 +1095,10 @@ void cGame::prepareMentatForPlayer()
     }
 }
 
-void cGame::createAndPrepareMentatForHumanPlayer(bool allowMissionSelect)
-{
-    prepareMentatForPlayer();
-}
+// void cGame::createAndPrepareMentatForHumanPlayer(bool allowMissionSelect)
+// {
+//     prepareMentatForPlayer();
+// }
 
 void cGame::prepareMentatToTellAboutHouse(int house)
 {
@@ -1119,7 +1119,7 @@ void cGame::loadScenario()
 void cGame::goingToWinLoseBrief(int value)
 {
     setState(value);
-    createAndPrepareMentatForHumanPlayer(!m_skirmish);
+    prepareMentatForPlayer();
 
 }
 
@@ -1486,7 +1486,7 @@ void cGame::transitionStateIfRequired()
 
         if (m_nextState == GAME_BRIEFING) {
             playMusicByType(MUSIC_BRIEFING);
-            game.createAndPrepareMentatForHumanPlayer();
+            game.prepareMentatForPlayer();
         }
 
         m_nextState = -1;

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -273,41 +273,9 @@ void cGamePlaying::onKeyPressedGamePlaying(const cKeyboardEvent &event)
         }
     }
 
-    /*@mira
-    if (event.hasKey(SDL_SCANCODE_M) || event.hasKey(SDL_SCANCODE_MUTE)) {
-        game.m_playMusic = !game.m_playMusic;
-        if (!game.m_playMusic) {
-            m_soundPlayer->stopMusic();
-            humanPlayer.addNotification("Music muted", eNotificationType::NEUTRAL);
-        }
-        else {
-            m_soundPlayer->playMusic(m_newMusicSample);
-            humanPlayer.addNotification("Music enabled", eNotificationType::NEUTRAL);
-        }
-    }
-
-    if (event.hasKey(SDL_SCANCODE_O) || event.hasKey(SDL_SCANCODE_VOLUMEDOWN)) {
-        m_soundPlayer->changeMusicVolume(-10);
-    }
-
-    if (event.hasKey(SDL_SCANCODE_P) || event.hasKey(SDL_SCANCODE_VOLUMEUP) ) {
-        m_soundPlayer->changeMusicVolume(10);
-    }
-    */
     if (event.hasKey(SDL_SCANCODE_H)) {
         mapCamera->centerAndJumpViewPortToCell(humanPlayer.getFocusCell());
     }
-
-    /* @mira
-    if (event.hasKey(SDL_SCANCODE_KP_PLUS)) {
-        auto timerManager = ctx->getTimeManager();
-        timerManager->setGlobalSpeedVariation(-1);
-    }
-    if (event.hasKey(SDL_SCANCODE_KP_MINUS)) {
-        auto timerManager = ctx->getTimeManager();
-        timerManager->setGlobalSpeedVariation(1);
-    }
-    */
 
     // Center on the selected structure
     if (event.hasKey(SDL_SCANCODE_C)) {
@@ -316,18 +284,6 @@ void cGamePlaying::onKeyPressedGamePlaying(const cKeyboardEvent &event)
             mapCamera->centerAndJumpViewPortToCell(selectedStructure->getCell());
         }
     }
-
-     /* @mira
-    if (event.hasKeys(SDL_SCANCODE_LALT,SDL_SCANCODE_RETURN)) {
-        if (m_windowed) {
-            m_Screen->setFullScreenMode();
-            m_windowed = false;
-        } else {
-            m_Screen->setWindowMode();
-            m_windowed = true;
-        }
-    }
-    */
 
     cAbstractStructure *selectedStructure = humanPlayer.getSelectedStructure();
     if (selectedStructure) {

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -292,13 +292,13 @@ void cGamePlaying::onKeyPressedGamePlaying(const cKeyboardEvent &event)
         // and then perform?
         if (event.hasKey(SDL_SCANCODE_D)) {
             if (selectedStructure->getType() == REPAIR) { // this should be done differently?
-                s_GameEvent e{
+                s_GameEvent event {
                     .eventType = eGameEventType::GAME_EVENT_DEPLOY_UNIT,
                     .entityType = eBuildType::UNKNOWN,
                     .entityID = -1,
                     .player = &humanPlayer
                 };
-                selectedStructure->onNotifyGameEvent(e);
+                selectedStructure->onNotifyGameEvent(event);
             }
         }
         // other keys for other structures?

--- a/src/gamestates/cSelectYourNextConquestState.cpp
+++ b/src/gamestates/cSelectYourNextConquestState.cpp
@@ -396,7 +396,7 @@ void cSelectYourNextConquestState::loadScenarioAndTransitionToNextState(int iMis
     m_dataCompaign->mission++;                        // FINALLY ADD MISSION NUMBER...
 
     // set up drawStateMentat
-    m_game.createAndPrepareMentatForHumanPlayer();
+    m_game.prepareMentatForPlayer();
 
     // load map
     m_game.loadScenario();

--- a/src/sidebar/cSideBar.cpp
+++ b/src/sidebar/cSideBar.cpp
@@ -270,7 +270,7 @@ void cSideBar::cancelBuildingListItem(cBuildingListItem *item)
             item->resetProgress();
 
             // notify game that the item just has been cancelled, just before the actual removal
-            s_GameEvent newEvent {
+            s_GameEvent event {
                 .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_CANCELLED,
                 .entityType = item->getBuildType(),
                 .entityID = -1,
@@ -281,7 +281,7 @@ void cSideBar::cancelBuildingListItem(cBuildingListItem *item)
                 .buildingListItem = item
             };
 
-            game.onNotifyGameEvent(newEvent);
+            game.onNotifyGameEvent(event);
             // else, only the number is decreased (used for queueing)
 
             cItemBuilder *itemBuilder = player->getItemBuilder();


### PR DESCRIPTION
Extract `GamePlaying` from `cGame`

### Changes
Always with the aim of separating the class
- Keys migration from local state to global state.

It's help me a lot to avoid terraforming `cGame` to give `GamePlaying` unnecessary authorization.
It make sense to to manage audio, and windows size, on every `StateGame`
