### PR TITLE
Fix: Only allow clicking briefing/mentat buttons when talking is done

### DIFF
--- a/src/mentat/AbstractMentat.cpp
+++ b/src/mentat/AbstractMentat.cpp
@@ -378,14 +378,16 @@ void AbstractMentat::onNotifyMouseEvent(const s_MouseEvent &event)
         }
     }
 
-    if (m_guiBtnToMissionSelect) {
-        m_guiBtnToMissionSelect->onNotifyMouseEvent(event);
-    }
-    if (leftGuiButton) {
-        leftGuiButton->onNotifyMouseEvent(event);
-    }
-    if (rightGuiButton) {
-        rightGuiButton->onNotifyMouseEvent(event);
+    if (state == AWAITING_RESPONSE) {
+        if (m_guiBtnToMissionSelect) {
+            m_guiBtnToMissionSelect->onNotifyMouseEvent(event);
+        }
+        if (leftGuiButton) {
+            leftGuiButton->onNotifyMouseEvent(event);
+        }
+        if (rightGuiButton) {
+            rightGuiButton->onNotifyMouseEvent(event);
+        }
     }
 }
 


### PR DESCRIPTION
Fix #766 

## **Goal**
The player cannot click until the button is displayed


### Changes
- `AbstractMentat::onNotifyMouseEvent`
Bad code: need to be refactored
