### PR TITLE
technical / step 7.3: Working gamestate editing improvements

### DIFF
--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -41,13 +41,16 @@ cEditorState::cEditorState(cGame &theGame, GameContext* ctx)
     m_selectBar = std::make_unique<GuiBar>(selectRect,GuiBarPlacement::HORIZONTAL);
     m_topologyBar = std::make_unique<GuiBar>(modifRect,GuiBarPlacement::VERTICAL);
     m_startCellBar = std::make_unique<GuiBar>(modifRect,GuiBarPlacement::VERTICAL);
+    m_symmetricBar = std::make_unique<GuiBar>(modifRect,GuiBarPlacement::VERTICAL);
     m_selectBar->setTheme(GuiTheme::Light());
     m_topologyBar->setTheme(GuiTheme::Light());
     m_startCellBar->setTheme(GuiTheme::Light());
+    m_symmetricBar->setTheme(GuiTheme::Light());
 
     populateSelectBar();
     populateTopologyBar();
     populateStartCellBar();
+    populateSymmetricBar();
     startCells.fill({-1, -1});
     //std::cout << "Entered Editor State" << std::endl;
 }
@@ -80,6 +83,18 @@ void cEditorState::populateSelectBar()
             .onClick([this]() {
                 // std::cout << "STARTPOSITION" << std::endl;
                 m_currentBar = m_startCellBar.get();
+            })
+            .build();
+    guiButton->setGroup(m_selectGroup.get());
+    m_selectBar->addGuiObject(guiButton);
+
+    rectGui = cRectangle(sBS+2*(heightBarSize+sBB),1,heightBarSize,heightBarSize);
+    guiButton = GuiStateButtonBuilder()
+            .withRect(rectGui)
+            .withTexture(m_gfxeditor->getTexture(FLIPHORZ))
+            .onClick([this]() {
+                // std::cout << "FLIPHORZ" << std::endl;
+                m_currentBar = m_symmetricBar.get();
             })
             .build();
     guiButton->setGroup(m_selectGroup.get());
@@ -261,6 +276,10 @@ void cEditorState::populateStartCellBar()
             .build();
     guiButton->setGroup(m_startCellGroup.get());
     m_startCellBar->addGuiObject(guiButton);
+}
+
+void cEditorState::populateSymmetricBar()
+{
 }
 
 void cEditorState::thinkFast()

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -653,7 +653,6 @@ void cEditorState::modifySymmetricArea(Direction dir)
             }
             break;
     }
-    normalizeModifications();
 }
 
 void cEditorState::drawStartCells() const

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -609,6 +609,7 @@ void cEditorState::modifyStartCell(int posX, int posY, int startCellID)
 
 void cEditorState::modifySymmetricArea(Direction dir)
 {
+    // std::cout << "modifySymmetricArea " << static_cast<int>(dir) << std::endl;
     switch (dir) {
         case Direction::bottom:
             for (size_t j = 1; j < (m_mapData->getRows())/2; j++) {

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -470,6 +470,19 @@ void cEditorState::loadMap(s_PreviewMap* map)
         }
     }
     updateVisibleTiles();
+    normalizeModifications();
+}
+
+void cEditorState::normalizeModifications()
+{
+    for (size_t j = 0; j < m_mapData->getRows(); j++) {
+        (*m_mapData)[j][0] = -1;
+        (*m_mapData)[j][m_mapData->getCols()-1] = -1;
+    }
+    for (size_t i = 0; i < m_mapData->getCols(); i++) {
+        (*m_mapData)[0][i] = -1;
+        (*m_mapData)[m_mapData->getRows()-1][i] = -1;
+    }
 }
 
 void cEditorState::clampCameraYToMapBounds()
@@ -640,6 +653,7 @@ void cEditorState::modifySymmetricArea(Direction dir)
             }
             break;
     }
+    normalizeModifications();
 }
 
 void cEditorState::drawStartCells() const

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -609,21 +609,22 @@ void cEditorState::modifyStartCell(int posX, int posY, int startCellID)
 
 void cEditorState::modifySymmetricArea(Direction dir)
 {
+    std::cout << "modifySymmetricArea " << static_cast<int>(dir) << std::endl;
     for (size_t j = 1; j < (m_mapData->getRows())/2; j++) {
         for (size_t i = 1; i < (m_mapData->getCols())/2; i++) {
             // Modify the tile at (i, j) based on the direction
             switch (dir) {
-                case Direction::top:
-                    
-                    break;
                 case Direction::bottom:
-                    
+                    (*m_mapData)[(m_mapData->getRows()-1)-j][i] = (*m_mapData)[j][i];
                     break;
-                case Direction::left:
-                    
+                case Direction::top:
+                    (*m_mapData)[j][i] = (*m_mapData)[(m_mapData->getRows()-1)-j][i];
                     break;
                 case Direction::right:
-                    
+                    (*m_mapData)[j][(m_mapData->getCols()-1)-i] = (*m_mapData)[j][i];
+                    break;
+                case Direction::left:
+                    (*m_mapData)[j][i] = (*m_mapData)[j][(m_mapData->getCols()-1)-i];
                     break;
             }
         }

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -62,7 +62,7 @@ cEditorState::~cEditorState()
 
 void cEditorState::populateSelectBar()
 {
-    m_selectGroup = std::make_unique<GuiButtonGroup>();
+    std::unique_ptr<GuiButtonGroup> m_selectGroup= std::make_unique<GuiButtonGroup>();
     auto rectGui = cRectangle(96,halfMarginBetweenButtons,heightButtonSize,heightButtonSize);
     auto guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
@@ -99,6 +99,7 @@ void cEditorState::populateSelectBar()
             .build();
     guiButton->setGroup(m_selectGroup.get());
     m_selectBar->addGuiObject(guiButton);
+    m_selectBar->addGuiGroup(std::move(m_selectGroup));
 
 /*
     rectGui = cRectangle(sBS+2*(heightBarSize+sBB),1,heightBarSize,heightBarSize);
@@ -138,7 +139,7 @@ void cEditorState::populateSelectBar()
 
 void cEditorState::populateTopologyBar()
 {
-    m_topologyGroup = std::make_unique<GuiButtonGroup>();
+    std::unique_ptr<GuiButtonGroup> m_topologyGroup = std::make_unique<GuiButtonGroup>();
     auto rectGui = cRectangle(m_game.m_screenW-heightBarSize+halfMarginBetweenButtons,sBS,heightButtonSize,heightButtonSize);
     auto guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
@@ -211,11 +212,12 @@ void cEditorState::populateTopologyBar()
             .build();
     guiButton->setGroup(m_topologyGroup.get());
     m_topologyBar->addGuiObject(guiButton);
+    m_topologyBar->addGuiGroup(std::move(m_topologyGroup));
 }
 
 void cEditorState::populateStartCellBar()
 {
-    m_startCellGroup = std::make_unique<GuiButtonGroup>();
+    std::unique_ptr<GuiButtonGroup> m_startCellGroup = std::make_unique<GuiButtonGroup>();
     auto rectGui = cRectangle(m_game.m_screenW-heightBarSize+halfMarginBetweenButtons,sBS,heightButtonSize,heightButtonSize);
     auto guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
@@ -276,11 +278,12 @@ void cEditorState::populateStartCellBar()
             .build();
     guiButton->setGroup(m_startCellGroup.get());
     m_startCellBar->addGuiObject(guiButton);
+    m_startCellBar->addGuiGroup(std::move(m_startCellGroup));
 }
 
 void cEditorState::populateSymmetricBar()
 {
-    m_symmetricGroup = std::make_unique<GuiButtonGroup>();
+    std::unique_ptr<GuiButtonGroup> m_symmetricGroup = std::make_unique<GuiButtonGroup>();
     auto rectGui = cRectangle(m_game.m_screenW-heightBarSize+halfMarginBetweenButtons,sBS,heightButtonSize,heightButtonSize);
     auto guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
@@ -328,6 +331,7 @@ void cEditorState::populateSymmetricBar()
             .build();
     guiButton->setGroup(m_symmetricGroup.get());
     m_symmetricBar->addGuiObject(guiButton);
+    m_symmetricBar->addGuiGroup(std::move(m_symmetricGroup));
 }
 
 void cEditorState::thinkFast()

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -609,25 +609,35 @@ void cEditorState::modifyStartCell(int posX, int posY, int startCellID)
 
 void cEditorState::modifySymmetricArea(Direction dir)
 {
-    std::cout << "modifySymmetricArea " << static_cast<int>(dir) << std::endl;
-    for (size_t j = 1; j < (m_mapData->getRows())/2; j++) {
-        for (size_t i = 1; i < (m_mapData->getCols())/2; i++) {
-            // Modify the tile at (i, j) based on the direction
-            switch (dir) {
-                case Direction::bottom:
+    switch (dir) {
+        case Direction::bottom:
+            for (size_t j = 1; j < (m_mapData->getRows())/2; j++) {
+                for (size_t i = 1; i < m_mapData->getCols(); i++) {
                     (*m_mapData)[(m_mapData->getRows()-1)-j][i] = (*m_mapData)[j][i];
-                    break;
-                case Direction::top:
-                    (*m_mapData)[j][i] = (*m_mapData)[(m_mapData->getRows()-1)-j][i];
-                    break;
-                case Direction::right:
-                    (*m_mapData)[j][(m_mapData->getCols()-1)-i] = (*m_mapData)[j][i];
-                    break;
-                case Direction::left:
-                    (*m_mapData)[j][i] = (*m_mapData)[j][(m_mapData->getCols()-1)-i];
-                    break;
+                }
             }
-        }
+            break;
+        case Direction::top:
+            for (size_t j = 1; j < (m_mapData->getRows())/2; j++) {
+                for (size_t i = 1; i < m_mapData->getCols(); i++) {
+                    (*m_mapData)[j][i] = (*m_mapData)[(m_mapData->getRows()-1)-j][i];
+                }
+            }
+            break;
+        case Direction::right:
+            for (size_t j = 1; j < m_mapData->getRows(); j++) {
+                for (size_t i = 1; i < (m_mapData->getCols())/2; i++) {
+                    (*m_mapData)[j][(m_mapData->getCols()-1)-i] = (*m_mapData)[j][i];
+                }
+            }
+            break;
+        case Direction::left:
+            for (size_t j = 1; j < m_mapData->getRows(); j++) {
+                for (size_t i = 1; i < (m_mapData->getCols())/2; i++) {
+                    (*m_mapData)[j][i] = (*m_mapData)[j][(m_mapData->getCols()-1)-i];
+                }
+            }
+            break;
     }
 }
 

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -291,7 +291,6 @@ void cEditorState::populateSymmetricBar()
             })
             .build();
     guiButton->setGroup(m_symmetricGroup.get());
-    guiButton->setPressed(true);
     m_symmetricBar->addGuiObject(guiButton);
 
     rectGui = cRectangle(m_game.m_screenW-heightBarSize+halfMarginBetweenButtons,sBS+1*(heightBarSize+sBB),heightButtonSize,heightButtonSize);

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -280,6 +280,55 @@ void cEditorState::populateStartCellBar()
 
 void cEditorState::populateSymmetricBar()
 {
+    m_symmetricGroup = std::make_unique<GuiButtonGroup>();
+    auto rectGui = cRectangle(m_game.m_screenW-heightBarSize+halfMarginBetweenButtons,sBS,heightButtonSize,heightButtonSize);
+    auto guiButton = GuiStateButtonBuilder()
+            .withRect(rectGui)
+            .withTexture(m_gfxeditor->getTexture(FLIPHORZLR))
+            .onClick([this]() {
+                // std::cout << "FLIPHORZLR" << std::endl;
+                modifySymmetricArea(Direction::right);
+            })
+            .build();
+    guiButton->setGroup(m_symmetricGroup.get());
+    guiButton->setPressed(true);
+    m_symmetricBar->addGuiObject(guiButton);
+
+    rectGui = cRectangle(m_game.m_screenW-heightBarSize+halfMarginBetweenButtons,sBS+1*(heightBarSize+sBB),heightButtonSize,heightButtonSize);
+    guiButton = GuiStateButtonBuilder()
+            .withRect(rectGui)
+            .withTexture(m_gfxeditor->getTexture(FLIPHORZRL))
+            .onClick([this]() {
+                // std::cout << "FLIPHORZRL" << std::endl;
+                modifySymmetricArea(Direction::left);
+            })
+            .build();
+    guiButton->setGroup(m_symmetricGroup.get());
+    m_symmetricBar->addGuiObject(guiButton);
+
+    rectGui = cRectangle(m_game.m_screenW-heightBarSize+halfMarginBetweenButtons,sBS+2*(heightBarSize+sBB),heightButtonSize,heightButtonSize);
+    guiButton = GuiStateButtonBuilder()
+            .withRect(rectGui)
+            .withTexture(m_gfxeditor->getTexture(FLIPVERTBT))
+            .onClick([this]() {
+                // std::cout << "FLIPVERTBT" << std::endl;
+                modifySymmetricArea(Direction::top);
+            })
+            .build();
+    guiButton->setGroup(m_symmetricGroup.get());
+    m_symmetricBar->addGuiObject(guiButton);
+
+    rectGui = cRectangle(m_game.m_screenW-heightBarSize+halfMarginBetweenButtons,sBS+3*(heightBarSize+sBB),heightButtonSize,heightButtonSize);
+    guiButton = GuiStateButtonBuilder()
+            .withRect(rectGui)
+            .withTexture(m_gfxeditor->getTexture(FLIPVERTTB))
+            .onClick([this]() {
+                // std::cout << "FLIPVERTTB" << std::endl;
+                modifySymmetricArea(Direction::bottom);
+            })
+            .build();
+    guiButton->setGroup(m_symmetricGroup.get());
+    m_symmetricBar->addGuiObject(guiButton);
 }
 
 void cEditorState::thinkFast()

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -559,6 +559,29 @@ void cEditorState::modifyStartCell(int posX, int posY, int startCellID)
     }
 }
 
+void cEditorState::modifySymmetricArea(Direction dir)
+{
+    for (size_t j = 1; j < (m_mapData->getRows())/2; j++) {
+        for (size_t i = 1; i < (m_mapData->getCols())/2; i++) {
+            // Modify the tile at (i, j) based on the direction
+            switch (dir) {
+                case Direction::top:
+                    
+                    break;
+                case Direction::bottom:
+                    
+                    break;
+                case Direction::left:
+                    
+                    break;
+                case Direction::right:
+                    
+                    break;
+            }
+        }
+    }
+}
+
 void cEditorState::drawStartCells() const
 {
     cRectangle destRect;

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -603,7 +603,7 @@ void cEditorState::modifyTile(int posX, int posY, int tileID)
     }
     int tileX = (cameraX + posX) / tileLenSize;
     int tileY = (cameraY + posY) / tileLenSize;
-    if (m_mapData && tileX >= 0 && tileY >= 0 && tileX < (int)m_mapData->getCols() && tileY < (int)m_mapData->getRows()) {
+    if (m_mapData && tileX >= 1 && tileY >= 1 && tileX < (int)m_mapData->getCols()-1 && tileY < (int)m_mapData->getRows()-1) {
         (*m_mapData)[tileY][tileX] = tileID;
     }
 }

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -379,8 +379,10 @@ void cEditorState::onNotifyMouseEvent(const s_MouseEvent &event)
         int mouseY = event.coords.y - mapSizeArea.getY(); // offset barre
         if (event.eventType == MOUSE_SCROLLED_DOWN) {
             zoomAtMapPosition(mouseX, mouseY, ZoomDirection::zoomOut);
+            updateVisibleTiles();
         } else if (event.eventType == MOUSE_SCROLLED_UP) {
             zoomAtMapPosition(mouseX, mouseY, ZoomDirection::zoomIn);
+            updateVisibleTiles();
         } else if (event.eventType == MOUSE_LEFT_BUTTON_PRESSED && m_currentBar == m_topologyBar.get()) {
             modifyTile(mouseX, mouseY, idTerrainToMapModif);
         }else if (event.eventType == MOUSE_LEFT_BUTTON_PRESSED && m_currentBar == m_startCellBar.get()) {
@@ -389,7 +391,6 @@ void cEditorState::onNotifyMouseEvent(const s_MouseEvent &event)
         else {
             return;
         }
-        updateVisibleTiles();
     } else {
         m_selectBar->onNotifyMouseEvent(event);
         m_currentBar->onNotifyMouseEvent(event);
@@ -421,11 +422,13 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
         }
         if (event.hasKey(SDL_Scancode::SDL_SCANCODE_PAGEUP)) {
             zoomAtMapPosition(m_game.m_screenW/2, m_game.m_screenH/2, ZoomDirection::zoomIn);
+            updateVisibleTiles();
         }
         if (event.hasKey(SDL_Scancode::SDL_SCANCODE_PAGEDOWN)) {
             zoomAtMapPosition(m_game.m_screenW/2, m_game.m_screenH/2, ZoomDirection::zoomOut);
+            updateVisibleTiles();
         }
-        updateVisibleTiles();
+
         m_selectBar->onNotifyKeyboardEvent(event);
         m_currentBar->onNotifyKeyboardEvent(event);
     }
@@ -434,26 +437,31 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
         if (event.hasKey(SDL_Scancode::SDL_SCANCODE_LEFT)) {
             cameraX -=tileLenSize;
             clampCameraXToMapBounds();
+            updateVisibleTiles();
         }
         if (event.hasKey(SDL_Scancode::SDL_SCANCODE_RIGHT)) {
             cameraX +=tileLenSize;
             clampCameraXToMapBounds();
+            updateVisibleTiles();
         }
         if (event.hasKey(SDL_Scancode::SDL_SCANCODE_UP)) {
             cameraY -=tileLenSize;
             clampCameraYToMapBounds();
+            updateVisibleTiles();
         }
         if (event.hasKey(SDL_Scancode::SDL_SCANCODE_DOWN)) {
             cameraY +=tileLenSize;
             clampCameraYToMapBounds();
+            updateVisibleTiles(); 
         }
         if (event.hasKeys(SDL_Scancode::SDL_SCANCODE_LSHIFT ,SDL_Scancode::SDL_SCANCODE_UP)) {
             zoomAtMapPosition(m_game.m_screenW/2, m_game.m_screenH/2, ZoomDirection::zoomIn);
+            updateVisibleTiles(); 
         }
         if (event.hasKeys(SDL_Scancode::SDL_SCANCODE_LSHIFT ,SDL_Scancode::SDL_SCANCODE_DOWN)) {
             zoomAtMapPosition(m_game.m_screenW/2, m_game.m_screenH/2, ZoomDirection::zoomOut);
+            updateVisibleTiles(); 
         }
-        updateVisibleTiles(); 
     }
 }
 

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -51,14 +51,12 @@ private:
     void modifyTile(int posX, int posY, int tileID);
     void modifyStartCell(int posX, int posY, int startCellID);
     void normalizeModifications();
-    // void clampCameraToMapBounds();
     void clampCameraXToMapBounds();
     void clampCameraYToMapBounds();
     void zoomAtMapPosition(int screenX, int screenY, ZoomDirection direction);
     void updateVisibleTiles();
 
     void saveMap() const;
-    //s_PreviewMap* m_map=nullptr;
     std::unique_ptr<GuiBar> m_selectBar;
     std::unique_ptr<GuiBar> m_topologyBar;
     std::unique_ptr<GuiBar> m_startCellBar;
@@ -66,10 +64,6 @@ private:
     GuiBar* m_currentBar = nullptr;
     std::unique_ptr<Matrix<int>> m_mapData;
     Graphics *m_gfxdata, *m_gfxeditor;
-    // std::unique_ptr<GuiButtonGroup> m_selectGroup;
-    // std::unique_ptr<GuiButtonGroup> m_topologyGroup;
-    // std::unique_ptr<GuiButtonGroup> m_startCellGroup;
-    // std::unique_ptr<GuiButtonGroup> m_symmetricGroup;
 
     cRectangle mapSizeArea;
     int tileLenSize = 16;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -34,10 +34,17 @@ private:
         zoomIn,
         zoomOut
     };
+    enum class Direction : char {
+        top,
+        bottom,
+        left,
+        right
+    };
     void populateTopologyBar();
     void populateStartCellBar();
     void populateSelectBar();
     void populateSymmetricBar();
+    void modifySymmetricArea(Direction dir);
 
     void drawMap() const;
     void drawStartCells() const;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -66,10 +66,10 @@ private:
     GuiBar* m_currentBar = nullptr;
     std::unique_ptr<Matrix<int>> m_mapData;
     Graphics *m_gfxdata, *m_gfxeditor;
-    std::unique_ptr<GuiButtonGroup> m_selectGroup;
-    std::unique_ptr<GuiButtonGroup> m_topologyGroup;
-    std::unique_ptr<GuiButtonGroup> m_startCellGroup;
-    std::unique_ptr<GuiButtonGroup> m_symmetricGroup;
+    // std::unique_ptr<GuiButtonGroup> m_selectGroup;
+    // std::unique_ptr<GuiButtonGroup> m_topologyGroup;
+    // std::unique_ptr<GuiButtonGroup> m_startCellGroup;
+    // std::unique_ptr<GuiButtonGroup> m_symmetricGroup;
 
     cRectangle mapSizeArea;
     int tileLenSize = 16;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -37,6 +37,7 @@ private:
     void populateTopologyBar();
     void populateStartCellBar();
     void populateSelectBar();
+    void populateSymmetricBar();
 
     void drawMap() const;
     void drawStartCells() const;
@@ -53,12 +54,14 @@ private:
     std::unique_ptr<GuiBar> m_selectBar;
     std::unique_ptr<GuiBar> m_topologyBar;
     std::unique_ptr<GuiBar> m_startCellBar;
+    std::unique_ptr<GuiBar> m_symmetricBar;
     GuiBar* m_currentBar = nullptr;
     std::unique_ptr<Matrix<int>> m_mapData;
     Graphics *m_gfxdata, *m_gfxeditor;
     std::unique_ptr<GuiButtonGroup> m_selectGroup;
     std::unique_ptr<GuiButtonGroup> m_topologyGroup;
     std::unique_ptr<GuiButtonGroup> m_startCellGroup;
+    std::unique_ptr<GuiButtonGroup> m_symmetricGroup;
 
     cRectangle mapSizeArea;
     int tileLenSize = 16;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -50,6 +50,7 @@ private:
     void drawStartCells() const;
     void modifyTile(int posX, int posY, int tileID);
     void modifyStartCell(int posX, int posY, int startCellID);
+    void normalizeModifications();
     // void clampCameraToMapBounds();
     void clampCameraXToMapBounds();
     void clampCameraYToMapBounds();

--- a/src/gamestates/cNewMapEditorState.h
+++ b/src/gamestates/cNewMapEditorState.h
@@ -34,5 +34,5 @@ private:
     GuiTextInput* m_inputDescription = nullptr;
     GuiCycleButton* m_cycleWidth = nullptr;
     GuiCycleButton* m_cycleHeight = nullptr;
-    std::vector<int> m_sizesMap = {32, 64, 96, 128, 160, 192, 224, 256};
+    std::vector<int> m_sizesMap = {16, 24, 32, 64, 96, 128, 160, 192, 224, 256};
 };

--- a/src/gui/GuiBar.cpp
+++ b/src/gui/GuiBar.cpp
@@ -2,6 +2,7 @@
 
 #include "d2tmc.h"
 #include "drawers/SDLDrawer.hpp"
+#include "gui/GuiButtonGroup.h"
 
 
 GuiBar::GuiBar(const cRectangle &rect, GuiBarPlacement placement) :
@@ -53,4 +54,9 @@ void GuiBar::onNotifyKeyboardEvent(const cKeyboardEvent &event)
     for (auto &guiObject : gui_objects) {
         guiObject->onNotifyKeyboardEvent(event);
     }
+}
+
+void GuiBar::addGuiGroup(std::unique_ptr<GuiButtonGroup> buttonGroup)
+{
+    gui_button_groups.push_back(std::move(buttonGroup));
 }

--- a/src/gui/GuiBar.h
+++ b/src/gui/GuiBar.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+class GuiButtonGroup;
+
 enum class GuiBarPlacement :char {
     HORIZONTAL = 0,
     VERTICAL = 1
@@ -22,6 +24,8 @@ public:
     void draw() const override;
 
     void addGuiObject(GuiObject *guiObject);
+    //void addGuiObject(GuiObject *guiObject, int position);
+    void addGuiGroup(std::unique_ptr<GuiButtonGroup> buttonGroup);
 
     cRectangle getRelativeRect(int x, int y, int width, int height);
 
@@ -36,5 +40,6 @@ private:
     std::vector<GuiObject *> gui_objects;
     GuiBarPlacement m_placement;
     int placementPosition;
+    std::vector<std::unique_ptr<GuiButtonGroup>> gui_button_groups;
 };
 


### PR DESCRIPTION
Fix #784 

## **Goal**
We can now apply symmetrical transformations on edited map.


### Changes
- Map Mirroring Tools LR, RL, BT, TB
- Fix smalls size on maps width/height
- Fix editing map's border

## Screenshots
<img width="1367" height="771" alt="image" src="https://github.com/user-attachments/assets/a7b14afb-151f-4207-a5d1-7de996c7b4dd" />

