### PR TITLE
master / Windows focus

### DIFF
--- a/resources/bin/settings.ini
+++ b/resources/bin/settings.ini
@@ -46,6 +46,9 @@ GameDir=data
 # activate drawUsages
 #drawUsages = True
 
+# enable focus (pauses game when losing focus)
+#useFocus = True
+
 # disable Music
 #playMusic = false
 

--- a/resources/bin/settings.ini
+++ b/resources/bin/settings.ini
@@ -46,8 +46,8 @@ GameDir=data
 # activate drawUsages
 #drawUsages = True
 
-# enable focus (pauses game when losing focus)
-#useFocus = True
+# pauses game when losing focus
+#pauseWhenLosingFocus = True
 
 # disable Music
 #playMusic = false

--- a/src/cGame.h
+++ b/src/cGame.h
@@ -76,19 +76,19 @@ public:
     int m_screenW;
     int m_screenH;
 
-    bool m_playSound;               // play sound?
-    bool m_disableAI;               // disable AI thinking?
-    bool m_oneAi;                   // disable all but one AI brain? (default == false)
-    bool m_disableWormAi;                // disable worm AI brain? (default == false)
-    bool m_disableReinforcements;   // disable any reinforcements from scenario ini file?
-    bool m_drawUsages;              // draw the amount of structures/units/bullets used during combat
-    bool m_drawUnitDebug;           // draw the unit debug info (rects, paths, etc)
-    bool m_noAiRest;                // Campaign AI does not have long initial REST time
-    bool m_playMusic;               // play any music?
-    bool m_useFocus;            // whether to use focus management (pausing the game when losing focus)
-    float m_cameraDragMoveSpeed;          // speed of camera when dragging mouse (default = 0.5f)
-    float m_cameraBorderOrKeyMoveSpeed;   // speed of camera when hitting mouse border or pressing keys (default = 0.5f)
-    bool m_cameraEdgeMove;              // should move map camera when hitting edges of screen
+    bool m_playSound;                       // play sound?
+    bool m_disableAI;                       // disable AI thinking?
+    bool m_oneAi;                           // disable all but one AI brain? (default == false)
+    bool m_disableWormAi;                   // disable worm AI brain? (default == false)
+    bool m_disableReinforcements;           // disable any reinforcements from scenario ini file?
+    bool m_drawUsages;                      // draw the amount of structures/units/bullets used during combat
+    bool m_drawUnitDebug;                   // draw the unit debug info (rects, paths, etc)
+    bool m_noAiRest;                        // Campaign AI does not have long initial REST time
+    bool m_playMusic;                       // play any music?
+    bool m_useFocus;                        // whether to use focus management (pausing the game when losing focus)
+    float m_cameraDragMoveSpeed;            // speed of camera when dragging mouse (default = 0.5f)
+    float m_cameraBorderOrKeyMoveSpeed;     // speed of camera when hitting mouse border or pressing keys (default = 0.5f)
+    bool m_cameraEdgeMove;                  // should move map camera when hitting edges of screen
 
     bool m_playing;				    // playing or not
     bool m_skirmish;                // playing a skirmish game or not

--- a/src/cGame.h
+++ b/src/cGame.h
@@ -85,6 +85,7 @@ public:
     bool m_drawUnitDebug;           // draw the unit debug info (rects, paths, etc)
     bool m_noAiRest;                // Campaign AI does not have long initial REST time
     bool m_playMusic;               // play any music?
+    bool m_useFocus;            // whether to use focus management (pausing the game when losing focus)
     float m_cameraDragMoveSpeed;          // speed of camera when dragging mouse (default = 0.5f)
     float m_cameraBorderOrKeyMoveSpeed;   // speed of camera when hitting mouse border or pressing keys (default = 0.5f)
     bool m_cameraEdgeMove;              // should move map camera when hitting edges of screen

--- a/src/cGame.h
+++ b/src/cGame.h
@@ -40,6 +40,7 @@ struct GameSettings;
 class ContextCreator;
 class GameContext;
 class cScreenShake;
+class cFocusManager;
 
 struct s_TerrainInfo;
 // Naming thoughts:
@@ -290,11 +291,11 @@ private:
     bool m_rocketTurretsDownOnLowPower;
 
     std::string m_gameFilename;
-    bool hasFocus;
 
     std::unique_ptr<cPlatformLayerInit> m_PLInit;
     std::unique_ptr<cScreenInit> m_Screen;
     std::unique_ptr<cInteractionManager> m_interactionManager;
+    std::unique_ptr<cFocusManager> m_focusManager;
 
     cSoundPlayer* m_soundPlayer;
 

--- a/src/cGame.h
+++ b/src/cGame.h
@@ -290,6 +290,7 @@ private:
     bool m_rocketTurretsDownOnLowPower;
 
     std::string m_gameFilename;
+    bool hasFocus;
 
     std::unique_ptr<cPlatformLayerInit> m_PLInit;
     std::unique_ptr<cScreenInit> m_Screen;

--- a/src/cGame.h
+++ b/src/cGame.h
@@ -85,7 +85,7 @@ public:
     bool m_drawUnitDebug;                   // draw the unit debug info (rects, paths, etc)
     bool m_noAiRest;                        // Campaign AI does not have long initial REST time
     bool m_playMusic;                       // play any music?
-    bool m_useFocus;                        // whether to use focus management (pausing the game when losing focus)
+    bool m_pauseWhenLosingFocus;        // pausing the game when losing focus
     float m_cameraDragMoveSpeed;            // speed of camera when dragging mouse (default = 0.5f)
     float m_cameraBorderOrKeyMoveSpeed;     // speed of camera when hitting mouse border or pressing keys (default = 0.5f)
     bool m_cameraEdgeMove;                  // should move map camera when hitting edges of screen

--- a/src/cGame_logic.cpp
+++ b/src/cGame_logic.cpp
@@ -65,6 +65,7 @@
 
 #include "utils/cScreenShake.h"
 #include "utils/cTimeCounter.h"
+#include "utils/cFocusManager.h"
 
 #include <algorithm>
 #include <random>
@@ -97,7 +98,6 @@ cGame::cGame()
     context = nullptr;
     ctx = nullptr;
     m_mentat = nullptr;
-    hasFocus = true;
 
     // create GameContext
     ctx = std::make_unique<GameContext>();
@@ -107,6 +107,9 @@ cGame::cGame()
     m_timeManager = timeManager.get();
     // send to GameContext
     ctx->setTimeManager(std::move(timeManager));
+    // focus manager
+    m_focusManager = std::make_unique<cFocusManager>(m_timeManager);
+    m_focusManager->setActivateFocus(true);
     // initialisation terrainInfo
     m_TerrainInfo = std::make_shared<s_TerrainInfo>();
 
@@ -645,7 +648,7 @@ void cGame::run()
     screenTexture = renderDrawer->createRenderTargetTexture(m_screenW, m_screenH);
     SDL_Event event;
     while (m_playing) {
-        if (hasFocus) {
+        if (m_focusManager->getFocus()) {
             m_timeManager->processTime();
         }
         while (SDL_PollEvent(&event)) {
@@ -654,28 +657,7 @@ void cGame::run()
                     m_playing = false;
                     break;
                 case SDL_WINDOWEVENT:
-                    switch (event.window.event) {
-                        case SDL_WINDOWEVENT_FOCUS_LOST:
-                            hasFocus = false;
-                            m_timeManager->focusLost();
-                            // std::cout << "Window focus lost" << std::endl;
-                            break;
-                        case SDL_WINDOWEVENT_FOCUS_GAINED:
-                            hasFocus = true;
-                            m_timeManager->focusGained();
-                            // std::cout << "Window focus gained" << std::endl;
-                            break;
-                        case SDL_WINDOWEVENT_MINIMIZED:
-                            hasFocus = false;
-                            m_timeManager->focusLost();
-                            // std::cout << "Window minimized" << std::endl;
-                            break;
-                        case SDL_WINDOWEVENT_RESTORED:
-                            hasFocus = true;
-                            m_timeManager->focusGained();
-                            // std::cout << "Window restored" << std::endl;
-                            break;
-                    }
+                    m_focusManager->onWindowsFocus(event.window);
                     break;
                 case SDL_KEYDOWN:
                 case SDL_KEYUP:
@@ -692,7 +674,7 @@ void cGame::run()
             }
         }
 
-        if (!hasFocus) {
+        if (!m_focusManager->getFocus()) {
             m_timeManager->waitForCPU(); // wait for CPU to catch up, so we don't run too fast
             continue; // skip the rest of the loop when we don't have focus
         }

--- a/src/cGame_logic.cpp
+++ b/src/cGame_logic.cpp
@@ -97,6 +97,7 @@ cGame::cGame()
     context = nullptr;
     ctx = nullptr;
     m_mentat = nullptr;
+    hasFocus = true;
 
     // create GameContext
     ctx = std::make_unique<GameContext>();
@@ -644,13 +645,38 @@ void cGame::run()
     screenTexture = renderDrawer->createRenderTargetTexture(m_screenW, m_screenH);
     SDL_Event event;
     while (m_playing) {
-        m_timeManager->processTime();
+        if (hasFocus) {
+            m_timeManager->processTime();
+        }
         while (SDL_PollEvent(&event)) {
             switch (event.type) {
                 case SDL_QUIT:
                     m_playing = false;
                     break;
-
+                case SDL_WINDOWEVENT:
+                    switch (event.window.event) {
+                        case SDL_WINDOWEVENT_FOCUS_LOST:
+                            hasFocus = false;
+                            m_timeManager->focusLost();
+                            // std::cout << "Window focus lost" << std::endl;
+                            break;
+                        case SDL_WINDOWEVENT_FOCUS_GAINED:
+                            hasFocus = true;
+                            m_timeManager->focusGained();
+                            // std::cout << "Window focus gained" << std::endl;
+                            break;
+                        case SDL_WINDOWEVENT_MINIMIZED:
+                            hasFocus = false;
+                            m_timeManager->focusLost();
+                            // std::cout << "Window minimized" << std::endl;
+                            break;
+                        case SDL_WINDOWEVENT_RESTORED:
+                            hasFocus = true;
+                            m_timeManager->focusGained();
+                            // std::cout << "Window restored" << std::endl;
+                            break;
+                    }
+                    break;
                 case SDL_KEYDOWN:
                 case SDL_KEYUP:
                     m_keyboard->handleEvent(event);
@@ -665,6 +691,12 @@ void cGame::run()
                     break;
             }
         }
+
+        if (!hasFocus) {
+            m_timeManager->waitForCPU(); // wait for CPU to catch up, so we don't run too fast
+            continue; // skip the rest of the loop when we don't have focus
+        }
+
         updateMouseAndKeyboardState();
         updateGamePlaying();
 

--- a/src/cGame_logic.cpp
+++ b/src/cGame_logic.cpp
@@ -98,7 +98,7 @@ cGame::cGame()
     context = nullptr;
     ctx = nullptr;
     m_mentat = nullptr;
-    m_useFocus = false;
+    m_pauseWhenLosingFocus = false;
 
     // create GameContext
     ctx = std::make_unique<GameContext>();
@@ -131,7 +131,7 @@ void cGame::applySettings(GameSettings *gs)
     m_playSound = gs->playSound;
     m_debugMode = gs->debugMode;
     m_drawUnitDebug = gs->drawUnitDebug;
-    m_useFocus = gs->useFocus;
+    m_pauseWhenLosingFocus = gs->pauseWhenLosingFocus;
     m_disableAI = gs->disableAI;
     m_oneAi = gs->oneAi;
     m_disableWormAi = gs->disableWormAi;
@@ -649,7 +649,7 @@ void cGame::run()
     screenTexture = renderDrawer->createRenderTargetTexture(m_screenW, m_screenH);
     SDL_Event event;
     while (m_playing) {
-        if (m_focusManager->getFocus()) {
+        if (m_focusManager->isGameWindowActive()) {
             m_timeManager->processTime();
         }
         while (SDL_PollEvent(&event)) {
@@ -675,7 +675,7 @@ void cGame::run()
             }
         }
 
-        if (!m_focusManager->getFocus()) {
+        if (!m_focusManager->isGameWindowActive()) {
             m_timeManager->waitForCPU(); // wait for CPU to catch up, so we don't run too fast
             continue; // skip the rest of the loop when we don't have focus
         }
@@ -926,7 +926,7 @@ bool cGame::setupGame()
     // Now we are ready for the menu state
     game.setState(GAME_MENU);
 
-    m_focusManager->setActivateFocus(m_useFocus);
+    m_focusManager->setEnabled(m_pauseWhenLosingFocus);
 
     // do install_upgrades after game.init, because game.init loads the INI file and then has the very latest
     // unit/structures catalog loaded - which the install_upgrades depends on.

--- a/src/cGame_logic.cpp
+++ b/src/cGame_logic.cpp
@@ -98,6 +98,7 @@ cGame::cGame()
     context = nullptr;
     ctx = nullptr;
     m_mentat = nullptr;
+    m_useFocus = false;
 
     // create GameContext
     ctx = std::make_unique<GameContext>();
@@ -109,7 +110,6 @@ cGame::cGame()
     ctx->setTimeManager(std::move(timeManager));
     // focus manager
     m_focusManager = std::make_unique<cFocusManager>(m_timeManager);
-    m_focusManager->setActivateFocus(true);
     // initialisation terrainInfo
     m_TerrainInfo = std::make_shared<s_TerrainInfo>();
 
@@ -131,6 +131,7 @@ void cGame::applySettings(GameSettings *gs)
     m_playSound = gs->playSound;
     m_debugMode = gs->debugMode;
     m_drawUnitDebug = gs->drawUnitDebug;
+    m_useFocus = gs->useFocus;
     m_disableAI = gs->disableAI;
     m_oneAi = gs->oneAi;
     m_disableWormAi = gs->disableWormAi;
@@ -924,6 +925,8 @@ bool cGame::setupGame()
     cIni::installGame(m_gameFilename);
     // Now we are ready for the menu state
     game.setState(GAME_MENU);
+
+    m_focusManager->setActivateFocus(m_useFocus);
 
     // do install_upgrades after game.init, because game.init loads the INI file and then has the very latest
     // unit/structures catalog loaded - which the install_upgrades depends on.

--- a/src/utils/GameSettings.hpp
+++ b/src/utils/GameSettings.hpp
@@ -21,6 +21,6 @@ struct GameSettings {
     bool disableReinforcements = false;
     bool noAiRest = false;
     bool drawUsages = false;
-    bool useFocus = false;
+    bool pauseWhenLosingFocus = false;
     std::string gameFilename = "game.ini";
 };

--- a/src/utils/GameSettings.hpp
+++ b/src/utils/GameSettings.hpp
@@ -21,5 +21,6 @@ struct GameSettings {
     bool disableReinforcements = false;
     bool noAiRest = false;
     bool drawUsages = false;
+    bool useFocus = false;
     std::string gameFilename = "game.ini";
 };

--- a/src/utils/cFocusManager.cpp
+++ b/src/utils/cFocusManager.cpp
@@ -1,5 +1,6 @@
 #include "utils/cFocusManager.h"
 #include "utils/cTimeManager.h"
+#include <iostream>
 
 cFocusManager::cFocusManager(cTimeManager* timeManager)
 {
@@ -36,22 +37,22 @@ void cFocusManager::onWindowsFocus(const SDL_WindowEvent &event)
         case SDL_WINDOWEVENT_FOCUS_LOST:
             hasFocus = false;
             m_timeManager->focusLost();
-            // std::cout << "Window focus lost" << std::endl;
+            std::cout << "Window focus lost" << std::endl;
             break;
         case SDL_WINDOWEVENT_FOCUS_GAINED:
             hasFocus = true;
             m_timeManager->focusGained();
-            // std::cout << "Window focus gained" << std::endl;
+            std::cout << "Window focus gained" << std::endl;
             break;
         case SDL_WINDOWEVENT_MINIMIZED:
             hasFocus = false;
             m_timeManager->focusLost();
-            // std::cout << "Window minimized" << std::endl;
+            std::cout << "Window minimized" << std::endl;
             break;
         case SDL_WINDOWEVENT_RESTORED:
             hasFocus = true;
             m_timeManager->focusGained();
-            // std::cout << "Window restored" << std::endl;
+            std::cout << "Window restored" << std::endl;
             break;
     }
 }

--- a/src/utils/cFocusManager.cpp
+++ b/src/utils/cFocusManager.cpp
@@ -8,51 +8,49 @@ cFocusManager::cFocusManager(cTimeManager* timeManager)
     m_timeManager = timeManager;
 }
 
-cFocusManager::~cFocusManager()
+void cFocusManager::setEnabled(bool value)
 {
-    // Clean up resources if needed
+    m_enabled = value;
 }
 
-void cFocusManager::setActivateFocus(bool value)
+bool cFocusManager::isEnabled() const
 {
-    actifFocus = value;
-}
-
-bool cFocusManager::getActivateFocus() const
-{
-    return actifFocus;
-}
-
-bool cFocusManager::getFocus() const
-{
-    return hasFocus;
+    return m_enabled;
 }
 
 void cFocusManager::onWindowsFocus(const SDL_WindowEvent &event)
 {
-    if (!actifFocus) {
+    if (!m_enabled) {
         return; // If focus management is not active, do nothing
     }
     switch (event.event) {
         case SDL_WINDOWEVENT_FOCUS_LOST:
-            hasFocus = false;
-            m_timeManager->focusLost();
-            std::cout << "Window focus lost" << std::endl;
-            break;
-        case SDL_WINDOWEVENT_FOCUS_GAINED:
-            hasFocus = true;
-            m_timeManager->focusGained();
-            std::cout << "Window focus gained" << std::endl;
+            gameWindowActive = false;
+            m_timeManager->onWindowFocusLost();
+            std::cout << "D2TM: Window focus lost" << std::endl;
             break;
         case SDL_WINDOWEVENT_MINIMIZED:
-            hasFocus = false;
-            m_timeManager->focusLost();
-            std::cout << "Window minimized" << std::endl;
+            gameWindowActive = false;
+            m_timeManager->onWindowFocusLost();
+            std::cout << "D2TM: Window minimized" << std::endl;
+            break;
+        case SDL_WINDOWEVENT_FOCUS_GAINED:
+            gameWindowActive = true;
+            m_timeManager->onWindowFocusGained();
+            std::cout << "D2TM: Window focus gained" << std::endl;
             break;
         case SDL_WINDOWEVENT_RESTORED:
-            hasFocus = true;
-            m_timeManager->focusGained();
-            std::cout << "Window restored" << std::endl;
+            gameWindowActive = true;
+            m_timeManager->onWindowFocusGained();
+            std::cout << "D2TM: Window restored" << std::endl;
+            break;
+        default:
+            // ignore other events
             break;
     }
+}
+
+bool cFocusManager::isGameWindowActive() const
+{
+    return gameWindowActive;
 }

--- a/src/utils/cFocusManager.cpp
+++ b/src/utils/cFocusManager.cpp
@@ -1,0 +1,57 @@
+#include "utils/cFocusManager.h"
+#include "utils/cTimeManager.h"
+
+cFocusManager::cFocusManager(cTimeManager* timeManager)
+{
+    // Initialize focus manager with time manager if needed
+    m_timeManager = timeManager;
+}
+
+cFocusManager::~cFocusManager()
+{
+    // Clean up resources if needed
+}
+
+void cFocusManager::setActivateFocus(bool value)
+{
+    actifFocus = value;
+}
+
+bool cFocusManager::getActivateFocus() const
+{
+    return actifFocus;
+}
+
+bool cFocusManager::getFocus() const
+{
+    return hasFocus;
+}
+
+void cFocusManager::onWindowsFocus(const SDL_WindowEvent &event)
+{
+    if (!actifFocus) {
+        return; // If focus management is not active, do nothing
+    }
+    switch (event.event) {
+        case SDL_WINDOWEVENT_FOCUS_LOST:
+            hasFocus = false;
+            m_timeManager->focusLost();
+            // std::cout << "Window focus lost" << std::endl;
+            break;
+        case SDL_WINDOWEVENT_FOCUS_GAINED:
+            hasFocus = true;
+            m_timeManager->focusGained();
+            // std::cout << "Window focus gained" << std::endl;
+            break;
+        case SDL_WINDOWEVENT_MINIMIZED:
+            hasFocus = false;
+            m_timeManager->focusLost();
+            // std::cout << "Window minimized" << std::endl;
+            break;
+        case SDL_WINDOWEVENT_RESTORED:
+            hasFocus = true;
+            m_timeManager->focusGained();
+            // std::cout << "Window restored" << std::endl;
+            break;
+    }
+}

--- a/src/utils/cFocusManager.h
+++ b/src/utils/cFocusManager.h
@@ -1,3 +1,4 @@
+#pragma once
 
 #include <SDL2/SDL.h>
 
@@ -6,14 +7,14 @@ class cTimeManager;
 class cFocusManager {
 public:
     cFocusManager(cTimeManager* timeManager);
-    ~cFocusManager();
+    ~cFocusManager() = default;
 
-    void setActivateFocus(bool value);
-    bool getActivateFocus() const;
+    void setEnabled(bool value);
+    [[nodiscard]] bool isEnabled() const;
     void onWindowsFocus(const SDL_WindowEvent& event);
-    bool getFocus() const;
+    [[nodiscard]] bool isGameWindowActive() const;
 private:
-    bool actifFocus = false;
-    bool hasFocus = true;
+    bool m_enabled = false;
+    bool gameWindowActive = true;
     cTimeManager* m_timeManager = nullptr;
 };

--- a/src/utils/cFocusManager.h
+++ b/src/utils/cFocusManager.h
@@ -1,0 +1,19 @@
+
+#include <SDL2/SDL.h>
+
+class cTimeManager;
+
+class cFocusManager {
+public:
+    cFocusManager(cTimeManager* timeManager);
+    ~cFocusManager();
+
+    void setActivateFocus(bool value);
+    bool getActivateFocus() const;
+    void onWindowsFocus(const SDL_WindowEvent& event);
+    bool getFocus() const;
+private:
+    bool actifFocus = false;
+    bool hasFocus = true;
+    cTimeManager* m_timeManager = nullptr;
+};

--- a/src/utils/cHandleArgument.cpp
+++ b/src/utils/cHandleArgument.cpp
@@ -4,6 +4,25 @@
 #include <string>
 #include <format>
 
+const std::map<std::string, cHandleArgument::Options> cHandleArgument::optionStrings{
+    {"-game",             Options::GAME},
+    {"-windowed",         Options::WINDOWED},
+    {"-nomusic",          Options::NOMUSIC},
+    {"-nosound",          Options::NOSOUND},
+    {"-debug",            Options::DEBUG},
+    {"-debug-units",      Options::DEBUG_UNITS},
+    {"-noai",             Options::NOAI},
+    {"-oneai",            Options::ONEAI},
+    {"-nowormai",         Options::NOWORMAI},
+    {"-noreinforcements", Options::NOREINFORCEMENTS},
+    {"-noairest",         Options::NOAIREST},
+    {"-screenWidth",      Options::SCREENX},
+    {"-screenHeight",     Options::SCREENY},
+    {"-usages",           Options::USAGES},
+    {"-useFocus",         Options::USEFOCUS},
+    {"--help",            Options::HELP}
+};
+
 int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings *settings)
 {
     if (argc < 2) {

--- a/src/utils/cHandleArgument.cpp
+++ b/src/utils/cHandleArgument.cpp
@@ -5,22 +5,22 @@
 #include <format>
 
 const std::map<std::string, cHandleArgument::Options> cHandleArgument::optionStrings{
-    {"-game",             Options::GAME},
-    {"-windowed",         Options::WINDOWED},
-    {"-nomusic",          Options::NOMUSIC},
-    {"-nosound",          Options::NOSOUND},
-    {"-debug",            Options::DEBUG},
-    {"-debug-units",      Options::DEBUG_UNITS},
-    {"-noai",             Options::NOAI},
-    {"-oneai",            Options::ONEAI},
-    {"-nowormai",         Options::NOWORMAI},
-    {"-noreinforcements", Options::NOREINFORCEMENTS},
-    {"-noairest",         Options::NOAIREST},
-    {"-screenWidth",      Options::SCREENX},
-    {"-screenHeight",     Options::SCREENY},
-    {"-usages",           Options::USAGES},
-    {"-useFocus",         Options::USEFOCUS},
-    {"--help",            Options::HELP}
+    {"-game",                   Options::GAME},
+    {"-windowed",               Options::WINDOWED},
+    {"-nomusic",                Options::NOMUSIC},
+    {"-nosound",                Options::NOSOUND},
+    {"-debug",                  Options::DEBUG},
+    {"-debug-units",            Options::DEBUG_UNITS},
+    {"-noai",                   Options::NOAI},
+    {"-oneai",                  Options::ONEAI},
+    {"-nowormai",               Options::NOWORMAI},
+    {"-noreinforcements",       Options::NOREINFORCEMENTS},
+    {"-noairest",               Options::NOAIREST},
+    {"-screenWidth",            Options::SCREENX},
+    {"-screenHeight",           Options::SCREENY},
+    {"-usages",                 Options::USAGES},
+    {"-autopause",              Options::PAUSE_WHEN_LOSING_FOCUS},
+    {"--help",                  Options::HELP}
 };
 
 int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings *settings)
@@ -99,8 +99,8 @@ int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings *setti
             case Options::USAGES:
                 settings->drawUsages = true;
                 break;
-            case Options::USEFOCUS:
-                settings->useFocus = true;
+            case Options::PAUSE_WHEN_LOSING_FOCUS:
+                settings->pauseWhenLosingFocus = true;
                 break;
         }
     }
@@ -126,6 +126,10 @@ void cHandleArgument::printInstructions() const
     std::cout << "------------\n\n";
     std::cout << "-game <filename>       - Specify which file to use instead of game.ini\n";
     std::cout << "\n\n";
+    std::cout << "Other\n";
+    std::cout << "---------\n\n";
+    std::cout << "-autopause             - Pauses game when losing focus\n";
+    std::cout << "\n\n";
     std::cout << "Debugging\n";
     std::cout << "---------\n\n";
     std::cout << "-debug                 - Run in debug mode\n";
@@ -136,7 +140,6 @@ void cHandleArgument::printInstructions() const
     std::cout << "-noreinforcements      - Disable reinforcements (Campaign mode)\n";
     std::cout << "-noairest              - Disable initial delay of player AI before becoming active\n";
     std::cout << "-usages                - Draw used units, structures, particles, etc.\n";
-    std::cout << "-useFocus              - Use focus management (pauses game when losing focus)\n";
     std::cout << "\n\n";
     std::cout << "Examples (Windows)\n";
     std::cout << "------------------\n\n";

--- a/src/utils/cHandleArgument.cpp
+++ b/src/utils/cHandleArgument.cpp
@@ -80,6 +80,9 @@ int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings *setti
             case Options::USAGES:
                 settings->drawUsages = true;
                 break;
+            case Options::USEFOCUS:
+                settings->useFocus = true;
+                break;
         }
     }
     return 0;
@@ -114,6 +117,7 @@ void cHandleArgument::printInstructions() const
     std::cout << "-noreinforcements      - Disable reinforcements (Campaign mode)\n";
     std::cout << "-noairest              - Disable initial delay of player AI before becoming active\n";
     std::cout << "-usages                - Draw used units, structures, particles, etc.\n";
+    std::cout << "-useFocus              - Use focus management (pauses game when losing focus)\n";
     std::cout << "\n\n";
     std::cout << "Examples (Windows)\n";
     std::cout << "------------------\n\n";

--- a/src/utils/cHandleArgument.h
+++ b/src/utils/cHandleArgument.h
@@ -31,25 +31,7 @@ private:
         HELP
     };
 
-    const std::map<std::string, Options> optionStrings{
-        {"-game",             Options::GAME},
-        {"-windowed",         Options::WINDOWED},
-        {"-nomusic",          Options::NOMUSIC},
-        {"-nosound",          Options::NOSOUND},
-        {"-debug",            Options::DEBUG},
-        {"-debug-units",      Options::DEBUG_UNITS},
-        {"-noai",             Options::NOAI},
-        {"-oneai",            Options::ONEAI},
-        {"-nowormai",         Options::NOWORMAI},
-        {"-noreinforcements", Options::NOREINFORCEMENTS},
-        {"-noairest",         Options::NOAIREST},
-        {"-screenWidth",      Options::SCREENX},
-        {"-screenHeight",     Options::SCREENY},
-        {"-usages",           Options::USAGES},
-        {"-useFocus",         Options::USEFOCUS},
-        {"--help",            Options::HELP}
-    };
-
+    static const std::map<std::string, Options> optionStrings;
 
     void printInstructions() const;
 };

--- a/src/utils/cHandleArgument.h
+++ b/src/utils/cHandleArgument.h
@@ -25,7 +25,7 @@ private:
         NOREINFORCEMENTS,
         NOAIREST,
         USAGES,
-        USEFOCUS,
+        PAUSE_WHEN_LOSING_FOCUS,
         SCREENX,
         SCREENY,
         HELP

--- a/src/utils/cHandleArgument.h
+++ b/src/utils/cHandleArgument.h
@@ -25,6 +25,7 @@ private:
         NOREINFORCEMENTS,
         NOAIREST,
         USAGES,
+        USEFOCUS,
         SCREENX,
         SCREENY,
         HELP
@@ -45,6 +46,7 @@ private:
         {"-screenWidth",      Options::SCREENX},
         {"-screenHeight",     Options::SCREENY},
         {"-usages",           Options::USAGES},
+        {"-useFocus",         Options::USEFOCUS},
         {"--help",            Options::HELP}
     };
 

--- a/src/utils/cTimeManager.cpp
+++ b/src/utils/cTimeManager.cpp
@@ -70,12 +70,12 @@ std::string cTimeManager::getCurrentTimer() const
 #endif
 }
 
-void cTimeManager::focusLost()
+void cTimeManager::onWindowFocusLost()
 {
     m_focusLostTime = SDL_GetTicks();
 }
 
-void cTimeManager::focusGained()
+void cTimeManager::onWindowFocusGained()
 {
     if (m_focusLostTime > 0) {
         int lostTime = SDL_GetTicks() - m_focusLostTime;

--- a/src/utils/cTimeManager.cpp
+++ b/src/utils/cTimeManager.cpp
@@ -70,6 +70,28 @@ std::string cTimeManager::getCurrentTimer() const
 #endif
 }
 
+void cTimeManager::focusLost()
+{
+    m_focusLostTime = SDL_GetTicks();
+}
+
+void cTimeManager::focusGained()
+{
+    if (m_focusLostTime > 0) {
+        int lostTime = SDL_GetTicks() - m_focusLostTime;
+        // std::cout << "Focus regained, lost time: " << lostTime << " ms" << std::endl;
+        m_focusLostTime = 0;
+
+        // std::cout << "Before : " << m_timerGameTime.lastTick << std::endl;
+        m_timerGameTime.lastTick += lostTime;
+        m_timerUnits.lastTick += lostTime;
+        m_timerSecond.lastTick += lostTime;
+        m_timerMinute.lastTick += lostTime;
+        // std::cout << "After : " << m_timerGameTime.lastTick << std::endl;
+        // std::cout << "yet : " << SDL_GetTicks() << std::endl;
+    }
+}
+
 /**
 	In case the system locks up, or the computer is on heavy duty. The capping
 	makes sure the computer will not cause a chainreaction (getting extremely high timers

--- a/src/utils/cTimeManager.cpp
+++ b/src/utils/cTimeManager.cpp
@@ -16,14 +16,10 @@ constexpr int IDEAL_FPS = 60; // ideal frames per second
 
 cTimeManager::cTimeManager(cGame *game)
     : m_game(game)
-    , m_timerUnits(0)
-    , m_timerSecond(0)
-    , m_timerMinute(0)
-    , m_timerGlobal(0)
     , m_gameTime(0)
 {
     // we fix time to 5 100 1000
-    durationTime.init(5);
+    initTimers(5);
     m_timeCounter = std::make_unique<cTimeCounter>();
 }
 
@@ -85,25 +81,25 @@ void cTimeManager::capTimers()
 {
     auto logger = cLogger::getInstance();
 
-    if (m_timerUnits > 10) {
+    if (m_timerUnits.count > 10) {
         if (m_game->isDebugMode()) {
-            logger->log(LOG_WARN, COMP_NONE, "Timer", std::format("WARNING: Exeptional high unit timer ({}); capped at 10", m_timerUnits));
-            m_timerUnits = 10;
+            logger->log(LOG_WARN, COMP_NONE, "Timer", std::format("WARNING: Exeptional high unit timer ({}); capped at 10", m_timerUnits.count));
+            m_timerUnits.count = 10;
         }
     }
 
-    if (m_timerGlobal > 40) {
+    if (m_timerGameTime.count > 40) {
         if (m_game->isDebugMode()) {
-            logger->log(LOG_WARN, COMP_NONE, "Timer", std::format("WARNING: Exeptional high global timer ({}); capped at 40", m_timerGlobal));
-            m_timerGlobal = 40;
+            logger->log(LOG_WARN, COMP_NONE, "Timer", std::format("WARNING: Exeptional high global timer ({}); capped at 40", m_timerGameTime.count));
+            m_timerGameTime.count = 40;
         }
     }
 
     /* Taking 10 seconds to render a frame? i hope not **/
-    if (m_timerSecond > 10) {
+    if (m_timerSecond.count > 10) {
         if (m_game->isDebugMode()) {
-            logger->log(LOG_WARN, COMP_NONE, "Timer", std::format("WARNING: Exeptional high timer second ({}); capped at 10", m_timerSecond));
-            m_timerSecond = 10;
+            logger->log(LOG_WARN, COMP_NONE, "Timer", std::format("WARNING: Exeptional high timer second ({}); capped at 10", m_timerSecond.count));
+            m_timerSecond.count = 10;
         }
     }
 }
@@ -113,11 +109,11 @@ void cTimeManager::capTimers()
  */
 void cTimeManager::handleTimerSecond()
 {
-    while (m_timerSecond > 0) {
+    while (m_timerSecond.count > 0) {
         m_gameTime++;
         m_game->thinkSlow();
-        m_timerSecond--; // done!
-        m_timeCounter->addTime(durationTime.secondTickDuration/1000);
+        m_timerSecond.count--;
+        m_timeCounter->addTime(m_timerSecond.tickDuration / 1000);
     }
 }
 
@@ -126,12 +122,10 @@ void cTimeManager::handleTimerSecond()
  */
 void cTimeManager::handleTimerGameTime()
 {
-    // keep up with time cycles
-    while (m_timerGlobal > 0) {
+    while (m_timerGameTime.count > 0) {
         m_game->think_fading();
         m_game->thinkFast_state();
-
-        m_timerGlobal--;
+        m_timerGameTime.count--;
     }
 }
 
@@ -140,9 +134,9 @@ void cTimeManager::handleTimerGameTime()
  */
 void cTimeManager::handleTimerUnits()
 {
-    while (m_timerUnits > 0) {
+    while (m_timerUnits.count > 0) {
         m_game->think_state();
-        m_timerUnits--;
+        m_timerUnits.count--;
     }
 }
 
@@ -151,9 +145,9 @@ void cTimeManager::handleTimerUnits()
  */
 void cTimeManager::handleTimerMinute()
 {
-    if (m_timerMinute > 0) {
+    while (m_timerMinute.count > 0) {
         m_game->think_minute();
-        m_timerMinute--;
+        m_timerMinute.count--;
     }
 }
 
@@ -172,32 +166,28 @@ void cTimeManager::handleTimerMinute()
 */
 void cTimeManager::processTime()
 {
-//    syncFromAllegroTimers();
     uint64_t now = SDL_GetTicks64();
 
-    // 100 ms pour allegro_timerunits
-    while (now - m_lastUnitsTick >= durationTime.unitTickDuration) {
-        m_timerUnits++;
-        m_lastUnitsTick += durationTime.unitTickDuration;
+    while (now - m_timerUnits.lastTick >= m_timerUnits.tickDuration) {
+        m_timerUnits.count++;
+        m_timerUnits.lastTick += m_timerUnits.tickDuration;
     }
 
-    // 5 ms pour allegro_timergametime
-    while (now - m_lastGameTimeTick >= durationTime.gameTickDuration) {
-        m_timerGlobal++;
-        m_lastGameTimeTick += durationTime.gameTickDuration;
+    while (now - m_timerGameTime.lastTick >= m_timerGameTime.tickDuration) {
+        m_timerGameTime.count++;
+        m_timerGameTime.lastTick += m_timerGameTime.tickDuration;
     }
 
-    // 1000 ms pour allegro_timerseconds
-    while (now - m_lastSecondsTick >= durationTime.secondTickDuration) {
-        m_timerSecond++;
-        m_lastSecondsTick += durationTime.secondTickDuration;
+    while (now - m_timerSecond.lastTick >= m_timerSecond.tickDuration) {
+        m_timerSecond.count++;
+        m_timerSecond.lastTick += m_timerSecond.tickDuration;
     }
 
-    // 60000 ms pour allegro_timerseconds
-    while (now - m_lastMinuteTick >= durationTime.minTickDuration) {
-        m_timerMinute++;
-        m_lastMinuteTick += durationTime.minTickDuration;
+    while (now - m_timerMinute.lastTick >= m_timerMinute.tickDuration) {
+        m_timerMinute.count++;
+        m_timerMinute.lastTick += m_timerMinute.tickDuration;
     }
+
     capTimers();
     handleTimerSecond();
     handleTimerUnits();
@@ -239,7 +229,7 @@ void cTimeManager::adaptWaitingTime()
 void cTimeManager::setGlobalSpeed(int speed)
 {
     speed = std::clamp(speed, 1, 10);
-    durationTime.init(speed);
+    initTimers(speed);
 }
 
 void cTimeManager::startTimer()
@@ -258,10 +248,17 @@ void cTimeManager::restartTimer()
 }
 void cTimeManager::setGlobalSpeedVariation(int variation)
 {
-    int speed = durationTime.gameTickDuration;
+    int speed = m_timerGameTime.tickDuration;
     if (variation > 0)
         speed += 1;
     if (variation < 0)
         speed -= 1;
     setGlobalSpeed(speed);
+}
+
+void cTimeManager::initTimers(int baseSpeed) {
+    m_timerGameTime.tickDuration = baseSpeed;
+    m_timerUnits.tickDuration = baseSpeed * 20;
+    m_timerSecond.tickDuration = baseSpeed * 200;
+    m_timerMinute.tickDuration = 60000;
 }

--- a/src/utils/cTimeManager.h
+++ b/src/utils/cTimeManager.h
@@ -55,9 +55,9 @@ public:
     void restartTimer();
 
     // freeze time when focus is lost, and catch up when focus is regained
-    void focusLost();
+    void onWindowFocusLost();
     // catch up time when focus is regained
-    void focusGained();
+    void onWindowFocusGained();
 
 private:
     // gametime timer is called every 100 ms, try to keep up with that.
@@ -76,9 +76,9 @@ private:
     cGame *m_game;
 
     struct Timer {
-        int count = 0;           // nombre de cycles à traiter
-        uint64_t lastTick = 0;   // dernier tick traité
-        uint64_t tickDuration = 0; // durée d'un tick (en ms)
+        int count = 0;                  // number of cycles to process
+        uint64_t lastTick = 0;          // last tick processed
+        uint64_t tickDuration = 0;      // duration of a tick (in ms)
     };
 
     Timer m_timerUnits;
@@ -86,11 +86,11 @@ private:
     Timer m_timerSecond;
     Timer m_timerMinute;
 
-    int m_gameTime = 0; // Definition of game time (= in seconds)
-    int m_fps = 0;			/** Frames per second **/
-    int frameCount = 0;		/** Frame count for FPS calculation **/
-    int waitingTime = 10;	/** Waiting time in ms, used to adapt FPS **/
-    int m_focusLostTime = 0; // Time when focus was lost, used to calculate time to catch up when focus is regained
+    int m_gameTime = 0;         // Definition of game time (= in seconds)
+    int m_fps = 0;			    // Frames per second
+    int frameCount = 0;		    // Frame count for FPS calculation
+    int waitingTime = 10;	    // Waiting time in ms, used to adapt FPS
+    int m_focusLostTime = 0;    // Time when focus was lost, used to calculate time to catch up when focus is regained
 
     std::unique_ptr<cTimeCounter> m_timeCounter;
 };

--- a/src/utils/cTimeManager.h
+++ b/src/utils/cTimeManager.h
@@ -41,7 +41,7 @@ public:
     void setGlobalSpeed(int speed);
     void setGlobalSpeedVariation(int variation);
     // get global speed
-    uint16_t getGlobalSpeed() const { return durationTime.gameTickDuration; }
+    uint16_t getGlobalSpeed() const { return m_timerGameTime.tickDuration; }
     // get current local Time
     std::string getCurrentTime() const;
     // returns the stored timer value on time format
@@ -65,36 +65,26 @@ private:
     void capTimers();
     // start every 60000 ms
     void handleTimerMinute();
+    // reset or set the tick duration based on the global speed
+    void initTimers(int baseSpeed);
 
     cGame *m_game;
-    int m_timerUnits;		/** !!Specificly!! used for units **/
-    int m_timerSecond;
-    int m_timerMinute;
-    int m_timerGlobal;
-    int m_gameTime;		/** Definition of game time (= in seconds) **/
 
+    struct Timer {
+        int count = 0;           // nombre de cycles à traiter
+        uint64_t lastTick = 0;   // dernier tick traité
+        uint64_t tickDuration = 0; // durée d'un tick (en ms)
+    };
+
+    Timer m_timerUnits;
+    Timer m_timerGameTime;
+    Timer m_timerSecond;
+    Timer m_timerMinute;
+
+    int m_gameTime = 0; // Definition of game time (= in seconds)
     int m_fps = 0;			/** Frames per second **/
     int frameCount = 0;		/** Frame count for FPS calculation **/
     int waitingTime = 10;	/** Waiting time in ms, used to adapt FPS **/
-    uint64_t m_lastUnitsTick = 0;
-    uint64_t m_lastGameTimeTick = 0;
-    uint64_t m_lastSecondsTick = 0;
-    uint64_t m_lastMinuteTick = 0;
-
-    struct DurationTime {
-        uint64_t gameTickDuration;  // 5
-        uint64_t unitTickDuration;  // 100
-        uint64_t secondTickDuration; // 1000
-        uint64_t minTickDuration; // 60000
-
-        void init(int value) {
-            gameTickDuration = value;
-            unitTickDuration = value * 20;
-            secondTickDuration = value * 200;
-            minTickDuration = 60000;
-        }
-    };
 
     std::unique_ptr<cTimeCounter> m_timeCounter;
-    DurationTime durationTime;
 };

--- a/src/utils/cTimeManager.h
+++ b/src/utils/cTimeManager.h
@@ -54,6 +54,11 @@ public:
     // restart Timer
     void restartTimer();
 
+    // freeze time when focus is lost, and catch up when focus is regained
+    void focusLost();
+    // catch up time when focus is regained
+    void focusGained();
+
 private:
     // gametime timer is called every 100 ms, try to keep up with that.
     void handleTimerUnits();
@@ -85,6 +90,7 @@ private:
     int m_fps = 0;			/** Frames per second **/
     int frameCount = 0;		/** Frame count for FPS calculation **/
     int waitingTime = 10;	/** Waiting time in ms, used to adapt FPS **/
+    int m_focusLostTime = 0; // Time when focus was lost, used to calculate time to catch up when focus is regained
 
     std::unique_ptr<cTimeCounter> m_timeCounter;
 };

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -83,8 +83,8 @@ std::unique_ptr<GameSettings> loadSettingsFromIni(const std::string& filename)
         gameSettings->noAiRest = section.getBoolean("noAiRest");
     if (section.hasValue("drawUsages"))
         gameSettings->drawUsages = section.getBoolean("drawUsages");
-    if (section.hasValue("useFocus"))
-        gameSettings->useFocus = section.getBoolean("useFocus");
+    if (section.hasValue("pauseWhenLosingFocus"))
+        gameSettings->pauseWhenLosingFocus = section.getBoolean("pauseWhenLosingFocus");
 
     return gameSettings;
 }

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -83,6 +83,8 @@ std::unique_ptr<GameSettings> loadSettingsFromIni(const std::string& filename)
         gameSettings->noAiRest = section.getBoolean("noAiRest");
     if (section.hasValue("drawUsages"))
         gameSettings->drawUsages = section.getBoolean("drawUsages");
+    if (section.hasValue("useFocus"))
+        gameSettings->useFocus = section.getBoolean("useFocus");
 
     return gameSettings;
 }


### PR DESCRIPTION
After Danzemon remarks 

## **Goal**

Pauses the entire application when the main window loses focus

### Changes

- Simplify cTimeManager
- Add `hasFocus` on cGame
- integration of SDL2 functionalities for window event handling : (get/lostFocus and minimize Windows)
- integration flag `useFocus` on `settings.ini` and on command line argument

## Testing Steps
- Need to test all focus lost 
- test interaction with useFocus

## Need to do
~- Creation of a focusKeeper class that encapsulates all the code added to cGame_logic if tests are conclusive~