### PR TITLE
master / Fix dumpCredits

### DIFF
--- a/src/player/cPlayer.cpp
+++ b/src/player/cPlayer.cpp
@@ -812,9 +812,11 @@ int cPlayer::getPowerUsage()
  */
 void cPlayer::dumpCredits(int amount)
 {
-    giveCredits(amount);
-    if (credits > maxCredits_) {
-        credits = maxCredits_;
+//    giveCredits(amount);
+    float oldCredit = credits;
+    credits += amount;
+    if (credits > std::max(oldCredit, maxCredits_)) {
+        credits = std::max(oldCredit, maxCredits_);
     }
 }
 


### PR DESCRIPTION

## **Goal**

In skirmish mode, bonus credits did not disappear once the havester arrived at the refinery.

### Changes
- extra credit didn't disappear
- new credit (when extras credit are not outdated)  are lost 
