### PR TITLE
Manually build binary for intel as well for manual release

### DIFF
--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -135,6 +135,54 @@ jobs:
           publish_dir: ./out
           publish_branch: gh-pages
           keep_files: true
+  MACOSX_INTEL:
+    name: Mac OS X (Intel)
+    runs-on: [ macos-15-intel ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          ./install_dependencies_macosx.sh
+      - name: Configure
+        run: |
+          cd "${{ github.workspace }}"
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          cd "${{ github.workspace }}/build"
+          make -j4
+      - name: Produce binary
+        run: |
+          cd "${{ github.workspace }}"
+          ./create_release.sh
+      - name: Zip binary
+        run: |
+          cd "${{ github.workspace }}/bin"
+          zip -vr d2tm.zip . -x "*.DS_Store"
+      - name: Produce release name
+        run: |
+          cd "${{ github.workspace }}"
+          mkdir -p out/nightly
+          FILE_NAME=D2TM-$(date -u +'%Y-%m-%dT%H-%M').macosx.intel.${{ inputs.tag }}.zip
+          cp bin/d2tm.zip "out/nightly/$FILE_NAME"
+          echo "RELEASE_NAME=$FILE_NAME" >> $GITHUB_ENV
+      - name: Upload ZIP as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.RELEASE_NAME }}
+          path: bin/d2tm.zip
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          publish_branch: gh-pages
+          keep_files: true
 
   MACOSX:
     name: Mac OS X
@@ -172,7 +220,7 @@ jobs:
         run: |
           cd "${{ github.workspace }}"
           mkdir -p out/nightly
-          FILE_NAME=D2TM-$(date -u +'%Y-%m-%dT%H-%M').macosx.${{ inputs.tag }}.zip
+          FILE_NAME=D2TM-$(date -u +'%Y-%m-%dT%H-%M').macosx.arm.${{ inputs.tag }}.zip
           cp bin/d2tm.zip "out/nightly/$FILE_NAME"
           echo "RELEASE_NAME=$FILE_NAME" >> $GITHUB_ENV
       - name: Upload ZIP as artifact
@@ -189,7 +237,7 @@ jobs:
           keep_files: true
 
   Cleanup-GH-Pages:
-    needs: [MSYS2, Ubuntu, MACOSX]  # all builds must be completed successfully
+    needs: [MSYS2, Ubuntu, MACOSX, MACOSX_INTEL]  # all builds must be completed successfully
     name: Cleanup old GH Pages builds
     runs-on: [ macos-15 ]
     steps:


### PR DESCRIPTION
This PR adds an additional build step to produce an Intel Mac zip file to be published. Requested from feedback on v0.8.0