### PR TITLE
Add `-fullscreen` option on startup

### DIFF
--- a/src/utils/cHandleArgument.cpp
+++ b/src/utils/cHandleArgument.cpp
@@ -7,6 +7,7 @@
 const std::map<std::string, cHandleArgument::Options> cHandleArgument::optionStrings{
     {"-game",                   Options::GAME},
     {"-windowed",               Options::WINDOWED},
+    {"-fullscreen",             Options::FULLSCREEN},
     {"-nomusic",                Options::NOMUSIC},
     {"-nosound",                Options::NOSOUND},
     {"-debug",                  Options::DEBUG},
@@ -51,6 +52,9 @@ int cHandleArgument::handleArguments(int argc, char *argv[], GameSettings *setti
                 break;
             case Options::WINDOWED:
                 settings->windowed = true;
+                break;
+            case Options::FULLSCREEN:
+                settings->windowed = false;
                 break;
             case Options::NOMUSIC:
                 settings->playMusic = false;
@@ -114,6 +118,7 @@ void cHandleArgument::printInstructions() const
     std::cout << "Graphics\n";
     std::cout << "--------\n\n";
     std::cout << "-windowed              - Run game in window instead of fullscreen\n";
+    std::cout << "-fullscreen            - Run game in fullscreen instead of windowed\n";
     std::cout << "-screenWidth <value>   - Width of screen / window (minimum 800)\n";
     std::cout << "-screenHeight <value>  - Height of screen / window (minimum 600)\n";
     std::cout << "\n\n";

--- a/src/utils/cHandleArgument.h
+++ b/src/utils/cHandleArgument.h
@@ -15,6 +15,7 @@ private:
     enum class Options : char {
         GAME,
         WINDOWED,
+        FULLSCREEN,
         NOMUSIC,
         NOSOUND,
         DEBUG,


### PR DESCRIPTION
## **Goal**

This PR introduces the `-fullscreen` startup flag so you can deviate from any default `FullScreen=false` in your `settings.ini` file.

### Changes

- Added argument handler to override settings


## Testing Steps
Change `settings.ini` file:

```ini
FullScreen=false
```

Now start the game with:

```
./d2tm -fullscreen
```

Witness that the game uses fullscreen.

## Screenshots (optional)