### PR TITLE
Self-destruct devastator when pressing key `D`

### DIFF
--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -487,6 +487,9 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
             if (pUnit.isHarvester() && pUnit.canUnload()) {
                 pUnit.findBestStructureCandidateAndHeadTowardsItOrWait(REFINERY, true, INTENT_UNLOAD_SPICE);
             }
+            if (pUnit.isType(DEVASTATOR) ) {
+                pUnit.die(true, false);
+            }
         }
     }
 


### PR DESCRIPTION
## **Goal**

Devastator tank will explode when player hit key D

### Changes
- On immediate mode, hit key D will order devastator to explode. 


## Testing Steps

BOOM !
