### PR TITLE
Improvement/repair units selection with key

### DIFF
--- a/src/controls/cGameControlsContext.cpp
+++ b/src/controls/cGameControlsContext.cpp
@@ -11,7 +11,6 @@ cGameControlsContext::cGameControlsContext(cPlayer *player, cMouse *mouse) :
     m_mouseHoveringOverStructureId(-1),
     m_mouseHoveringOverUnitId(-1),
     m_mouseOnBattleField(false),
-    // m_drawToolTip(true),
     m_mouseCell(-99),
     m_player(player),
     m_state(MOUSESTATE_SELECT),
@@ -73,16 +72,6 @@ int cGameControlsContext::getMouseCellFromScreen(int mouseX, int mouseY) const
     int absMapY = game.m_mapCamera->getAbsMapMouseY(mouseY);
     return game.m_mapCamera->getCellFromAbsolutePosition(absMapX, absMapY);
 }
-
-// void cGameControlsContext::determineToolTip()
-// {
-    // @Mira : magical call to key ...
-    // @mira: this function activate drawToolTip with GUI branch
-    // m_drawToolTip = false;
-    // if (key[SDL_SCANCODE_T] && isMouseOnBattleField()) { // TODO: this gets removed later, when we redo tooltips anyway
-    // m_drawToolTip = true;
-    // }
-// }
 
 void cGameControlsContext::determineHoveringOverStructureId()
 {
@@ -146,7 +135,6 @@ void cGameControlsContext::onMouseMovedTo(const s_MouseEvent &event)
     updateMouseCell(event.coords);
     bool mouseOnBattleField = isMouseOnBattleField();
     if (mouseOnBattleField) {
-        // determineToolTip();
         determineHoveringOverStructureId();
         determineHoveringOverUnitId();
 

--- a/src/controls/cGameControlsContext.cpp
+++ b/src/controls/cGameControlsContext.cpp
@@ -11,7 +11,7 @@ cGameControlsContext::cGameControlsContext(cPlayer *player, cMouse *mouse) :
     m_mouseHoveringOverStructureId(-1),
     m_mouseHoveringOverUnitId(-1),
     m_mouseOnBattleField(false),
-    m_drawToolTip(false),
+    // m_drawToolTip(true),
     m_mouseCell(-99),
     m_player(player),
     m_state(MOUSESTATE_SELECT),
@@ -74,15 +74,15 @@ int cGameControlsContext::getMouseCellFromScreen(int mouseX, int mouseY) const
     return game.m_mapCamera->getCellFromAbsolutePosition(absMapX, absMapY);
 }
 
-void cGameControlsContext::determineToolTip()
-{
+// void cGameControlsContext::determineToolTip()
+// {
     // @Mira : magical call to key ...
     // @mira: this function activate drawToolTip with GUI branch
     // m_drawToolTip = false;
     // if (key[SDL_SCANCODE_T] && isMouseOnBattleField()) { // TODO: this gets removed later, when we redo tooltips anyway
     // m_drawToolTip = true;
     // }
-}
+// }
 
 void cGameControlsContext::determineHoveringOverStructureId()
 {
@@ -146,7 +146,7 @@ void cGameControlsContext::onMouseMovedTo(const s_MouseEvent &event)
     updateMouseCell(event.coords);
     bool mouseOnBattleField = isMouseOnBattleField();
     if (mouseOnBattleField) {
-        determineToolTip();
+        // determineToolTip();
         determineHoveringOverStructureId();
         determineHoveringOverUnitId();
 

--- a/src/controls/cGameControlsContext.h
+++ b/src/controls/cGameControlsContext.h
@@ -1,8 +1,7 @@
 #pragma once
 
 // this class holds the game controls context. This means, the updateMouseAndKeyboardStateAndGamePlaying() method
-// will check how the mouse is positioned in this particular frame. It then updates
-// any ids, or other relevant data.
+// will check how the mouse is positioned in this particular frame. It then updates any ids, or other relevant data.
 //
 // For instance, this class knows if a mouse is hovering above a structure, or a unit. The sidebar
 // or above the minimap. It also knows if an order has been issued (attack, move, repair, etc).
@@ -57,11 +56,9 @@ public:
     bool isMouseOnSidebarOrMinimap() const {
         return isMouseOnSidebar() || isMouseOnMiniMap();
     }
+
     bool isMouseOnBattleField() const;
 
-    // bool shouldDrawToolTip() const {
-    //     return m_drawToolTip;
-    // }
     bool isMouseRightButtonPressed() const{
         return m_mouse->isRightButtonPressed();
     }
@@ -83,7 +80,6 @@ public:
     void onFocusMouseStateEvent();
 
 protected:
-    // void determineToolTip();
     void determineHoveringOverStructureId();
     void determineHoveringOverUnitId();
 
@@ -91,8 +87,6 @@ private:
     int m_mouseHoveringOverStructureId;
     int m_mouseHoveringOverUnitId;
     bool m_mouseOnBattleField;
-
-    // bool m_drawToolTip;
 
     // on what cell is the mouse hovering
     int m_mouseCell;

--- a/src/controls/cGameControlsContext.h
+++ b/src/controls/cGameControlsContext.h
@@ -59,9 +59,9 @@ public:
     }
     bool isMouseOnBattleField() const;
 
-    bool shouldDrawToolTip() const {
-        return m_drawToolTip;
-    }
+    // bool shouldDrawToolTip() const {
+    //     return m_drawToolTip;
+    // }
     bool isMouseRightButtonPressed() const{
         return m_mouse->isRightButtonPressed();
     }
@@ -83,7 +83,7 @@ public:
     void onFocusMouseStateEvent();
 
 protected:
-    void determineToolTip();
+    // void determineToolTip();
     void determineHoveringOverStructureId();
     void determineHoveringOverUnitId();
 
@@ -92,7 +92,7 @@ private:
     int m_mouseHoveringOverUnitId;
     bool m_mouseOnBattleField;
 
-    bool m_drawToolTip;
+    // bool m_drawToolTip;
 
     // on what cell is the mouse hovering
     int m_mouseCell;

--- a/src/controls/mousestates/cMouseNormalState.cpp
+++ b/src/controls/mousestates/cMouseNormalState.cpp
@@ -245,7 +245,7 @@ void cMouseNormalState::onKeyPressed(const cKeyboardEvent &event)
         }
     }
 
-    if (event.hasKey(SDL_SCANCODE_R)) {
+    if (event.hasKey(SDL_SCANCODE_R) && m_player->getSelectedUnits().size() == 0) {
         m_context->setMouseState(MOUSESTATE_REPAIR);
     }
 }

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -475,8 +475,19 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
     }
 
     // go to repair state
-    if (event.hasKey(SDL_SCANCODE_R)  && m_player->getSelectedUnits().size() == 0) {
-        m_context->setMouseState(MOUSESTATE_REPAIR);
+    if (event.hasKey(SDL_SCANCODE_R)) {
+        if (m_player->getSelectedUnits().size() == 0) { // no units selected
+            m_context->setMouseState(MOUSESTATE_REPAIR);
+        } else { // units selected
+            for (auto id: m_selectedUnits) {
+                cUnit &pUnit = game.getUnit(id);
+                if (pUnit.isEligibleForRepair()) {
+                    pUnit.findBestStructureCandidateAndHeadTowardsItOrWait(REPAIR, true, INTENT_REPAIR);
+                    pUnit.bSelected = false;
+                    spawnParticle(D2TM_PARTICLE_MOVE);
+                }
+            }
+        }
     }
 
     // order any selected harvester to return to refinery

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -475,7 +475,7 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
     }
 
     // go to repair state
-    if (event.hasKey(SDL_SCANCODE_R)) {
+    if (event.hasKey(SDL_SCANCODE_R)  && m_player->getSelectedUnits().size() == 0) {
         m_context->setMouseState(MOUSESTATE_REPAIR);
     }
 

--- a/src/managers/cDrawManager.cpp
+++ b/src/managers/cDrawManager.cpp
@@ -227,7 +227,7 @@ void cDrawManager::drawCombatMouse()
 
     cGameControlsContext *context = m_player->getGameControlsContext();
     //context->isMouseRightButtonPressed()
-    if (context->shouldDrawToolTip()) {
+    if (m_drawToolTip && context->isMouseOnBattleField() ) {
         m_mouseDrawer->drawToolTip();
     }
 }
@@ -326,6 +326,9 @@ void cDrawManager::onKeyDown(const cKeyboardEvent &event)
             m_mapDrawer->setDrawGrid(true);
         }
     }
+    if (event.hasKey(SDL_SCANCODE_T)) {
+        m_drawToolTip = true;
+    }
 }
 
 void cDrawManager::onKeyPressed(const cKeyboardEvent &event)
@@ -339,6 +342,9 @@ void cDrawManager::onKeyPressed(const cKeyboardEvent &event)
         if (event.hasKey(SDL_SCANCODE_G)) {
             m_mapDrawer->setDrawGrid(false);
         }
+    }
+    if (event.hasKey(SDL_SCANCODE_T)) {
+        m_drawToolTip = false;
     }
 }
 

--- a/src/managers/cDrawManager.cpp
+++ b/src/managers/cDrawManager.cpp
@@ -18,15 +18,6 @@
 #include <cassert>
 
 cDrawManager::cDrawManager(GameContext *ctx, cPlayer *thePlayer) :
-    //m_sidebarDrawer(ctx, thePlayer),
-    // m_creditsDrawer(ctx, thePlayer),
-    // m_orderDrawer(ctx, thePlayer),
-    // m_mapDrawer(&game.m_map, thePlayer, mapCamera),
-    // miniMapDrawer(ctx, &game.m_map, thePlayer, mapCamera),
-    // m_particleDrawer(),
-    // m_messageDrawer(ctx),
-    // m_placeitDrawer(thePlayer),
-    // m_structureDrawer(ctx),
     m_sidebarColor(Color{214, 149, 20,255}),
     m_player(thePlayer),
     m_textDrawer(ctx->getTextContext()->getGameTextDrawer()),
@@ -216,7 +207,6 @@ void cDrawManager::drawStructurePlacing()
 void cDrawManager::drawMessage()
 {
     m_messageDrawer->draw();
-
     // TODO: replace messageDrawer with drawMessageBar?
     // messageBarDrawer->drawMessageBar();
 }
@@ -226,7 +216,6 @@ void cDrawManager::drawCombatMouse()
     drawMouse();
 
     cGameControlsContext *context = m_player->getGameControlsContext();
-    //context->isMouseRightButtonPressed()
     if (m_drawToolTip && context->isMouseOnBattleField() ) {
         m_mouseDrawer->drawToolTip();
     }

--- a/src/managers/cDrawManager.h
+++ b/src/managers/cDrawManager.h
@@ -118,7 +118,7 @@ private:
     std::unique_ptr<cStructureDrawer> m_structureDrawer;
     Color m_sidebarColor;
     Texture *btnOptions;
-
+    bool m_drawToolTip = false;
     // TODO: bullet/projectile drawer
     cPlayer *m_player;
     cTextDrawer *m_textDrawer = nullptr;


### PR DESCRIPTION
## **Goal**

### Changes
- repair mode is restricted by no units selected before hit key
- group of selected units go to repair center and will be deselected

## Testing Steps
Select group of Units. Hit R and all damaged units go to repair center AND will be deselected


## Screenshots
https://github.com/user-attachments/assets/8022f7da-0ef4-4d4d-9571-2b2855b17a78
