### PR TITLE
Send units to repair facility when pressing `r` when a unit is selected.

### DIFF
--- a/src/controls/mousestates/cMouseNormalState.cpp
+++ b/src/controls/mousestates/cMouseNormalState.cpp
@@ -245,7 +245,7 @@ void cMouseNormalState::onKeyPressed(const cKeyboardEvent &event)
         }
     }
 
-    if (event.hasKey(SDL_SCANCODE_R)) {
+    if (event.hasKey(SDL_SCANCODE_R) && m_player->getSelectedUnits().size() == 0) {
         m_context->setMouseState(MOUSESTATE_REPAIR);
     }
 }

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -475,8 +475,19 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
     }
 
     // go to repair state
-    if (event.hasKey(SDL_SCANCODE_R)  && m_player->getSelectedUnits().size() == 0) {
-        m_context->setMouseState(MOUSESTATE_REPAIR);
+    if (event.hasKey(SDL_SCANCODE_R)) {
+        if (m_player->getSelectedUnits().size() == 0) { // no units selected
+            m_context->setMouseState(MOUSESTATE_REPAIR);
+        } else { // units selected
+            for (auto id: m_selectedUnits) {
+                cUnit &pUnit = game.getUnit(id);
+                if (pUnit.isEligibleForRepair()) {
+                    pUnit.findBestStructureCandidateAndHeadTowardsItOrWait(REPAIR, true, INTENT_REPAIR);
+                    pUnit.bSelected = false;
+                    spawnParticle(D2TM_PARTICLE_MOVE);
+                }
+            }
+        }
     }
 
     // order any selected harvester to return to refinery

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -475,7 +475,7 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
     }
 
     // go to repair state
-    if (event.hasKey(SDL_SCANCODE_R)) {
+    if (event.hasKey(SDL_SCANCODE_R)  && m_player->getSelectedUnits().size() == 0) {
         m_context->setMouseState(MOUSESTATE_REPAIR);
     }
 

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -7,7 +7,6 @@
 #include "gameobjects/particles/cParticle.h"
 #include "map/cMapCamera.h"
 #include "player/cPlayer.h"
-#include "utils/cSoundPlayer.h"
 #include "utils/RNG.hpp"
 #include <format>
 
@@ -476,24 +475,19 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
 
     // go to repair state
     if (event.hasKey(SDL_SCANCODE_R)) {
-        if (m_player->getSelectedUnits().size() == 0) { // no units selected
+        if (m_player->getSelectedUnits().empty()) {
             m_context->setMouseState(MOUSESTATE_REPAIR);
-        } else { // units selected
+        } else {
             for (auto id: m_selectedUnits) {
                 cUnit &pUnit = game.getUnit(id);
                 if (pUnit.isEligibleForRepair()) {
                     pUnit.findBestStructureCandidateAndHeadTowardsItOrWait(REPAIR, true, INTENT_REPAIR);
                     pUnit.bSelected = false;
-                    spawnParticle(D2TM_PARTICLE_MOVE);
                 }
             }
-            // @Mira Another loop. I'm looking into how to rewrite this code more elegantly.
             std::erase_if(m_selectedUnits, [&](auto id) {
                 cUnit &pUnit = game.getUnit(id);
-                if (pUnit.isEligibleForRepair()) {
-                    return true; // remove from selection
-                }
-                    return false; // keep in selection
+                return pUnit.isEligibleForRepair(); // remove from selection
             });
         }
     }

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -487,6 +487,14 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
                     spawnParticle(D2TM_PARTICLE_MOVE);
                 }
             }
+            // @Mira Another loop. I'm looking into how to rewrite this code more elegantly.
+            std::erase_if(m_selectedUnits, [&](auto id) {
+                cUnit &pUnit = game.getUnit(id);
+                if (pUnit.isEligibleForRepair()) {
+                    return true; // remove from selection
+                }
+                    return false; // keep in selection
+            });
         }
     }
 


### PR DESCRIPTION
## **Goal**

Damaged unit enter to repair mode


### Changes
- repair mode is restricted by no units selected before hit key
- group of selected units go to repair center and will be deselected

## Testing Steps
Select group of Units. Hit R and all damaged units go to repair center AND will be deselected


## Screenshots
https://github.com/user-attachments/assets/8022f7da-0ef4-4d4d-9571-2b2855b17a78
