### PR TITLE
Units can retreat to nearby base with key `f`

### DIFF
--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -482,7 +482,7 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
                 cUnit &pUnit = game.getUnit(id);
                 if (pUnit.isEligibleForRepair()) {
                     pUnit.findBestStructureCandidateAndHeadTowardsItOrWait(REPAIR, true, INTENT_REPAIR);
-                    pUnit.bSelected = false;
+                    pUnit.deselect();
                 }
             }
             std::erase_if(m_selectedUnits, [&](auto id) {
@@ -505,12 +505,12 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
             }
         }
     }
+
     if (event.hasKey(SDL_SCANCODE_F)) {
         for (auto id: m_selectedUnits) {
             cUnit &pUnit = game.getUnit(id);
             pUnit.retreatToNearbyBase();
-            pUnit.bSelected = false;
-            spawnParticle(D2TM_PARTICLE_MOVE);
+            pUnit.deselect();
         }
         m_selectedUnits.clear();
     }

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -475,7 +475,7 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
 
     // go to repair state
     if (event.hasKey(SDL_SCANCODE_R)) {
-        if (m_player->getSelectedUnits().empty()) {
+        if (m_selectedUnits.empty()) {
             m_context->setMouseState(MOUSESTATE_REPAIR);
         } else {
             for (auto id: m_selectedUnits) {

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -505,8 +505,15 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
             }
         }
     }
-
-    // force move?
+    if (event.hasKey(SDL_SCANCODE_F)) {
+        for (auto id: m_selectedUnits) {
+            cUnit &pUnit = game.getUnit(id);
+            pUnit.retreatToNearbyBase();
+            pUnit.bSelected = false;
+            spawnParticle(D2TM_PARTICLE_MOVE);
+        }
+        m_selectedUnits.clear();
+    }
 }
 
 void cMouseUnitsSelectedState::toPreviousState()

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -2618,7 +2618,7 @@ void cUnit::thinkFast_move()
                         else {
                             // start entering the structure at next cell
                             pStructure->startEnteringStructure(iID);
-                            bSelected = false; // deselect unit
+                            deselect();
                         }
 
                         // TODO: this should be done via events (EVENT_CAPTURED? and then make unit choose different structure)
@@ -3807,6 +3807,10 @@ void cUnit::retreatToNearbyBase()
     int cellToRetreatTo = findNewDropLocation(iType, pStructure->getCell());
 
     move_to(cellToRetreatTo); // intent retreat?
+}
+
+void cUnit::deselect() {
+    this->bSelected = false;
 }
 
 std::string cUnit::getHarvesterStatusForMessageBar()

--- a/src/gameobjects/units/cUnit.h
+++ b/src/gameobjects/units/cUnit.h
@@ -147,6 +147,7 @@ public:
     bool bHovered;      // mouse hovers over this unit or not?
 
     void retreatToNearbyBase();
+    void deselect();
 
     float fExpDamage();	// experience damage by bullet (extra damage that is)
 

--- a/src/player/cPlayer.cpp
+++ b/src/player/cPlayer.cpp
@@ -2294,7 +2294,7 @@ void cPlayer::thinkSlow()
 
 void cPlayer::deselectUnit(const int &unitId)
 {
-    game.getUnit(unitId).bSelected = false;
+    game.getUnit(unitId).deselect();
 }
 
 void cPlayer::onMyStructureDestroyed(const s_GameEvent &event)


### PR DESCRIPTION
## **Goal**

Unit enter to fallback mode

### Changes
- group of selected units retreat `ToNearbyBase` and will be deselected

## Testing Steps
Select group of Units. Hit F and all units move to current near building AND will be deselected
