### PR TITLE
Select same type of units on screen when pressing `CTRL-z`

### DIFF
--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -514,6 +514,13 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
         }
         m_selectedUnits.clear();
     }
+
+    if (event.hasKey(SDL_SCANCODE_B)) {
+        if (m_selectedUnits.size()==1) {
+            cUnit &pUnit = game.getUnit(m_selectedUnits[0]);
+            selectSameUnitsOnScreen(pUnit.iType);
+        }
+    }
 }
 
 void cMouseUnitsSelectedState::toPreviousState()
@@ -537,4 +544,17 @@ void cMouseUnitsSelectedState::onBlur()
 {
     m_mouse->resetBoxSelect();
     m_mouse->resetDragViewportInteraction();
+}
+
+void cMouseUnitsSelectedState::selectSameUnitsOnScreen(int iIDType)
+{
+    const std::vector<int> &ids = m_player->getAllMyUnitsWithinViewportRect(*game.m_mapViewport);
+    std::vector<int> sameUnits =std::vector<int>();
+    for (int i : ids) {
+        cUnit &pUnit = game.getUnit(i);
+        if (pUnit.iType == iIDType) {
+            sameUnits.push_back(i);
+        }
+    }
+    m_player->selectUnits(sameUnits);
 }

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -546,15 +546,16 @@ void cMouseUnitsSelectedState::onBlur()
     m_mouse->resetDragViewportInteraction();
 }
 
-void cMouseUnitsSelectedState::selectSameUnitsOnScreen(int iIDType)
+void cMouseUnitsSelectedState::selectSameUnitsOnScreen(int unitType)
 {
     const std::vector<int> &ids = m_player->getAllMyUnitsWithinViewportRect(*game.m_mapViewport);
     std::vector<int> sameUnits =std::vector<int>();
     for (int i : ids) {
         cUnit &pUnit = game.getUnit(i);
-        if (pUnit.iType == iIDType) {
+        if (pUnit.iType == unitType) {
             sameUnits.push_back(i);
         }
     }
     m_player->selectUnits(sameUnits);
+    m_selectedUnits = m_player->getSelectedUnits();
 }

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -459,6 +459,14 @@ void cMouseUnitsSelectedState::onKeyDown(const cKeyboardEvent &event)
         }
     }
     // force move?
+
+    bool controlPressed = event.hasKey(SDL_SCANCODE_LCTRL) || event.hasKey(SDL_SCANCODE_RCTRL);
+    if (controlPressed && event.hasKey(SDL_SCANCODE_Z)) {
+        if (m_selectedUnits.size() == 1) {
+            cUnit &pUnit = game.getUnit(m_selectedUnits[0]);
+            selectSameUnitsOnScreen(pUnit.iType);
+        }
+    }
 }
 
 void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
@@ -513,13 +521,6 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
             pUnit.deselect();
         }
         m_selectedUnits.clear();
-    }
-
-    if (event.hasKey(SDL_SCANCODE_B)) {
-        if (m_selectedUnits.size()==1) {
-            cUnit &pUnit = game.getUnit(m_selectedUnits[0]);
-            selectSameUnitsOnScreen(pUnit.iType);
-        }
     }
 }
 

--- a/src/controls/mousestates/cMouseUnitsSelectedState.h
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.h
@@ -46,6 +46,7 @@ public:
     void onFocus() override;
     void onBlur() override;
 
+    void selectSameUnitsOnScreen(int iType);
 private:
     // A list of unit id's that we have selected
     std::vector<int> m_selectedUnits;


### PR DESCRIPTION
## **Goal**

select same units type on screen

### Changes
- select from player unit in screen the same unit type.
- link to key `CTRL-z`

## Testing Steps
Select one unit, press `CTRL-z` and the game will select all player's unit in screen from the same type 

## Screenshots
https://github.com/user-attachments/assets/de794d27-f600-4501-9204-37d70b60d08e

