### PR TITLE
Improvement game object context (Refactoring 2/3)

### DIFF
--- a/src/building/cItemBuilder.cpp
+++ b/src/building/cItemBuilder.cpp
@@ -240,7 +240,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                 // airborn unit
                 int structureToDeployUnit = game.m_structureUtils.findHiTechToDeployAirUnit(m_player);
                 if (structureToDeployUnit > -1) {
-                    cAbstractStructure *pStructureToDeploy = game.m_pStructures[structureToDeployUnit];
+                    cAbstractStructure *pStructureToDeploy = game.m_gameObjectsContext->getStructures()[structureToDeployUnit];
                     pStructureToDeploy->setAnimating(true); // animate
                     int unitId = cUnits::unitCreate(pStructureToDeploy->getCell(), buildId, m_player->getId(), false);
                     if (unitId > -1) {
@@ -287,10 +287,10 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                     // Case: Fremen is deployed at random cell on the map
                     if (special.providesType == UNIT) {
                         // determine cell
-                        int iCll = game.m_map.getRandomCellWithinMapWithSafeDistanceFromBorder(4);
+                        int iCll = game.m_gameObjectsContext->getMap().getRandomCellWithinMapWithSafeDistanceFromBorder(4);
 
                         for (int j = 0; j < special.units; j++) {
-                            bool passable = game.m_map.isCellPassableForFootUnits(iCll);
+                            bool passable = game.m_gameObjectsContext->getMap().isCellPassableForFootUnits(iCll);
 
                             if (passable) {
                                 cUnits::unitCreate(iCll, special.providesTypeId, FREMEN, false);
@@ -299,8 +299,8 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                                 REINFORCE(FREMEN, special.providesTypeId, iCll, -1);
                             }
 
-                            int x = game.m_map.getCellX(iCll);
-                            int y = game.m_map.getCellY(iCll);
+                            int x = game.m_gameObjectsContext->getMap().getCellX(iCll);
+                            int y = game.m_gameObjectsContext->getMap().getCellY(iCll);
                             int amount = RNG::rnd(2) + 1;
 
                             // randomly shift the cell one coordinate up/down/left/right
@@ -319,9 +319,9 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                                     break;
                             }
                             // change cell
-                            cPoint::split(x, y) = game.m_map.fixCoordinatesToBeWithinMap(x, y);
+                            cPoint::split(x, y) = game.m_gameObjectsContext->getMap().fixCoordinatesToBeWithinMap(x, y);
 
-                            iCll = game.m_map.getGeometry().makeCell(x, y);
+                            iCll = game.m_gameObjectsContext->getMap().getGeometry().makeCell(x, y);
                         }
                     }
                     item->stopBuilding();
@@ -407,7 +407,7 @@ void cItemBuilder::deployUnit(cBuildingListItem *item, int buildId) const
     int structureToDeployUnit = game.m_structureUtils.findStructureToDeployUnit(m_player, structureTypeByItem);
     int buildIdToProduce = buildId;
     if (structureToDeployUnit > -1) {
-        cAbstractStructure *pStructureToDeploy = game.m_pStructures[structureToDeployUnit];
+        cAbstractStructure *pStructureToDeploy = game.m_gameObjectsContext->getStructures()[structureToDeployUnit];
         // TODO: Remove duplication, which also exists in AI::think_buildingplacement()
         int cell = pStructureToDeploy->getNonOccupiedCellAroundStructure();
         if (cell > -1) {
@@ -429,7 +429,7 @@ void cItemBuilder::deployUnit(cBuildingListItem *item, int buildId) const
         if (structureToDeployUnit < 0) {
             // find any structure of type (regardless if we can deploy or not)
             for (int structureId = 0; structureId < MAX_STRUCTURES; structureId++) {
-                cAbstractStructure *pStructure = game.m_pStructures[structureId];
+                cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[structureId];
                 if (pStructure &&
                         pStructure->isValid() &&
                         pStructure->belongsTo(m_player->getId()) &&
@@ -440,9 +440,9 @@ void cItemBuilder::deployUnit(cBuildingListItem *item, int buildId) const
             }
         }
 
-        cAbstractStructure *pStructureToDeploy = game.m_pStructures[structureToDeployUnit];
+        cAbstractStructure *pStructureToDeploy = game.m_gameObjectsContext->getStructures()[structureToDeployUnit];
         if (pStructureToDeploy && pStructureToDeploy->isValid()) {
-            int cellToDeploy = game.m_pStructures[structureToDeployUnit]->getCell();
+            int cellToDeploy = game.m_gameObjectsContext->getStructures()[structureToDeployUnit]->getCell();
             if (pStructureToDeploy->getRallyPoint() > -1) {
                 cellToDeploy = pStructureToDeploy->getRallyPoint();
             }

--- a/src/context/cGameObjectContext.cpp
+++ b/src/context/cGameObjectContext.cpp
@@ -1,0 +1,78 @@
+#include "cGameObjectContext.h"
+
+#include "gameobjects/particles/cParticles.h"
+#include "gameobjects/projectiles/cBullets.h"
+#include "gameobjects/structures/cStructures.h"
+#include "gameobjects/units/cUnits.h"
+#include "player/cPlayers.h"
+#include "map/cMap.h"
+
+#include <stdexcept>
+
+cGameObjectContext::~cGameObjectContext() = default;
+
+void cGameObjectContext::setBullets(std::unique_ptr<cBullets> bullets) {
+    m_Bullets = std::move(bullets);
+}
+
+cBullets& cGameObjectContext::getBullets() const {
+    if (!m_Bullets) {
+        throw std::runtime_error("cBullets not initialized in cGameObjectContext");
+    }
+    return *m_Bullets;
+}
+
+void cGameObjectContext::setPlayers(std::unique_ptr<cPlayers> players) {
+    m_Players = std::move(players);
+}
+
+cPlayers& cGameObjectContext::getPlayers() const {
+    if (!m_Players) {
+        throw std::runtime_error("cPlayers not initialized in cGameObjectContext");
+    }
+    return *m_Players;
+}
+
+void cGameObjectContext::setParticles(std::unique_ptr<cParticles> particles) {
+    m_particles = std::move(particles);
+}
+
+cParticles& cGameObjectContext::getParticles() const {
+    if (!m_particles) {
+        throw std::runtime_error("cParticles not initialized in cGameObjectContext");
+    }
+    return *m_particles;
+}
+
+void cGameObjectContext::setStructures(std::unique_ptr<cStructures> structures) {
+    m_pStructures = std::move(structures);
+}
+
+cStructures& cGameObjectContext::getStructures() const {
+    if (!m_pStructures) {
+        throw std::runtime_error("cStructures not initialized in cGameObjectContext");
+    }
+    return *m_pStructures;
+}
+
+void cGameObjectContext::setUnits(std::unique_ptr<cUnits> units) {
+    m_Units = std::move(units);
+}
+
+cUnits& cGameObjectContext::getUnits() const {
+    if (!m_Units) {
+        throw std::runtime_error("cUnits not initialized in cGameObjectContext");
+    }
+    return *m_Units;
+}
+
+void cGameObjectContext::setMap(std::unique_ptr<cMap> map) {
+    m_map = std::move(map);
+}
+
+cMap& cGameObjectContext::getMap() const {
+    if (!m_map) {
+        throw std::runtime_error("cMap not initialized in cGameObjectContext");
+    }
+    return *m_map;
+}

--- a/src/context/cGameObjectContext.cpp
+++ b/src/context/cGameObjectContext.cpp
@@ -9,21 +9,28 @@
 
 #include <stdexcept>
 
-cGameObjectContext::~cGameObjectContext() = default;
-
-void cGameObjectContext::setBullets(std::unique_ptr<cBullets> bullets) {
-    m_Bullets = std::move(bullets);
+cGameObjectContext::cGameObjectContext(
+    std::unique_ptr<cBullets> bullets,
+    std::unique_ptr<cPlayers> players,
+    std::unique_ptr<cParticles> particles,
+    std::unique_ptr<cStructures> structures,
+    std::unique_ptr<cUnits> units,
+    std::unique_ptr<cMap> map)
+    : m_Bullets(std::move(bullets))
+    , m_Players(std::move(players))
+    , m_particles(std::move(particles))
+    , m_pStructures(std::move(structures))
+    , m_Units(std::move(units))
+    , m_map(std::move(map)) {
 }
+
+cGameObjectContext::~cGameObjectContext() = default;
 
 cBullets& cGameObjectContext::getBullets() const {
     if (!m_Bullets) {
         throw std::runtime_error("cBullets not initialized in cGameObjectContext");
     }
     return *m_Bullets;
-}
-
-void cGameObjectContext::setPlayers(std::unique_ptr<cPlayers> players) {
-    m_Players = std::move(players);
 }
 
 cPlayers& cGameObjectContext::getPlayers() const {
@@ -33,19 +40,11 @@ cPlayers& cGameObjectContext::getPlayers() const {
     return *m_Players;
 }
 
-void cGameObjectContext::setParticles(std::unique_ptr<cParticles> particles) {
-    m_particles = std::move(particles);
-}
-
 cParticles& cGameObjectContext::getParticles() const {
     if (!m_particles) {
         throw std::runtime_error("cParticles not initialized in cGameObjectContext");
     }
     return *m_particles;
-}
-
-void cGameObjectContext::setStructures(std::unique_ptr<cStructures> structures) {
-    m_pStructures = std::move(structures);
 }
 
 cStructures& cGameObjectContext::getStructures() const {
@@ -55,19 +54,11 @@ cStructures& cGameObjectContext::getStructures() const {
     return *m_pStructures;
 }
 
-void cGameObjectContext::setUnits(std::unique_ptr<cUnits> units) {
-    m_Units = std::move(units);
-}
-
 cUnits& cGameObjectContext::getUnits() const {
     if (!m_Units) {
         throw std::runtime_error("cUnits not initialized in cGameObjectContext");
     }
     return *m_Units;
-}
-
-void cGameObjectContext::setMap(std::unique_ptr<cMap> map) {
-    m_map = std::move(map);
 }
 
 cMap& cGameObjectContext::getMap() const {

--- a/src/context/cGameObjectContext.h
+++ b/src/context/cGameObjectContext.h
@@ -12,25 +12,20 @@ class cMap;
 
 class cGameObjectContext {
 public:
-    cGameObjectContext() = default;
+    cGameObjectContext(
+        std::unique_ptr<cBullets> bullets,
+        std::unique_ptr<cPlayers> players,
+        std::unique_ptr<cParticles> particles,
+        std::unique_ptr<cStructures> structures,
+        std::unique_ptr<cUnits> units,
+        std::unique_ptr<cMap> map);
     ~cGameObjectContext();
 
-    void setBullets(std::unique_ptr<cBullets> bullets);
     cBullets& getBullets() const;
-
-    void setPlayers(std::unique_ptr<cPlayers> players);
     cPlayers& getPlayers() const;
-
-    void setParticles(std::unique_ptr<cParticles> particles);
     cParticles& getParticles() const;
-
-    void setStructures(std::unique_ptr<cStructures> structures);
     cStructures& getStructures() const;
-
-    void setUnits(std::unique_ptr<cUnits> units);
     cUnits& getUnits() const;
-
-    void setMap(std::unique_ptr<cMap> map);
     cMap& getMap() const;
 
 private:

--- a/src/context/cGameObjectContext.h
+++ b/src/context/cGameObjectContext.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <stdexcept>
+#include <memory>
+
+class cBullets;
+class cPlayers;
+class cParticles;
+class cStructures;
+class cUnits;
+class cMap;
+
+class cGameObjectContext {
+public:
+    cGameObjectContext() = default;
+    ~cGameObjectContext();
+
+    void setBullets(std::unique_ptr<cBullets> bullets);
+    cBullets& getBullets() const;
+
+    void setPlayers(std::unique_ptr<cPlayers> players);
+    cPlayers& getPlayers() const;
+
+    void setParticles(std::unique_ptr<cParticles> particles);
+    cParticles& getParticles() const;
+
+    void setStructures(std::unique_ptr<cStructures> structures);
+    cStructures& getStructures() const;
+
+    void setUnits(std::unique_ptr<cUnits> units);
+    cUnits& getUnits() const;
+
+    void setMap(std::unique_ptr<cMap> map);
+    cMap& getMap() const;
+
+private:
+    std::unique_ptr<cBullets> m_Bullets;
+    std::unique_ptr<cPlayers> m_Players;
+    std::unique_ptr<cParticles> m_particles;
+    std::unique_ptr<cStructures> m_pStructures;
+    std::unique_ptr<cUnits> m_Units;
+    std::unique_ptr<cMap> m_map;
+};

--- a/src/context/cGameObjectContextCreator.cpp
+++ b/src/context/cGameObjectContextCreator.cpp
@@ -32,7 +32,7 @@ std::unique_ptr<cMap> cGameObjectsContextCreator::createMap() {
     return std::make_unique<cMap>();
 }
 
-void cGameObjectsContextCreator::installGameObjects(cGameObjectContext& gameObjectContext) {
+void cGameObjectsContextCreator::installGameObjects(cGameObjectContext& gameObjectContext){
     gameObjectContext.setBullets(createBullets());
     gameObjectContext.setPlayers(createPlayers());
     gameObjectContext.setParticles(createParticles());

--- a/src/context/cGameObjectContextCreator.cpp
+++ b/src/context/cGameObjectContextCreator.cpp
@@ -1,0 +1,42 @@
+#include "cGameObjectContextCreator.h"
+#include "cGameObjectContext.h"
+
+#include "gameobjects/particles/cParticles.h"
+#include "gameobjects/projectiles/cBullets.h"
+#include "gameobjects/structures/cStructures.h"
+#include "gameobjects/units/cUnits.h"
+#include "player/cPlayers.h"
+#include "map/cMap.h"
+
+std::unique_ptr<cBullets> cGameObjectsContextCreator::createBullets() {
+    return std::make_unique<cBullets>();
+}
+
+std::unique_ptr<cPlayers> cGameObjectsContextCreator::createPlayers() {
+    return std::make_unique<cPlayers>();
+}
+
+std::unique_ptr<cParticles> cGameObjectsContextCreator::createParticles() {
+    return std::make_unique<cParticles>();
+}
+
+std::unique_ptr<cStructures> cGameObjectsContextCreator::createStructures() {
+    return std::make_unique<cStructures>();
+}
+
+std::unique_ptr<cUnits> cGameObjectsContextCreator::createUnits() {
+    return std::make_unique<cUnits>();
+}
+
+std::unique_ptr<cMap> cGameObjectsContextCreator::createMap() {
+    return std::make_unique<cMap>();
+}
+
+void cGameObjectsContextCreator::installGameObjects(cGameObjectContext& gameObjectContext) {
+    gameObjectContext.setBullets(createBullets());
+    gameObjectContext.setPlayers(createPlayers());
+    gameObjectContext.setParticles(createParticles());
+    gameObjectContext.setStructures(createStructures());
+    gameObjectContext.setUnits(createUnits());
+    gameObjectContext.setMap(createMap());
+}

--- a/src/context/cGameObjectContextCreator.cpp
+++ b/src/context/cGameObjectContextCreator.cpp
@@ -8,35 +8,12 @@
 #include "player/cPlayers.h"
 #include "map/cMap.h"
 
-std::unique_ptr<cBullets> cGameObjectsContextCreator::createBullets() {
-    return std::make_unique<cBullets>();
-}
-
-std::unique_ptr<cPlayers> cGameObjectsContextCreator::createPlayers() {
-    return std::make_unique<cPlayers>();
-}
-
-std::unique_ptr<cParticles> cGameObjectsContextCreator::createParticles() {
-    return std::make_unique<cParticles>();
-}
-
-std::unique_ptr<cStructures> cGameObjectsContextCreator::createStructures() {
-    return std::make_unique<cStructures>();
-}
-
-std::unique_ptr<cUnits> cGameObjectsContextCreator::createUnits() {
-    return std::make_unique<cUnits>();
-}
-
-std::unique_ptr<cMap> cGameObjectsContextCreator::createMap() {
-    return std::make_unique<cMap>();
-}
-
-void cGameObjectsContextCreator::installGameObjects(cGameObjectContext& gameObjectContext){
-    gameObjectContext.setBullets(createBullets());
-    gameObjectContext.setPlayers(createPlayers());
-    gameObjectContext.setParticles(createParticles());
-    gameObjectContext.setStructures(createStructures());
-    gameObjectContext.setUnits(createUnits());
-    gameObjectContext.setMap(createMap());
+std::unique_ptr<cGameObjectContext> cGameObjectsContextCreator::create() {
+    return std::make_unique<cGameObjectContext>(
+        std::make_unique<cBullets>(),
+        std::make_unique<cPlayers>(),
+        std::make_unique<cParticles>(),
+        std::make_unique<cStructures>(),
+        std::make_unique<cUnits>(),
+        std::make_unique<cMap>());
 }

--- a/src/context/cGameObjectContextCreator.h
+++ b/src/context/cGameObjectContextCreator.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+
+class cGameObjectContext;
+class cBullets;
+class cPlayers;
+class cParticles;
+class cStructures;
+class cUnits;
+class cMap;
+
+class cGameObjectsContextCreator {
+public:
+    cGameObjectsContextCreator() = default;
+    ~cGameObjectsContextCreator() = default;
+
+    std::unique_ptr<cBullets> createBullets();
+    std::unique_ptr<cPlayers> createPlayers();
+    std::unique_ptr<cParticles> createParticles();
+    std::unique_ptr<cStructures> createStructures();
+    std::unique_ptr<cUnits> createUnits();
+    std::unique_ptr<cMap> createMap();
+
+    void installGameObjects(cGameObjectContext& gameObjectContext);
+
+private:
+
+};

--- a/src/context/cGameObjectContextCreator.h
+++ b/src/context/cGameObjectContextCreator.h
@@ -3,27 +3,11 @@
 #include <memory>
 
 class cGameObjectContext;
-class cBullets;
-class cPlayers;
-class cParticles;
-class cStructures;
-class cUnits;
-class cMap;
 
 class cGameObjectsContextCreator {
 public:
     cGameObjectsContextCreator() = default;
     ~cGameObjectsContextCreator() = default;
 
-    std::unique_ptr<cBullets> createBullets();
-    std::unique_ptr<cPlayers> createPlayers();
-    std::unique_ptr<cParticles> createParticles();
-    std::unique_ptr<cStructures> createStructures();
-    std::unique_ptr<cUnits> createUnits();
-    std::unique_ptr<cMap> createMap();
-
-    void installGameObjects(cGameObjectContext& gameObjectContext);
-
-private:
-
+    static std::unique_ptr<cGameObjectContext> create();
 };

--- a/src/controls/cGameControlsContext.cpp
+++ b/src/controls/cGameControlsContext.cpp
@@ -77,34 +77,34 @@ void cGameControlsContext::determineHoveringOverStructureId()
 {
     m_mouseHoveringOverStructureId = -1;
 
-    if (!game.m_map.isVisible(m_mouseCell, this->m_player)) {
+    if (!game.m_gameObjectsContext->getMap().isVisible(m_mouseCell, this->m_player)) {
         return; // cell not visible
     }
 
-    m_mouseHoveringOverStructureId = game.m_map.getCellIdStructuresLayer(m_mouseCell);
+    m_mouseHoveringOverStructureId = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(m_mouseCell);
 }
 
 void cGameControlsContext::determineHoveringOverUnitId()
 {
     if (m_mouseHoveringOverUnitId > -1) {
-        cUnit &aUnit = game.getUnit(m_mouseHoveringOverUnitId);
+        cUnit &aUnit = game.m_gameObjectsContext->getUnits()[m_mouseHoveringOverUnitId];
         if (aUnit.isValid()) {
             aUnit.rendering.bHovered = false;
         }
     }
     m_mouseHoveringOverUnitId = -1;
     int mc = getMouseCell();
-    tCell *cellOfMouse = game.m_map.getCell(mc);
+    tCell *cellOfMouse = game.m_gameObjectsContext->getMap().getCell(mc);
     if (cellOfMouse == nullptr) return; // mouse is not on battlefield
 
-    if (!game.m_map.isVisible(mc, this->m_player)) {
+    if (!game.m_gameObjectsContext->getMap().isVisible(mc, this->m_player)) {
         return; // cell not visible
     }
 
     if (cellOfMouse->id[MAPID_UNITS] > -1) {
         int iUnitId = cellOfMouse->id[MAPID_UNITS];
 
-        if (!game.getUnit(iUnitId).isHidden()) {
+        if (!game.m_gameObjectsContext->getUnits()[iUnitId].isHidden()) {
             m_mouseHoveringOverUnitId = iUnitId;
         }
 
@@ -115,7 +115,7 @@ void cGameControlsContext::determineHoveringOverUnitId()
     }
 
     if (m_mouseHoveringOverUnitId > -1) {
-        cUnit &aUnit = game.getUnit(m_mouseHoveringOverUnitId);
+        cUnit &aUnit = game.m_gameObjectsContext->getUnits()[m_mouseHoveringOverUnitId];
         if (aUnit.isValid()) {
             aUnit.rendering.bHovered = true;
         }
@@ -127,7 +127,7 @@ cAbstractStructure *cGameControlsContext::getStructurePointerWhereMouseHovers() 
     if (m_mouseHoveringOverStructureId < 0) {
         return nullptr;
     }
-    return game.m_pStructures[m_mouseHoveringOverStructureId];
+    return game.m_gameObjectsContext->getStructures()[m_mouseHoveringOverStructureId];
 }
 
 void cGameControlsContext::onMouseMovedTo(const s_MouseEvent &event)

--- a/src/controls/mousestates/cMousePlaceState.cpp
+++ b/src/controls/mousestates/cMousePlaceState.cpp
@@ -86,8 +86,8 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
 
 #define SCANWIDTH    1
 
-    int iCellX = game.m_map.getCellX(mouseCell);
-    int iCellY = game.m_map.getCellY(mouseCell);
+    int iCellX = game.m_gameObjectsContext->getMap().getCellX(mouseCell);
+    int iCellY = game.m_gameObjectsContext->getMap().getCellY(mouseCell);
 
     // check
     int iStartX = iCellX - SCANWIDTH;
@@ -97,20 +97,20 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
     int iEndY = iCellY + SCANWIDTH + cellHeight;
 
     // Fix up the boundaries
-    cPoint::split(iStartX, iStartY) = game.m_map.fixCoordinatesToBeWithinMap(iStartX, iStartY);
-    cPoint::split(iEndX, iEndY) = game.m_map.fixCoordinatesToBeWithinMap(iEndX, iEndY);
+    cPoint::split(iStartX, iStartY) = game.m_gameObjectsContext->getMap().fixCoordinatesToBeWithinMap(iStartX, iStartY);
+    cPoint::split(iEndX, iEndY) = game.m_gameObjectsContext->getMap().fixCoordinatesToBeWithinMap(iEndX, iEndY);
 
     // Determine if structure to be placed is within build distance
     for (int iX = iStartX; iX < iEndX; iX++) {
         for (int iY = iStartY; iY < iEndY; iY++) {
-            int iCll = game.m_map.getGeometry().getCellWithMapDimensions(iX, iY);
+            int iCll = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapDimensions(iX, iY);
 
             if (iCll > -1) {
-                int idOfStructureAtCell = game.m_map.getCellIdStructuresLayer(iCll);
+                int idOfStructureAtCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(iCll);
                 if (idOfStructureAtCell > -1) {
                     int iID = idOfStructureAtCell;
 
-                    if (game.m_pStructures[iID]->getOwner() == HUMAN) {
+                    if (game.m_gameObjectsContext->getStructures()[iID]->getOwner() == HUMAN) {
                         bWithinBuildDistance = true; // connection!
                         break;
                     }
@@ -118,8 +118,8 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
                     // TODO: Allow placement nearby allies?
                 }
 
-                if (game.m_map.getCellType(iCll) == TERRAIN_WALL ||
-                        game.m_map.getCellType(iCll) == TERRAIN_SLAB) {
+                if (game.m_gameObjectsContext->getMap().getCellType(iCll) == TERRAIN_WALL ||
+                        game.m_gameObjectsContext->getMap().getCellType(iCll) == TERRAIN_SLAB) {
                     bWithinBuildDistance = true;
                     // TODO: here we should actually find out if the slab is ours or not??
                     break;
@@ -140,14 +140,14 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
             int cellX = iCellX + iX;
             int cellY = iCellY + iY;
 
-            if (!game.m_map.isWithinBoundaries(cellX, cellY)) {
+            if (!game.m_gameObjectsContext->getMap().isWithinBoundaries(cellX, cellY)) {
                 return false;
             }
 
-            int iCll = game.m_map.getGeometry().makeCell(cellX, cellY);
+            int iCll = game.m_gameObjectsContext->getMap().getGeometry().makeCell(cellX, cellY);
 
             // occupied by units or structures
-            int idOfStructureAtCell = game.m_map.getCellIdStructuresLayer(iCll);
+            int idOfStructureAtCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(iCll);
             if (idOfStructureAtCell > -1) {
                 // may not place when we're not placing a slab.. hack hack
                 if (structureIdToPlace != SLAB4) {
@@ -157,10 +157,10 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
 
             // non slab 'structures' can be blocked by units
             if (structureIdToPlace != SLAB4 && structureIdToPlace != SLAB1) {
-                int unitIdOnMap = game.m_map.getCellIdUnitLayer(iCll);
+                int unitIdOnMap = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(iCll);
                 if (unitIdOnMap > -1) {
                     // temporarily dead units do not block, but alive units (non-dead) do block placement
-                    if (!game.getUnit(unitIdOnMap).isDead()) {
+                    if (!game.m_gameObjectsContext->getUnits()[unitIdOnMap].isDead()) {
                         return false;
                     }
                     // TODO: Allow placement, let units move aside when clicking before placement?

--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -297,7 +297,7 @@ void cMiniMapDrawer::drawUnitsAndStructures(bool playerOnly) const {
 
             int idOfStructureAtCell = m_map->getCellIdStructuresLayer(iCll);
             if (idOfStructureAtCell > -1) {
-                int iPlr = game.m_pStructures[idOfStructureAtCell]->getOwner();
+                int iPlr = game.m_gameObjectsContext->getStructures()[idOfStructureAtCell]->getOwner();
                 if (playerOnly) {
                     if (iPlr != m_player->getId()) continue; // skip non player units
                 }

--- a/src/drawers/cParticleDrawer.cpp
+++ b/src/drawers/cParticleDrawer.cpp
@@ -9,7 +9,7 @@ void cParticleDrawer::determineParticlesToDraw(const cRectangle &viewport)
 {
     m_particlesLowerLayer.clear();
     m_particlesTopLayer.clear();
-    for (auto &pParticle : game.m_particles) {
+    for (auto &pParticle : game.m_gameObjectsContext->getParticles()) {
         if (!pParticle.isValid()) continue;
         if (!pParticle.isWithinViewport(viewport)) continue;
 

--- a/src/drawers/cPlaceItDrawer.cpp
+++ b/src/drawers/cPlaceItDrawer.cpp
@@ -54,8 +54,8 @@ void cPlaceItDrawer::drawStatusOfStructureAtCell(cBuildingListItem *itemToPlace,
 
 #define SCANWIDTH	1
 
-    int iCellX = game.m_map.getCellX(mouseCell);
-    int iCellY = game.m_map.getCellY(mouseCell);
+    int iCellX = game.m_gameObjectsContext->getMap().getCellX(mouseCell);
+    int iCellY = game.m_gameObjectsContext->getMap().getCellY(mouseCell);
 
     // check
     int iStartX = iCellX-SCANWIDTH;
@@ -65,20 +65,20 @@ void cPlaceItDrawer::drawStatusOfStructureAtCell(cBuildingListItem *itemToPlace,
     int iEndY = iCellY + SCANWIDTH + cellHeight;
 
     // Fix up the boundaries
-    cPoint::split(iStartX, iStartY) = game.m_map.fixCoordinatesToBeWithinMap(iStartX, iStartY);
-    cPoint::split(iEndX, iEndY) = game.m_map.fixCoordinatesToBeWithinMap(iEndX, iEndY);
+    cPoint::split(iStartX, iStartY) = game.m_gameObjectsContext->getMap().fixCoordinatesToBeWithinMap(iStartX, iStartY);
+    cPoint::split(iEndX, iEndY) = game.m_gameObjectsContext->getMap().fixCoordinatesToBeWithinMap(iEndX, iEndY);
 
     // Determine if structure to be placed is within build distance
     for (int iX=iStartX; iX < iEndX; iX++) {
         for (int iY=iStartY; iY < iEndY; iY++) {
-            int iCll = game.m_map.getGeometry().getCellWithMapDimensions(iX, iY);
+            int iCll = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapDimensions(iX, iY);
 
             if (iCll > -1) {
-                int idOfStructureAtCell = game.m_map.getCellIdStructuresLayer(iCll);
+                int idOfStructureAtCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(iCll);
                 if (idOfStructureAtCell > -1) {
                     int iID = idOfStructureAtCell;
 
-                    if (game.m_pStructures[iID]->getOwner() == HUMAN) {
+                    if (game.m_gameObjectsContext->getStructures()[iID]->getOwner() == HUMAN) {
                         bWithinBuildDistance = true; // connection!
                         break;
                     }
@@ -86,8 +86,8 @@ void cPlaceItDrawer::drawStatusOfStructureAtCell(cBuildingListItem *itemToPlace,
                     // TODO: Allow placement nearby allies?
                 }
 
-                if (game.m_map.getCellType(iCll) == TERRAIN_WALL ||
-                        game.m_map.getCellType(iCll) == TERRAIN_SLAB) {
+                if (game.m_gameObjectsContext->getMap().getCellType(iCll) == TERRAIN_WALL ||
+                        game.m_gameObjectsContext->getMap().getCellType(iCll) == TERRAIN_SLAB) {
                     bWithinBuildDistance=true;
                     // TODO: here we should actually find out if the slab is ours or not??
                     break;
@@ -96,8 +96,8 @@ void cPlaceItDrawer::drawStatusOfStructureAtCell(cBuildingListItem *itemToPlace,
         }
     }
 
-    int iDrawX = game.m_map.mouse_draw_x();
-    int iDrawY = game.m_map.mouse_draw_y();
+    int iDrawX = game.m_gameObjectsContext->getMap().mouse_draw_x();
+    int iDrawY = game.m_gameObjectsContext->getMap().mouse_draw_y();
 
     if (!bWithinBuildDistance) {
         itemToPlaceColor = game.getColorPlaceBad();
@@ -111,27 +111,27 @@ void cPlaceItDrawer::drawStatusOfStructureAtCell(cBuildingListItem *itemToPlace,
                 int cellX = iCellX + iX;
                 int cellY = iCellY + iY;
 
-                if (!game.m_map.isWithinBoundaries(cellX, cellY)) {
+                if (!game.m_gameObjectsContext->getMap().isWithinBoundaries(cellX, cellY)) {
                     continue;
                 }
 
-                int iCll = game.m_map.getGeometry().makeCell(cellX, cellY);
+                int iCll = game.m_gameObjectsContext->getMap().getGeometry().makeCell(cellX, cellY);
 
-                if (!game.m_map.isCellPassable(iCll) || game.m_map.getCellType(iCll) != TERRAIN_ROCK) {
+                if (!game.m_gameObjectsContext->getMap().isCellPassable(iCll) || game.m_gameObjectsContext->getMap().getCellType(iCll) != TERRAIN_ROCK) {
                     itemToPlaceColor = game.getColorPlaceBad();
                 }
 
-                if (game.m_map.getCellType(iCll) == TERRAIN_SLAB) {
+                if (game.m_gameObjectsContext->getMap().getCellType(iCll) == TERRAIN_SLAB) {
                     itemToPlaceColor = game.getColorPlaceGood();
                 }
 
                 // occupied by units or structures
-                int idOfStructureAtCell = game.m_map.getCellIdStructuresLayer(iCll);
+                int idOfStructureAtCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(iCll);
                 if (idOfStructureAtCell > -1) {
                     itemToPlaceColor = game.getColorPlaceBad();
                 }
 
-                int unitIdOnMap = game.m_map.getCellIdUnitLayer(iCll);
+                int unitIdOnMap = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(iCll);
                 if (unitIdOnMap > -1) {
                     // temporarily dead units do not block, but alive units (non-dead) do block placement
                     if (!game.getUnit(unitIdOnMap).isDead()) {
@@ -158,8 +158,8 @@ void cPlaceItDrawer::drawStructureIdAtMousePos(cBuildingListItem *itemToPlace)
 
     int structureId = itemToPlace->getBuildId();
 
-    int iDrawX = game.m_map.mouse_draw_x();
-    int iDrawY = game.m_map.mouse_draw_y();
+    int iDrawX = game.m_gameObjectsContext->getMap().mouse_draw_x();
+    int iDrawY = game.m_gameObjectsContext->getMap().mouse_draw_y();
 
     int width = game.m_infoContext->getStructureInfo(structureId).bmp_width;
     int height = game.m_infoContext->getStructureInfo(structureId).bmp_height;

--- a/src/drawers/cStructureDrawer.cpp
+++ b/src/drawers/cStructureDrawer.cpp
@@ -166,11 +166,11 @@ void cStructureDrawer::drawStructureAnimationTurret(cAbstractStructure *structur
 
             m_renderDrawer->renderLine( x1, y1, x2, y2, Color{255, 255, 255,255});
 
-            int mouseCellX = game.m_map.getCellX(pContext->getMouseCell());
-            int mouseCellY = game.m_map.getCellY(pContext->getMouseCell());
+            int mouseCellX = game.m_gameObjectsContext->getMap().getCellX(pContext->getMouseCell());
+            int mouseCellY = game.m_gameObjectsContext->getMap().getCellY(pContext->getMouseCell());
 
-            int cellX = game.m_map.getCellX(structure->getCell());
-            int cellY = game.m_map.getCellY(structure->getCell());
+            int cellX = game.m_gameObjectsContext->getMap().getCellX(structure->getCell());
+            int cellY = game.m_gameObjectsContext->getMap().getCellY(structure->getCell());
 
             float degrees = fDegrees(cellX, cellY, mouseCellX, mouseCellY);
 
@@ -321,7 +321,7 @@ void cStructureDrawer::renderIconOfUnitBeingRepaired(cAbstractStructure *structu
 void cStructureDrawer::drawStructuresForLayer(int layer)
 {
     for (int i=0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_pStructures[i];
+        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
 
         if (!theStructure) continue;
 
@@ -350,7 +350,7 @@ void cStructureDrawer::drawStructureHealthBar(int iStructure)
 {
     if (iStructure < 0 || iStructure >= MAX_STRUCTURES) return;
 
-    cAbstractStructure *theStructure = game.m_pStructures[iStructure];
+    cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[iStructure];
 
     if (!theStructure) {
         return;

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -29,6 +29,7 @@
 #include "utils/cStructureUtils.h"
 
 #include "context/cInfoContext.h"
+#include "context/cGameObjectContext.h"
 
 #include <memory>
 #include <string>
@@ -121,7 +122,9 @@ public:
     cStructureUtils             m_structureUtils;
     // end
 
-    // TODO: this should be moved on a GameObjectContext class same method as std::unique_ptr<cInfoContext> m_infoContext;
+    // Game object context manages all game entities
+    std::unique_ptr<cGameObjectContext> m_gameObjectsContext;
+        // TODO: this should be moved on a GameObjectContext class same method as std::unique_ptr<cInfoContext> m_infoContext;
     cBullets                    m_Bullets;    
     cPlayers                    m_Players;
     cParticles                  m_particles;
@@ -131,6 +134,9 @@ public:
     
     //todo: this should get moved to private, but not yet.
     std::unique_ptr<cInfoContext> m_infoContext;
+
+    // Initialize game objects - must be called once after cGameObjectContext is created
+    void setupGameObjects();
 
     // Initialization functions
     void init();		            // initialize all game variables

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -128,9 +128,6 @@ public:
     //todo: this should get moved to private, but not yet.
     std::unique_ptr<cInfoContext> m_infoContext;
 
-    // Initialize game objects - must be called once after cGameObjectContext is created
-    void setupGameObjects();
-
     // Initialization functions
     void init();		            // initialize all game variables
     void missionInit();             // initialize variables for mission loading only

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -122,15 +122,8 @@ public:
     cStructureUtils             m_structureUtils;
     // end
 
-    // Game object context manages all game entities
+    //todo: this should get moved to private, but not yet.
     std::unique_ptr<cGameObjectContext> m_gameObjectsContext;
-        // TODO: this should be moved on a GameObjectContext class same method as std::unique_ptr<cInfoContext> m_infoContext;
-    cBullets                    m_Bullets;    
-    cPlayers                    m_Players;
-    cParticles                  m_particles;
-    cStructures                 m_pStructures;
-    cUnits                      m_Units;
-    cMap                        m_map;
     
     //todo: this should get moved to private, but not yet.
     std::unique_ptr<cInfoContext> m_infoContext;

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -122,7 +122,7 @@ public:
     // end
 
     // TODO: this should be moved on a GameObjectContext class same method as std::unique_ptr<cInfoContext> m_infoContext;
-    cBullets                    g_Bullets;    
+    cBullets                    m_Bullets;    
     cPlayers                    m_Players;
     cParticles                  m_particles;
     cStructures                 m_pStructures;

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -116,15 +116,20 @@ public:
 
     // TODO: move these to a another class that we can pass around, instead of having them as global variables.
     // begin
-    cBullets                    g_Bullets;
     cMapCamera					*m_mapCamera;
     cDrawManager                *m_drawManager;
     cStructureUtils             m_structureUtils;
+    // end
+
+    // TODO: this should be moved on a GameObjectContext class same method as std::unique_ptr<cInfoContext> m_infoContext;
+    cBullets                    g_Bullets;    
     cPlayers                    m_Players;
     cParticles                  m_particles;
     cStructures                 m_pStructures;
     cUnits                      m_Units;
     cMap                        m_map;
+    
+    //todo: this should get moved to private, but not yet.
     std::unique_ptr<cInfoContext> m_infoContext;
 
     // Initialization functions

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -130,7 +130,8 @@ cGame::cGame()
     m_gameObjectsContext = std::make_unique<cGameObjectContext>();
 
     // Initialize game objects in the context
-    setupGameObjects();
+    cGameObjectsContextCreator creator;
+    creator.installGameObjects(*m_gameObjectsContext);
 
     m_screenShake = std::make_unique<cScreenShake>();
 
@@ -1763,9 +1764,4 @@ void cGame::loadMapFromEditor(s_PreviewMap *map)
     setState(GAME_EDITOR);
     auto *pState = dynamic_cast<cEditorState*>(m_states[GAME_EDITOR]);
     pState->loadMap(map);
-}
-
-void cGame::setupGameObjects(){
-    cGameObjectsContextCreator creator;
-    creator.installGameObjects(*m_gameObjectsContext);
 }

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -111,6 +111,9 @@ cGame::cGame()
     ctx = nullptr;
     m_pauseWhenLosingFocus = false;
 
+    m_mapCamera = nullptr;
+    m_drawManager = nullptr;
+
     // create GameContext
     ctx = std::make_unique<GameContext>();
     // create TimeManager
@@ -122,6 +125,13 @@ cGame::cGame()
     // focus manager
     m_focusManager = std::make_unique<cFocusManager>(m_timeManager);
 
+    m_infoContext = std::make_unique<cInfoContext>();
+    
+    m_gameObjectsContext = std::make_unique<cGameObjectContext>();
+
+    // Initialize game objects in the context
+    setupGameObjects();
+
     m_screenShake = std::make_unique<cScreenShake>();
 
     m_dataCampaign = std::make_unique<s_DataCampaign>();
@@ -129,10 +139,6 @@ cGame::cGame()
     m_gameConditionChecker = std::make_unique<cGameConditionChecker>(this);
 
     m_cScreenFader = std::make_unique<cScreenFader>();
-
-    m_infoContext = std::make_unique<cInfoContext>();
-    
-    m_gameObjectsContext = std::make_unique<cGameObjectContext>();
 }
 
 void cGame::applySettings(GameSettings *gs)
@@ -163,9 +169,6 @@ void cGame::applySettings(GameSettings *gs)
 
 void cGame::init()
 {
-    // Initialize game objects in the context
-    setupGameObjects();
-    
     m_infoContext->initializeDefaultInfos();
     auto &map = m_gameObjectsContext->getMap();
     map.setTerrainInfo(m_infoContext->getTerrainInfo());
@@ -669,7 +672,9 @@ bool cGame::setupGame()
     cInfoContextCreator infoCreator;
     infoCreator.installInfos(*game.m_infoContext);
 
-    delete m_mapCamera;
+    if (m_mapCamera != nullptr)
+        delete m_mapCamera;
+
     m_mapCamera = new cMapCamera(&game.m_gameObjectsContext->getMap(), game.m_cameraDragMoveSpeed, game.m_cameraBorderOrKeyMoveSpeed, game.m_cameraEdgeMove);
 
     cIni::installGame(m_gameFilename);
@@ -683,7 +688,9 @@ bool cGame::setupGame()
     game.m_infoContext->setUpgradeInfos(infoCreator.createUpgradeInfos());
     cPlayer *humanPlayer = &game.getPlayer(HUMAN);
 
-    delete game.m_drawManager;
+    // if (m_drawManager!=nullptr) {
+    //     delete game.m_drawManager;
+    // }
     game.m_drawManager = new cDrawManager(ctx.get(), humanPlayer);
 
     // Must be after drawManager, because the cInteractionManager constructor depends on drawManager

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -209,6 +209,10 @@ void cGame::init()
         particle.init();
     }
 
+    for (auto& bullet : m_gameObjectsContext->getBullets()) {
+        bullet.init();
+    }
+
     // Initialize InfoContext with empty objects that will be populated by cIni::installGame()
     m_infoContext->initializeDefaultInfos();
 
@@ -234,6 +238,18 @@ void cGame::missionInit()
     m_gameObjectsContext->getMap().init(64, 64);
     // @mira: while cMap is created beforce all, need to set up terrain before loading scenario, so we can use it in cIni::installGame() when loading map.
     m_gameObjectsContext->getMap().setTerrainInfo(m_infoContext->getTerrainInfo());
+
+    for (int i = 0; i < m_gameObjectsContext->getUnits().size(); i++) {
+        m_gameObjectsContext->getUnits()[i].init(i);
+    }
+
+    for (auto& particle : m_gameObjectsContext->getParticles()) {
+        particle.init();
+    }
+
+    for (auto& bullet : m_gameObjectsContext->getBullets()) {
+        bullet.init();
+    }
 
     initPlayers(true);
 

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -167,7 +167,8 @@ void cGame::init()
     setupGameObjects();
     
     m_infoContext->initializeDefaultInfos();
-    m_map.setTerrainInfo(m_infoContext->getTerrainInfo());
+    auto &map = m_gameObjectsContext->getMap();
+    map.setTerrainInfo(m_infoContext->getTerrainInfo());
     m_newMusicSample = MUSIC_MENU;
     m_newMusicCountdown = 0;
 
@@ -196,15 +197,15 @@ void cGame::init()
     m_cameraBorderOrKeyMoveSpeed=0.5;
     m_cameraEdgeMove = true;
 
-    m_map.init(64, 64);
+    map.init(64, 64);
 
     initPlayers(false);
 
-    for (int i = 0; i < m_Units.size(); i++) {
-        m_Units[i].init(i);
+    for (int i = 0; i < m_gameObjectsContext->getUnits().size(); i++) {
+        m_gameObjectsContext->getUnits()[i].init(i);
     }
 
-    for (auto& particle : m_particles) {
+    for (auto& particle : m_gameObjectsContext->getParticles()) {
         particle.init();
     }
 
@@ -230,9 +231,9 @@ void cGame::missionInit()
 
     m_screenShake->reset();
 
-    m_map.init(64, 64);
+    m_gameObjectsContext->getMap().init(64, 64);
     // @mira: while cMap is created beforce all, need to set up terrain before loading scenario, so we can use it in cIni::installGame() when loading map.
-    m_map.setTerrainInfo(m_infoContext->getTerrainInfo());
+    m_gameObjectsContext->getMap().setTerrainInfo(m_infoContext->getTerrainInfo());
 
     initPlayers(true);
 
@@ -467,7 +468,7 @@ void cGame::shakeScreen(int duration)
 */
 void cGame::shutdown()
 {
-    m_particles.reset();
+    m_gameObjectsContext->getParticles().reset();
     cLogger *logger = cLogger::getInstance();
     logger->logHeader("SHUTDOWN");
 
@@ -547,7 +548,7 @@ bool cGame::setupGame()
     std::shared_ptr<cIniFile> gamesCfg = std::make_shared<cIniFile>(m_gameFilename, m_debugMode);
 
     m_reinforcements = std::make_shared<cReinforcements>();
-    m_map.setReinforcements(m_reinforcements);
+    m_gameObjectsContext->getMap().setReinforcements(m_reinforcements);
 
     game.init(); // Must be first! (loads game.ini file at the end, which is required before going on...)
 
@@ -600,7 +601,7 @@ bool cGame::setupGame()
     ctx->setGraphicsContext(context->createGraphicsContext());
     // share Text to all class what use ctx !
     ctx->setTextContext(context->createTextContext());
-    m_map.setGameContext(ctx.get());
+    m_gameObjectsContext->getMap().setGameContext(ctx.get());
 
     m_textDrawer = ctx->getTextContext()->getGameTextDrawer();
 
@@ -669,7 +670,7 @@ bool cGame::setupGame()
     infoCreator.installInfos(*game.m_infoContext);
 
     delete m_mapCamera;
-    m_mapCamera = new cMapCamera(&m_map, game.m_cameraDragMoveSpeed, game.m_cameraBorderOrKeyMoveSpeed, game.m_cameraEdgeMove);
+    m_mapCamera = new cMapCamera(&game.m_gameObjectsContext->getMap(), game.m_cameraDragMoveSpeed, game.m_cameraBorderOrKeyMoveSpeed, game.m_cameraEdgeMove);
 
     cIni::installGame(m_gameFilename);
     // Now we are ready for the menu state
@@ -920,7 +921,7 @@ void cGame::setState(int newState)
                         cPlayer &player = game.getPlayer(i);
                         player.evaluateStillAlive();
                     }
-                    m_particles.reset();
+                    m_gameObjectsContext->getParticles().reset();
                     // in-between solution until we have a proper combat state object
                     game.m_drawManager->init();
 
@@ -1095,7 +1096,7 @@ void cGame::onNotifyGameEvent(const s_GameEvent &event)
 {
     logbook(s_GameEvent::toString(event));
 
-    m_map.onNotifyGameEvent(event);
+    m_gameObjectsContext->getMap().onNotifyGameEvent(event);
 
     // game itself handles events
     switch (event.eventType) {
@@ -1134,14 +1135,14 @@ void cGame::onEventEntityDestroyed(const s_GameEvent &event) {
     int widthInCells = structureInfo.bmp_width / 32;
     int heightInCells = structureInfo.bmp_height / 32;
 
-    int cellX = m_map.getGeometry().getCellX(event.atCell);
-    int cellY = m_map.getGeometry().getCellY(event.atCell);
+    int cellX = m_gameObjectsContext->getMap().getGeometry().getCellX(event.atCell);
+    int cellY = m_gameObjectsContext->getMap().getGeometry().getCellY(event.atCell);
 
     for (int i = 0; i < amountOfUnitsToSpawn; i++) {
         int randomX = cellX + RNG::genIntMaxExcl(0, widthInCells);
         int randomY = cellY + RNG::genIntMaxExcl(0, heightInCells);
         cUnits::unitCreate(
-            m_map.getGeometry().makeCell(randomX, randomY),
+            m_gameObjectsContext->getMap().getGeometry().makeCell(randomX, randomY),
             unitTypeToSpawn,
             event.player->getId(),
             false,
@@ -1164,19 +1165,19 @@ void cGame::onEventSpecialLaunch(const s_GameEvent &event) const {
         }
         else if (special.deployTargetType == eDeployTargetType::TARGET_INACCURATE_CELL) {
             int precision = special.deployTargetPrecision;
-            int mouseCellX = m_map.getCellX(iMouseCell) - precision;
-            int mouseCellY = m_map.getCellY(iMouseCell) - precision;
+            int mouseCellX = m_gameObjectsContext->getMap().getCellX(iMouseCell) - precision;
+            int mouseCellY = m_gameObjectsContext->getMap().getCellY(iMouseCell) - precision;
 
             int posX = mouseCellX + RNG::rnd((precision * 2) + 1);
             int posY = mouseCellY + RNG::rnd((precision * 2) + 1);
-            cPoint::split(posX, posY) = m_map.fixCoordinatesToBeWithinPlayableMap(posX, posY);
+            cPoint::split(posX, posY) = m_gameObjectsContext->getMap().fixCoordinatesToBeWithinPlayableMap(posX, posY);
 
             logbook(std::format(
                         "eDeployTargetType::TARGET_INACCURATE_CELL, mouse cell X,Y = {},{} - target pos ={},{} - precision {}",
                         mouseCellY, mouseCellY, posX, posY,precision)
                    );
 
-            deployCell = m_map.getGeometry().makeCell(posX, posY);
+            deployCell = m_gameObjectsContext->getMap().getGeometry().makeCell(posX, posY);
         }
 
 
@@ -1184,7 +1185,7 @@ void cGame::onEventSpecialLaunch(const s_GameEvent &event) const {
             // from where
             int structureId = game.m_structureUtils.findStructureBy(player->getId(), special.deployAtStructure, false);
             if (structureId > -1) {
-                cAbstractStructure *pStructure = game.m_pStructures[structureId];
+                cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[structureId];
                 if (pStructure && pStructure->isValid()) {
                     m_soundPlayer->playSound(SOUND_PLACE);
                     createBullet(special.providesTypeId, pStructure->getCell(), deployCell, -1, structureId);
@@ -1408,7 +1409,7 @@ void cGame::playSoundWithDistance(int sampleId, int iDistance)
 
     // zoom factor influences distance we can 'hear'. The closer up, the less max distance. Unzoomed, this is half the map.
     // where when unit is at half map, we can hear it only a bit.
-    float maxDistance = m_mapCamera->divideByZoomLevel(m_map.getMaxDistanceInPixels() / 2);
+    float maxDistance = m_mapCamera->divideByZoomLevel(m_gameObjectsContext->getMap().getMaxDistanceInPixels() / 2);
     float distanceNormalized = 1.0 - (iDistance / maxDistance);
 
     float volume = m_soundPlayer->getMaxVolume() * distanceNormalized;
@@ -1604,24 +1605,24 @@ void cGame::onKeyDownDebugMode(const cKeyboardEvent &event)
     if (event.hasKeys(SDL_SCANCODE_F4, SDL_SCANCODE_LSHIFT)) {
         int mc = humanPlayer.getGameControlsContext()->getMouseCell();
         if (mc > -1) {
-            int idOfUnitAtCell = m_map.getCellIdUnitLayer(mc);
+            int idOfUnitAtCell = m_gameObjectsContext->getMap().getCellIdUnitLayer(mc);
             if (idOfUnitAtCell > -1) {
-                m_Units[idOfUnitAtCell].die(true, false);
+                m_gameObjectsContext->getUnits()[idOfUnitAtCell].die(true, false);
             }
 
-            int idOfStructureAtCell = m_map.getCellIdStructuresLayer(mc);
+            int idOfStructureAtCell = m_gameObjectsContext->getMap().getCellIdStructuresLayer(mc);
             if (idOfStructureAtCell > -1) {
-                game.m_pStructures[idOfStructureAtCell]->die();
+                game.m_gameObjectsContext->getStructures()[idOfStructureAtCell]->die();
             }
 
-            idOfUnitAtCell = m_map.getCellIdWormsLayer(mc);
+            idOfUnitAtCell = m_gameObjectsContext->getMap().getCellIdWormsLayer(mc);
             if (idOfUnitAtCell > -1) {
-                m_Units[idOfUnitAtCell].die(false, false);
+                m_gameObjectsContext->getUnits()[idOfUnitAtCell].die(false, false);
             }
 
-            idOfUnitAtCell = m_map.getCellIdAirUnitLayer(mc);
+            idOfUnitAtCell = m_gameObjectsContext->getMap().getCellIdAirUnitLayer(mc);
             if (idOfUnitAtCell > -1) {
-                m_Units[idOfUnitAtCell].die(false, false);
+                m_gameObjectsContext->getUnits()[idOfUnitAtCell].die(false, false);
             }
         }
     }
@@ -1630,9 +1631,9 @@ void cGame::onKeyDownDebugMode(const cKeyboardEvent &event)
     if (event.hasKeys(SDL_SCANCODE_F5, SDL_SCANCODE_LSHIFT)) {
         int mc = humanPlayer.getGameControlsContext()->getMouseCell();
         if (mc > -1) {
-            int idOfUnitAtCell = m_map.getCellIdUnitLayer(mc);
+            int idOfUnitAtCell = m_gameObjectsContext->getMap().getCellIdUnitLayer(mc);
             if (idOfUnitAtCell > -1) {
-                cUnit &pUnit = m_Units[idOfUnitAtCell];
+                cUnit &pUnit = m_gameObjectsContext->getUnits()[idOfUnitAtCell];
                 int damageToTake = pUnit.getHitPoints() - 25;
                 if (damageToTake > 0) {
                     pUnit.takeDamage(damageToTake, -1, -1);
@@ -1644,7 +1645,7 @@ void cGame::onKeyDownDebugMode(const cKeyboardEvent &event)
         // REVEAL MAP
         if (event.hasKey(SDL_SCANCODE_F5)) {
             for (int i = 0; i < AI_WORM; i++) {
-                m_map.clear_all(i);
+                m_gameObjectsContext->getMap().clear_all(i);
             }
         }
     }
@@ -1653,7 +1654,7 @@ void cGame::onKeyDownDebugMode(const cKeyboardEvent &event)
         // kill all carry-all's
         const std::vector<int> &myUnitsForType = humanPlayer.getAllMyUnitsForType(CARRYALL);
         for (auto &unitId : myUnitsForType) {
-            cUnit &pUnit = m_Units[unitId];
+            cUnit &pUnit = m_gameObjectsContext->getUnits()[unitId];
             pUnit.die(true, false);
         }
     }
@@ -1693,22 +1694,22 @@ s_DataCampaign* cGame::getDataCampaign() const
 
 cUnit& cGame::getUnit(int index)
 {
-    return m_Units[index];
+    return m_gameObjectsContext->getUnits()[index];
 }
 
 const cUnit& cGame::getUnit(int index) const
 {
-    return m_Units[index];
+    return m_gameObjectsContext->getUnits()[index];
 }
 
 cPlayer& cGame::getPlayer(int index)
 {
-    return m_Players[index];
+    return m_gameObjectsContext->getPlayers()[index];
 }
 
 const cPlayer& cGame::getPlayer(int index) const
 {
-    return m_Players[index];
+    return m_gameObjectsContext->getPlayers()[index];
 }
 
 int cGame::getCurrentState() const

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -14,6 +14,7 @@
 #include "config.h"
 #include "context/ContextCreator.hpp"
 #include "context/GameContext.hpp"
+#include "context/cGameObjectContextCreator.h"
 #include "game/cGame.h"
 #include "include/d2tmc.h"
 #include "data/gfxdata.h"
@@ -130,6 +131,8 @@ cGame::cGame()
     m_cScreenFader = std::make_unique<cScreenFader>();
 
     m_infoContext = std::make_unique<cInfoContext>();
+    
+    m_gameObjectsContext = std::make_unique<cGameObjectContext>();
 }
 
 void cGame::applySettings(GameSettings *gs)
@@ -160,6 +163,9 @@ void cGame::applySettings(GameSettings *gs)
 
 void cGame::init()
 {
+    // Initialize game objects in the context
+    setupGameObjects();
+    
     m_infoContext->initializeDefaultInfos();
     m_map.setTerrainInfo(m_infoContext->getTerrainInfo());
     m_newMusicSample = MUSIC_MENU;
@@ -1749,4 +1755,9 @@ void cGame::loadMapFromEditor(s_PreviewMap *map)
     setState(GAME_EDITOR);
     auto *pState = dynamic_cast<cEditorState*>(m_states[GAME_EDITOR]);
     pState->loadMap(map);
+}
+
+void cGame::setupGameObjects(){
+    cGameObjectsContextCreator creator;
+    creator.installGameObjects(*m_gameObjectsContext);
 }

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -127,11 +127,7 @@ cGame::cGame()
 
     m_infoContext = std::make_unique<cInfoContext>();
     
-    m_gameObjectsContext = std::make_unique<cGameObjectContext>();
-
-    // Initialize game objects in the context
-    cGameObjectsContextCreator creator;
-    creator.installGameObjects(*m_gameObjectsContext);
+    m_gameObjectsContext = cGameObjectsContextCreator::create();
 
     m_screenShake = std::make_unique<cScreenShake>();
 

--- a/src/gameobjects/particles/cParticle.cpp
+++ b/src/gameobjects/particles/cParticle.cpp
@@ -585,7 +585,7 @@ int cParticle::create(long x, long y, int iType, int iHouse, int iFrame, int iUn
         return -1;
     }
 
-    cParticle &pParticle = game.m_particles[iNewId];
+    cParticle &pParticle = game.m_gameObjectsContext->getParticles()[iNewId];
     const int particleInfoCount = game.m_infoContext->getParticleInfos()->size();
     if (iType >= 0 && iType < particleInfoCount) {
         s_ParticleInfo &sParticle = game.m_infoContext->getParticleInfo(iType);
@@ -719,7 +719,7 @@ int cParticle::create(long x, long y, int iType, int iHouse, int iFrame, int iUn
 int cParticle::findNewSlot()
 {
     int i = 0;
-    for (auto &particle : game.m_particles) {
+    for (auto &particle : game.m_gameObjectsContext->getParticles()) {
         if (!particle.isValid()) {
             return i;
         }
@@ -789,7 +789,7 @@ void cParticle::addPosX(float d)
 {
     this->x += d;
     if (boundParticleID > -1) {
-        cParticle &otherParticle = game.m_particles[boundParticleID];
+        cParticle &otherParticle = game.m_gameObjectsContext->getParticles()[boundParticleID];
         if (otherParticle.isValid()) {
             otherParticle.addPosX(d);
         }
@@ -803,7 +803,7 @@ void cParticle::addPosY(float d)
 {
     this->y += d;
     if (boundParticleID > -1) {
-        cParticle &otherParticle = game.m_particles[boundParticleID];
+        cParticle &otherParticle = game.m_gameObjectsContext->getParticles()[boundParticleID];
         if (otherParticle.isValid()) {
             otherParticle.addPosY(d);
         }
@@ -818,7 +818,7 @@ void cParticle::die()
     bindToUnit(-1);
     bAlive = false;
     if (boundParticleID > -1) {
-        cParticle &pParticle = game.m_particles[boundParticleID];
+        cParticle &pParticle = game.m_gameObjectsContext->getParticles()[boundParticleID];
         if (pParticle.isValid()) {
             pParticle.die();
         }

--- a/src/gameobjects/projectiles/bullet.cpp
+++ b/src/gameobjects/projectiles/bullet.cpp
@@ -181,10 +181,10 @@ void cBullet::thinkFast()
         TIMER_homing--;
 
         if (iHoming > -1) {
-            if (game.getUnit(iHoming).isValid()) {
-                int cll = game.getUnit(iHoming).getCell();
-                targetX = game.m_map.getAbsoluteXPositionFromCell(cll);
-                targetY = game.m_map.getAbsoluteYPositionFromCell(cll);
+            if (game.m_gameObjectsContext->getUnits()[iHoming].isValid()) {
+                int cll = game.m_gameObjectsContext->getUnits()[iHoming].getCell();
+                targetX = game.m_gameObjectsContext->getMap().getAbsoluteXPositionFromCell(cll);
+                targetY = game.m_gameObjectsContext->getMap().getAbsoluteYPositionFromCell(cll);
             }
         }
     }
@@ -197,11 +197,11 @@ void cBullet::think_move()
 {
     iCell = game.m_mapCamera->getCellFromAbsolutePosition(posX, posY);
 
-    int iCellX = game.m_map.getCellX(iCell);
-    int iCellY = game.m_map.getCellY(iCell);
+    int iCellX = game.m_gameObjectsContext->getMap().getCellX(iCell);
+    int iCellY = game.m_gameObjectsContext->getMap().getCellY(iCell);
 
     // out of bounds somehow; then die
-    if (!game.m_map.isWithinBoundaries(iCellX, iCellY)) {
+    if (!game.m_gameObjectsContext->getMap().isWithinBoundaries(iCellX, iCellY)) {
         die();
         return;
     }
@@ -214,8 +214,8 @@ void cBullet::think_move()
         return;
     }
 
-    int idOfStructureAtCell = game.m_map.getCellIdStructuresLayer(iCell);
-    int cellTypeAtCell = game.m_map.getCellType(iCell);
+    int idOfStructureAtCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(iCell);
+    int cellTypeAtCell = game.m_gameObjectsContext->getMap().getCellType(iCell);
 
     if (!isGroundBullet()) {
         return;
@@ -250,7 +250,7 @@ void cBullet::think_move()
             }
             else {
                 // do not hit own or allied structures
-                if (!game.m_pStructures[id]->getPlayer()->isSameTeamAs(getPlayer())) {
+                if (!game.m_gameObjectsContext->getStructures()[id]->getPlayer()->isSameTeamAs(getPlayer())) {
                     bHitsEnemyBuilding = true;
                 }
             }
@@ -278,8 +278,8 @@ void cBullet::arrivedAtDestinationLogic()
     const s_BulletInfo &sBullet = gets_Bullet();
 
     // damage is inflicted to size of explosion
-    int x = game.m_map.getCellX(iCell);
-    int y = game.m_map.getCellY(iCell);
+    int x = game.m_gameObjectsContext->getMap().getCellX(iCell);
+    int y = game.m_gameObjectsContext->getMap().getCellY(iCell);
 
     int halfExplosionSize = std::round((float)(sBullet.explosionSize / 2));
     int startX = (x - halfExplosionSize);
@@ -290,7 +290,7 @@ void cBullet::arrivedAtDestinationLogic()
     float maxDistanceFromCenter = halfExplosionSize + 0.5f;
     for (int sx = startX; sx < endX; sx++) {
         for (int sy = startY; sy < endY; sy++) {
-            int cellToDamage = game.m_map.getGeometry().getCellWithMapBorders(sx, sy);
+            int cellToDamage = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders(sx, sy);
             if (cellToDamage < 0) continue;
 
             float actualDistance = ABS_length(sx, sy, x, y);
@@ -304,8 +304,8 @@ void cBullet::arrivedAtDestinationLogic()
             int half = 16;
             int randomX = -8 + RNG::rnd(half);
             int randomY = -8 + RNG::rnd(half);
-            int posX = game.m_map.getAbsoluteXPositionFromCellCentered(cellToDamage) + randomX;
-            int posY = game.m_map.getAbsoluteYPositionFromCellCentered(cellToDamage) + randomY;
+            int posX = game.m_gameObjectsContext->getMap().getAbsoluteXPositionFromCellCentered(cellToDamage) + randomX;
+            int posY = game.m_gameObjectsContext->getMap().getAbsoluteYPositionFromCellCentered(cellToDamage) + randomY;
 
             logbook(std::format(
                         "iCell {} : cellToDamage : {} : ExplosionSize is {}, maxDistanceFromCenter is {} , actualDistance = {}, x={}, y={} and factor = {}",
@@ -360,21 +360,21 @@ void cBullet::arrivedAtDestinationLogic()
  */
 void cBullet::damageTerrain(int cell, double factor) const
 {
-    if (!game.m_map.isValidCell(cell)) return;
+    if (!game.m_gameObjectsContext->getMap().isValidCell(cell)) return;
     if (!canDamageGround()) return;
 
     float iDamage = getDamageToInflictToNonInfantry() * factor;
 
-    int idOfStructureAtCell = game.m_map.getCellIdStructuresLayer(cell);
-    int cellTypeAtCell = game.m_map.getCellType(cell);
+    int idOfStructureAtCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(cell);
+    int cellTypeAtCell = game.m_gameObjectsContext->getMap().getCellType(cell);
 
-    game.m_map.cellTakeDamage(cell, iDamage);
+    game.m_gameObjectsContext->getMap().cellTakeDamage(cell, iDamage);
 
     if (cellTypeAtCell == TERRAIN_SLAB) {
         // change into rock, get destroyed. But only when we did not hit a structure.
         if (idOfStructureAtCell < 0) {
-            game.m_map.cellChangeType(cell, TERRAIN_ROCK);
-            cMapEditor(game.m_map).smoothAroundCell(cell);
+            game.m_gameObjectsContext->getMap().cellChangeType(cell, TERRAIN_ROCK);
+            cMapEditor(game.m_gameObjectsContext->getMap()).smoothAroundCell(cell);
         }
     }
 }
@@ -400,7 +400,7 @@ bool cBullet::doesAirUnitTakeDamage(int unitIdOnAirLayer) const
     if (unitIdOnAirLayer < 0) return false;
     if (iOwnerUnit > 0 && unitIdOnAirLayer == iOwnerUnit) return false; // do not damage self
 
-    cUnit &airUnit = game.getUnit(unitIdOnAirLayer);
+    cUnit &airUnit = game.m_gameObjectsContext->getUnits()[unitIdOnAirLayer];
     if (!airUnit.isValid()) {
         return false;
     }
@@ -410,7 +410,7 @@ bool cBullet::doesAirUnitTakeDamage(int unitIdOnAirLayer) const
         return true;
     }
 
-    cUnit &ownerUnit = game.getUnit(iOwnerUnit);
+    cUnit &ownerUnit = game.m_gameObjectsContext->getUnits()[iOwnerUnit];
     if (!ownerUnit.isValid()) {
         return true;
     }
@@ -428,15 +428,15 @@ bool cBullet::doesAirUnitTakeDamage(int unitIdOnAirLayer) const
  */
 bool cBullet::damageAirUnit(int cell) const
 {
-    if (!game.m_map.isValidCell(cell)) return false;
+    if (!game.m_gameObjectsContext->getMap().isValidCell(cell)) return false;
     if (!canDamageAirUnits()) return false;
-    int unitIdOnAirLayer = game.m_map.getCellIdAirUnitLayer(cell);
+    int unitIdOnAirLayer = game.m_gameObjectsContext->getMap().getCellIdAirUnitLayer(cell);
 
     float iDamage = getDamageToInflictToNonInfantry();
 
     if (doesAirUnitTakeDamage(unitIdOnAirLayer)) {
-        cUnit &airUnit = game.getUnit(unitIdOnAirLayer);
-        int originUnitId = (iOwnerUnit > -1 && game.getUnit(iOwnerUnit).isValid()) ? iOwnerUnit : -1;
+        cUnit &airUnit = game.m_gameObjectsContext->getUnits()[unitIdOnAirLayer];
+        int originUnitId = (iOwnerUnit > -1 && game.m_gameObjectsContext->getUnits()[iOwnerUnit].isValid()) ? iOwnerUnit : -1;
         airUnit.takeDamage(iDamage, originUnitId, iOwnerStructure);
         return true;
     }
@@ -451,16 +451,16 @@ bool cBullet::damageAirUnit(int cell) const
  */
 bool cBullet::damageGroundUnit(int cell, double factor) const
 {
-    if (!game.m_map.isValidCell(cell)) return false;
-    int id = game.m_map.getCellIdUnitLayer(cell);
+    if (!game.m_gameObjectsContext->getMap().isValidCell(cell)) return false;
+    int id = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(cell);
     if (id < 0) return false;
     if (iOwnerUnit >= 0 && id == iOwnerUnit) return false; // do not damage self
 
-    cUnit &groundUnitTakingDamage = game.getUnit(id);
+    cUnit &groundUnitTakingDamage = game.m_gameObjectsContext->getUnits()[id];
     if (!groundUnitTakingDamage.isValid()) return false;
 
     float iDamage = getDamageToInflictToUnit(groundUnitTakingDamage) * factor;
-    int originUnitId = (iOwnerUnit > -1 && game.getUnit(iOwnerUnit).isValid()) ? iOwnerUnit : -1;
+    int originUnitId = (iOwnerUnit > -1 && game.m_gameObjectsContext->getUnits()[iOwnerUnit].isValid()) ? iOwnerUnit : -1;
     groundUnitTakingDamage.takeDamage(iDamage, originUnitId, iOwnerStructure);
 
     // this unit will think what to do now (he got hit ouchy!)
@@ -470,7 +470,7 @@ bool cBullet::damageGroundUnit(int cell, double factor) const
     if (groundUnitTakingDamage.isDead()) {
         // who is to blame for killing this unit?
         if (originUnitId > -1) {
-            cUnit &ownerUnit = game.getUnit(originUnitId);
+            cUnit &ownerUnit = game.m_gameObjectsContext->getUnits()[originUnitId];
             if (ownerUnit.isValid()) {
                 // TODO: update statistics
 
@@ -493,7 +493,7 @@ bool cBullet::damageGroundUnit(int cell, double factor) const
 
         // take over unit
         if (RNG::rnd(100) < gets_Bullet().deviateProbability) {
-            cUnit &ownerUnit = game.getUnit(iOwnerUnit);
+            cUnit &ownerUnit = game.m_gameObjectsContext->getUnits()[iOwnerUnit];
             if (ownerUnit.isValid()) {
                 groundUnitTakingDamage.iPlayer = ownerUnit.iPlayer;
                 groundUnitTakingDamage.iGroup = -1;
@@ -547,13 +547,13 @@ float cBullet::getDamageToInflictToInfantry() const
  */
 void cBullet::detonateSpiceBloom(int cell) const
 {
-    game.m_map.detonateSpiceBloom(cell);
+    game.m_gameObjectsContext->getMap().detonateSpiceBloom(cell);
 }
 
 void cBullet::damageSandworm(int cell, double factor) const
 {
-    if (!game.m_map.isValidCell(cell)) return;
-    int id = game.m_map.getCellIdWormsLayer(cell);
+    if (!game.m_gameObjectsContext->getMap().isValidCell(cell)) return;
+    int id = game.m_gameObjectsContext->getMap().getCellIdWormsLayer(cell);
     if (id < 0) return; // bail
 
     cUnit &worm = game.getUnit(id);
@@ -579,20 +579,20 @@ bool cBullet::isAtDestination() const
  */
 void cBullet::damageWall(int cell, double factor) const
 {
-    if (!game.m_map.isValidCell(cell)) return;
-    int cellTypeAtCell = game.m_map.getCellType(cell);
+    if (!game.m_gameObjectsContext->getMap().isValidCell(cell)) return;
+    int cellTypeAtCell = game.m_gameObjectsContext->getMap().getCellType(cell);
     if (cellTypeAtCell != TERRAIN_WALL) return;
 
     float iDamage = getDamageToInflictToNonInfantry() * factor;
 
-    game.m_map.cellTakeDamage(cell, iDamage);
+    game.m_gameObjectsContext->getMap().cellTakeDamage(cell, iDamage);
 
-    if (game.m_map.getCellHealth(cell) < 0) {
+    if (game.m_gameObjectsContext->getMap().getCellHealth(cell) < 0) {
         // remove wall, turn into smudge:
-        auto mapEditor = cMapEditor(game.m_map);
+        auto mapEditor = cMapEditor(game.m_gameObjectsContext->getMap());
         mapEditor.createCell(cell, TERRAIN_ROCK, 0);
         mapEditor.smoothAroundCell(cell);
-        game.m_map.smudge_increase(SmudgeType::S_WALL, cell);
+        game.m_gameObjectsContext->getMap().smudge_increase(SmudgeType::S_WALL, cell);
     }
 }
 
@@ -662,8 +662,8 @@ cPlayer *cBullet::getPlayer() const
  */
 void cBullet::damageStructure(int idOfStructureAtCell, double factor)
 {
-    if (!game.m_map.isValidCell(idOfStructureAtCell)) return;
-    int id = game.m_map.getCellIdStructuresLayer(idOfStructureAtCell);
+    if (!game.m_gameObjectsContext->getMap().isValidCell(idOfStructureAtCell)) return;
+    int id = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(idOfStructureAtCell);
     if (id < 0) return; // bail
 
     cPlayerDifficultySettings *difficultySettings = getDifficultySettings();
@@ -684,7 +684,7 @@ void cBullet::damageStructure(int idOfStructureAtCell, double factor)
         iDamage += iDam;
     }
 
-    cAbstractStructure *pStructure = game.m_pStructures[id];
+    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[id];
     if (pStructure == nullptr) {
         return; // invalid pointer!
     }

--- a/src/gameobjects/structures/cAbstractStructure.cpp
+++ b/src/gameobjects/structures/cAbstractStructure.cpp
@@ -176,7 +176,7 @@ void cAbstractStructure::die()
     }
 
     // remove from array
-    game.m_pStructures[id] = nullptr;
+    game.m_gameObjectsContext->getStructures()[id] = nullptr;
 
     // Destroy structure, take stuff in effect for the player
     pPlayer->decreaseStructureAmount(getType()); // remove from player building indexes
@@ -197,25 +197,25 @@ void cAbstractStructure::die()
     }
 
     int iCll=iCell;
-    int iCX= game.m_map.getCellX(iCll);
-    int iCY= game.m_map.getCellY(iCll);
+    int iCX= game.m_gameObjectsContext->getMap().getCellX(iCll);
+    int iCY= game.m_gameObjectsContext->getMap().getCellY(iCll);
 
     // create destroy particles
     for (int w = 0; w < iWidth; w++) {
         for (int h = 0; h < iHeight; h++) {
-            iCll = game.m_map.getGeometry().makeCell(iCX + w, iCY + h);
+            iCll = game.m_gameObjectsContext->getMap().getGeometry().makeCell(iCX + w, iCY + h);
 
-            game.m_map.cellChangeType(iCll, TERRAIN_ROCK);
-            cMapEditor(game.m_map).smoothAroundCell(iCll);
+            game.m_gameObjectsContext->getMap().cellChangeType(iCll, TERRAIN_ROCK);
+            cMapEditor(game.m_gameObjectsContext->getMap()).smoothAroundCell(iCll);
 
             int half = 16;
-            int posX = game.m_map.getAbsoluteXPositionFromCell(iCll);
-            int posY = game.m_map.getAbsoluteYPositionFromCell(iCll);
+            int posX = game.m_gameObjectsContext->getMap().getAbsoluteXPositionFromCell(iCll);
+            int posY = game.m_gameObjectsContext->getMap().getAbsoluteYPositionFromCell(iCll);
 
             cParticle::create(posX + half, posY + half, D2TM_PARTICLE_OBJECT_BOOM01, -1, -1);
 
             for (int i=0; i < 3; i++) {
-                game.m_map.smudge_increase(SmudgeType::S_ROCK, iCll);
+                game.m_gameObjectsContext->getMap().smudge_increase(SmudgeType::S_ROCK, iCll);
 
                 // create particle
                 int iType = D2TM_PARTICLE_EXPLOSION_STRUCTURE01 + RNG::rnd(2);
@@ -246,7 +246,7 @@ void cAbstractStructure::die()
     game.playSoundWithDistance(SOUND_CRUMBLE01 + RNG::rnd(2), distanceBetweenCellAndCenterOfScreen(iCell));
 
     // remove from the playground
-    game.m_map.remove_id(id, MAPID_STRUCTURES);
+    game.m_gameObjectsContext->getMap().remove_id(id, MAPID_STRUCTURES);
 
     // screen shaking
     game.shakeScreen((iWidth * iHeight) * 20);
@@ -282,8 +282,8 @@ void cAbstractStructure::think_prebuild()
 
 std::vector<int> cAbstractStructure::getCellsAroundStructure()
 {
-    int iStartX = game.m_map.getCellX(iCell);
-    int iStartY = game.m_map.getCellY(iCell);
+    int iStartX = game.m_gameObjectsContext->getMap().getCellX(iCell);
+    int iStartY = game.m_gameObjectsContext->getMap().getCellY(iCell);
 
     int iEndX = (iStartX + iWidth) + 1;
     int iEndY = (iStartY + iHeight) + 1;
@@ -295,7 +295,7 @@ std::vector<int> cAbstractStructure::getCellsAroundStructure()
 
     for (int x = iStartX; x < iEndX; x++) {
         for (int y = iStartY; y < iEndY; y++) {
-            int cell = game.m_map.getGeometry().getCellWithMapBorders(x, y);
+            int cell = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders(x, y);
             if (cell > -1) {
                 cells.push_back(cell);
             }
@@ -311,8 +311,8 @@ std::vector<int> cAbstractStructure::getCellsAroundStructure()
  */
 std::vector<int> cAbstractStructure::getCellsOfStructure()
 {
-    int iStartX = game.m_map.getCellX(iCell);
-    int iStartY = game.m_map.getCellY(iCell);
+    int iStartX = game.m_gameObjectsContext->getMap().getCellX(iCell);
+    int iStartY = game.m_gameObjectsContext->getMap().getCellY(iCell);
 
     int iEndX = (iStartX + iWidth);
     int iEndY = (iStartY + iHeight);
@@ -321,7 +321,7 @@ std::vector<int> cAbstractStructure::getCellsOfStructure()
 
     for (int x = iStartX; x < iEndX; x++) {
         for (int y = iStartY; y < iEndY; y++) {
-            int cell = game.m_map.getGeometry().getCellWithMapBorders(x, y);
+            int cell = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders(x, y);
             if (cell > -1) {
                 cells.push_back(cell);
             }
@@ -341,7 +341,7 @@ int cAbstractStructure::getNonOccupiedCellAroundStructure()
     const std::vector<int> &cells = getCellsAroundStructure();
 
     for (auto &cll : cells) {
-        if (!game.m_map.occupied(cll)) {
+        if (!game.m_gameObjectsContext->getMap().occupied(cll)) {
             return cll;
         }
     }
@@ -431,7 +431,7 @@ void cAbstractStructure::setHeight(int height)
 void cAbstractStructure::setRallyPoint(int cell)
 {
     assert(cell > -2); // -1 is allowed (means disable);
-    assert(cell < game.m_map.getMaxCells());
+    assert(cell < game.m_gameObjectsContext->getMap().getMaxCells());
     iRallyPoint = cell;
 }
 
@@ -510,7 +510,7 @@ void cAbstractStructure::damage(int hp, int originId)
             long y = getRandomPosY();
             int particleIndex = cParticle::create(x, y, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
             if (particleIndex > -1) {
-                TIMER_reduceSmoke = game.m_particles[particleIndex].getTimerDeadInTicks();
+                TIMER_reduceSmoke = game.m_gameObjectsContext->getParticles()[particleIndex].getTimerDeadInTicks();
                 m_smokeParticlesCreated++;
             }
         }
@@ -551,8 +551,8 @@ void cAbstractStructure::setHitPoints(int hp)
 void cAbstractStructure::setCell(int cell)
 {
     iCell = cell;
-    posX = game.m_map.getAbsoluteXPositionFromCell(iCell);
-    posY = game.m_map.getAbsoluteYPositionFromCell(iCell);
+    posX = game.m_gameObjectsContext->getMap().getAbsoluteXPositionFromCell(iCell);
+    posY = game.m_gameObjectsContext->getMap().getAbsoluteYPositionFromCell(iCell);
 }
 
 void cAbstractStructure::setOwner(int player)
@@ -641,7 +641,7 @@ bool cAbstractStructure::isValid()
     if (dead) // flagged for deletion, so no longer 'valid'
         return false;
 
-    if (!game.m_map.isValidCell(iCell))
+    if (!game.m_gameObjectsContext->getMap().isValidCell(iCell))
         return false;
 
     return true;
@@ -773,7 +773,7 @@ void cAbstractStructure::enterStructure(int unitId)
     pUnit.setCell(getCell());
     pUnit.updateCellXAndY();
 
-    game.m_map.remove_id(unitId, MAPID_UNITS);
+    game.m_gameObjectsContext->getMap().remove_id(unitId, MAPID_UNITS);
 }
 
 void cAbstractStructure::unitLeavesStructure()
@@ -806,7 +806,7 @@ void cAbstractStructure::unitLeavesStructure()
         unitToLeave.move_to(getRallyPoint(), -1, -1);
     }
 
-    game.m_map.cellSetIdForLayer(unitToLeave.getCell(), MAPID_UNITS, iUnitIDWithinStructure);
+    game.m_gameObjectsContext->getMap().cellSetIdForLayer(unitToLeave.getCell(), MAPID_UNITS, iUnitIDWithinStructure);
 
     setUnitIdWithin(-1);
     setUnitIdHeadingTowards(-1);
@@ -827,7 +827,7 @@ void cAbstractStructure::unitHeadsTowardsStructure(int unitId)
 
 int cAbstractStructure::getRandomStructureCell()
 {
-    return getCell() + RNG::rnd(getWidth()) + (RNG::rnd(getHeight()) * game.m_map.getWidth());
+    return getCell() + RNG::rnd(getWidth()) + (RNG::rnd(getHeight()) * game.m_gameObjectsContext->getMap().getWidth());
 }
 
 /**

--- a/src/gameobjects/structures/cGunTurret.cpp
+++ b/src/gameobjects/structures/cGunTurret.cpp
@@ -64,13 +64,13 @@ void cGunTurret::think_attack()
 {
     cUnit &unitTarget = game.getUnit(iTargetID);
     if (unitTarget.isValid() && !unitTarget.isDead()) {
-        int iCellX = game.m_map.getCellX(getCell());
-        int iCellY = game.m_map.getCellY(getCell());
+        int iCellX = game.m_gameObjectsContext->getMap().getCellX(getCell());
+        int iCellY = game.m_gameObjectsContext->getMap().getCellY(getCell());
 
         int unitCell = unitTarget.getCell();
 
-        int iTargetX = game.m_map.getCellX(unitCell);
-        int iTargetY = game.m_map.getCellY(unitCell);
+        int iTargetX = game.m_gameObjectsContext->getMap().getCellX(unitCell);
+        int iTargetY = game.m_gameObjectsContext->getMap().getCellY(unitCell);
 
         int d = fDegrees(iCellX, iCellY, iTargetX, iTargetY);
         int facingAngle = faceAngle(d, kTurretFacings); // get the angle
@@ -143,7 +143,7 @@ void cGunTurret::think_fire()
     if (unitTarget.isValid() && !unitTarget.isDead()) {
         TIMER_fire++;
 
-        int iDistance = game.m_map.distance(getCell(), unitTarget.getCell());
+        int iDistance = game.m_gameObjectsContext->getMap().distance(getCell(), unitTarget.getCell());
 
         if (iDistance > getSight()) {
             iTargetID = -1;
@@ -189,9 +189,9 @@ void cGunTurret::think_fire()
             if (unitTarget.isAirbornUnit()) {
                 if (iBull > -1 && bulletType == ROCKET_RTURRET) {
                     // it is a homing missile!
-                    game.m_Bullets[iBull].iHoming = iTargetID;
+                    game.m_gameObjectsContext->getBullets()[iBull].iHoming = iTargetID;
                     // TODO: property for homing?
-                    game.m_Bullets[iBull].TIMER_homing = 200;
+                    game.m_gameObjectsContext->getBullets()[iBull].TIMER_homing = 200;
                 }
             }
 
@@ -214,8 +214,8 @@ void cGunTurret::think_guard()
         TIMER_guard=0-RNG::rnd(20);
 
         int c = getCell();
-        int iCellX = game.m_map.getCellX(c);
-        int iCellY = game.m_map.getCellY(c);
+        int iCellX = game.m_gameObjectsContext->getMap().getCellX(c);
+        int iCellY = game.m_gameObjectsContext->getMap().getCellY(c);
 
         int iDistance=9999; // closest distance
 
@@ -233,13 +233,13 @@ void cGunTurret::think_guard()
         }
 
         // scan area for units
-        for (int i = 0; i < game.m_Units.size(); i++) {
+        for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
             // is valid
-            cUnit &cUnit = game.getUnit(i);
+            cUnit &cUnit = game.m_gameObjectsContext->getUnits()[i];
             if (!cUnit.isValid()) continue;
             if (cUnit.iPlayer == getOwner()) continue; // skip own units
             if (cUnit.getPlayer()->isSameTeamAs(getPlayer())) continue; // skip allied units
-            if (!game.m_map.isVisible(cUnit.getCell(), getPlayer())) continue; // skip not visible
+            if (!game.m_gameObjectsContext->getMap().isVisible(cUnit.getCell(), getPlayer())) continue; // skip not visible
 
             if (!canAttackAirUnits()) {
                 if (cUnit.isAirbornUnit()) {
@@ -257,7 +257,7 @@ void cGunTurret::think_guard()
             }
 
             int c1 = cUnit.getCell();
-            int distance = ABS_length(iCellX, iCellY, game.m_map.getCellX(c1), game.m_map.getCellY(c1));
+            int distance = ABS_length(iCellX, iCellY, game.m_gameObjectsContext->getMap().getCellX(c1), game.m_gameObjectsContext->getMap().getCellY(c1));
 
             if (distance <= distanceForAttacking) {
                 if (cUnit.isAttackableAirUnit()) {

--- a/src/gameobjects/structures/cGunTurret.cpp
+++ b/src/gameobjects/structures/cGunTurret.cpp
@@ -189,9 +189,9 @@ void cGunTurret::think_fire()
             if (unitTarget.isAirbornUnit()) {
                 if (iBull > -1 && bulletType == ROCKET_RTURRET) {
                     // it is a homing missile!
-                    game.g_Bullets[iBull].iHoming = iTargetID;
+                    game.m_Bullets[iBull].iHoming = iTargetID;
                     // TODO: property for homing?
-                    game.g_Bullets[iBull].TIMER_homing = 200;
+                    game.m_Bullets[iBull].TIMER_homing = 200;
                 }
             }
 

--- a/src/gameobjects/structures/cOrderProcesser.cpp
+++ b/src/gameobjects/structures/cOrderProcesser.cpp
@@ -228,10 +228,10 @@ void cOrderProcesser::sendFrigate()
 
     if (structureId > -1) {
         // found structure
-        game.m_pStructures[structureId]->setAnimating(true);
-        int destinationCell = game.m_pStructures[structureId]->getCell();
+        game.m_gameObjectsContext->getStructures()[structureId]->setAnimating(true);
+        int destinationCell = game.m_gameObjectsContext->getStructures()[structureId]->getCell();
 
-        int iStartCell = game.m_map.findCloseMapBorderCellRelativelyToDestinationCel(destinationCell);
+        int iStartCell = game.m_gameObjectsContext->getMap().findCloseMapBorderCellRelativelyToDestinationCel(destinationCell);
 
         if (iStartCell < 0) {
             logbook("cOrderProcesser::sendFrigate : unable to find start cell to spawn frigate");
@@ -246,10 +246,10 @@ void cOrderProcesser::sendFrigate()
             }
 
             // STEP 2b: make sure its facing the starport directly
-            int iCellX = game.m_map.getCellX(iStartCell);
-            int iCellY = game.m_map.getCellY(iStartCell);
-            int cx = game.m_map.getCellX(destinationCell);
-            int cy = game.m_map.getCellY(destinationCell);
+            int iCellX = game.m_gameObjectsContext->getMap().getCellX(iStartCell);
+            int iCellY = game.m_gameObjectsContext->getMap().getCellY(iStartCell);
+            int cx = game.m_gameObjectsContext->getMap().getCellX(destinationCell);
+            int cy = game.m_gameObjectsContext->getMap().getCellY(destinationCell);
 
             int d = fDegrees(iCellX, iCellY, cx, cy);
             int f = faceAngle(d); // get the angle

--- a/src/gameobjects/structures/cStarPort.cpp
+++ b/src/gameobjects/structures/cStarPort.cpp
@@ -101,7 +101,7 @@ void cStarPort::think_deploy()
                         // assume that the cell to drop is the location of the structure itself
                         cellToDeployTo = getCell();
                     }
-                    int cellAtBorderOfMap = game.m_map.findCloseMapBorderCellRelativelyToDestinationCel(cellToDeployTo);
+                    int cellAtBorderOfMap = game.m_gameObjectsContext->getMap().findCloseMapBorderCellRelativelyToDestinationCel(cellToDeployTo);
                     REINFORCE(iPlayer, item->getBuildId(), cellToDeployTo, cellAtBorderOfMap);
                 }
             }

--- a/src/gameobjects/structures/cStructureFactory.cpp
+++ b/src/gameobjects/structures/cStructureFactory.cpp
@@ -70,7 +70,7 @@ cAbstractStructure *cStructureFactory::createStructureInstance(int type)
 void cStructureFactory::deleteStructureInstance(cAbstractStructure *pStructure)
 {
     // delete memory acquired
-    game.m_pStructures[pStructure->getStructureId()] = nullptr;
+    game.m_gameObjectsContext->getStructures()[pStructure->getStructureId()] = nullptr;
     delete pStructure;
 }
 
@@ -128,7 +128,7 @@ cAbstractStructure *cStructureFactory::createStructure(int iCell, int iStructure
         return nullptr; // fail
     }
 
-    cPoint absTopLeft = game.m_map.getAbsolutePositionFromCell(iCell);
+    cPoint absTopLeft = game.m_gameObjectsContext->getMap().getAbsolutePositionFromCell(iCell);
     cPlayer *player = &game.getPlayer(iPlayer);
 
     for (auto flag : structureInfo.flags) {
@@ -154,7 +154,7 @@ cAbstractStructure *cStructureFactory::createStructure(int iCell, int iStructure
     int structureSize = structureInfo.bmp_width * structureInfo.bmp_height;
 
     // assign to array
-    game.m_pStructures[iNewId] = str;
+    game.m_gameObjectsContext->getStructures()[iNewId] = str;
 
     // Now set it up for location & player
     str->setCell(iCell);
@@ -204,7 +204,7 @@ void cStructureFactory::updatePlayerCatalogAndPlaceNonStructureTypeIfApplicable(
     cPlayer &cPlayer = game.getPlayer(iPlayer);
     cPlayer.increaseStructureAmount(iStructureType);
 
-    auto mapEditor = cMapEditor(game.m_map);
+    auto mapEditor = cMapEditor(game.m_gameObjectsContext->getMap());
 
     if (iStructureType == SLAB1) {
         mapEditor.createCell(iCell, TERRAIN_SLAB, 0);
@@ -212,29 +212,29 @@ void cStructureFactory::updatePlayerCatalogAndPlaceNonStructureTypeIfApplicable(
     }
 
     if (iStructureType == SLAB4) {
-        if (game.m_map.occupiedByUnit(iCell) == false) {
-            if (game.m_map.getCellType(iCell) == TERRAIN_ROCK) {
+        if (game.m_gameObjectsContext->getMap().occupiedByUnit(iCell) == false) {
+            if (game.m_gameObjectsContext->getMap().getCellType(iCell) == TERRAIN_ROCK) {
                 mapEditor.createCell(iCell, TERRAIN_SLAB, 0);
             }
         }
 
-        int cellRight = game.m_map.getCellRight(iCell);
-        if (game.m_map.occupiedByUnit(cellRight) == false) {
-            if (game.m_map.getCellType(cellRight) == TERRAIN_ROCK) {
+        int cellRight = game.m_gameObjectsContext->getMap().getCellRight(iCell);
+        if (game.m_gameObjectsContext->getMap().occupiedByUnit(cellRight) == false) {
+            if (game.m_gameObjectsContext->getMap().getCellType(cellRight) == TERRAIN_ROCK) {
                 mapEditor.createCell(cellRight, TERRAIN_SLAB, 0);
             }
         }
 
-        int oneRowBelowCell = game.m_map.getCellBelow(iCell);
-        if (game.m_map.occupiedByUnit(oneRowBelowCell) == false) {
-            if (game.m_map.getCellType(oneRowBelowCell) == TERRAIN_ROCK) {
+        int oneRowBelowCell = game.m_gameObjectsContext->getMap().getCellBelow(iCell);
+        if (game.m_gameObjectsContext->getMap().occupiedByUnit(oneRowBelowCell) == false) {
+            if (game.m_gameObjectsContext->getMap().getCellType(oneRowBelowCell) == TERRAIN_ROCK) {
                 mapEditor.createCell(oneRowBelowCell, TERRAIN_SLAB, 0);
             }
         }
 
-        int rightToRowBelowCell = game.m_map.getCellRight(oneRowBelowCell);
-        if (game.m_map.occupiedByUnit(rightToRowBelowCell) == false) {
-            if (game.m_map.getCellType(rightToRowBelowCell) == TERRAIN_ROCK) {
+        int rightToRowBelowCell = game.m_gameObjectsContext->getMap().getCellRight(oneRowBelowCell);
+        if (game.m_gameObjectsContext->getMap().occupiedByUnit(rightToRowBelowCell) == false) {
+            if (game.m_gameObjectsContext->getMap().getCellType(rightToRowBelowCell) == TERRAIN_ROCK) {
                 mapEditor.createCell(rightToRowBelowCell, TERRAIN_SLAB, 0);
             }
         }
@@ -273,14 +273,14 @@ void cStructureFactory::clearFogForStructureType(int iCell, int iStructureType, 
     int iWidth = game.m_infoContext->getStructureInfo(iStructureType).bmp_width / 32;;
     int iHeight = game.m_infoContext->getStructureInfo(iStructureType).bmp_height / 32;
 
-    int iCellX = game.m_map.getCellX(iCell);
-    int iCellY = game.m_map.getCellY(iCell);
+    int iCellX = game.m_gameObjectsContext->getMap().getCellX(iCell);
+    int iCellY = game.m_gameObjectsContext->getMap().getCellY(iCell);
     int iCellXMax = iCellX + iWidth;
     int iCellYMax = iCellY + iHeight;
 
     for (int x = iCellX; x < iCellXMax; x++) {
         for (int y = iCellY; y < iCellYMax; y++) {
-            game.m_map.clearShroud(game.m_map.getGeometry().makeCell(x, y), iSight, iPlayer);
+            game.m_gameObjectsContext->getMap().clearShroud(game.m_gameObjectsContext->getMap().getGeometry().makeCell(x, y), iSight, iPlayer);
         }
     }
 }
@@ -291,7 +291,7 @@ void cStructureFactory::clearFogForStructureType(int iCell, int iStructureType, 
 int cStructureFactory::getFreeSlot()
 {
     for (int i=0; i < MAX_STRUCTURES; i++) {
-        if (game.m_pStructures[i] == nullptr) {
+        if (game.m_gameObjectsContext->getStructures()[i] == nullptr) {
             return i;
         }
     }
@@ -314,7 +314,7 @@ int cStructureFactory::getFreeSlot()
 **/
 int cStructureFactory::getSlabStatus(int iCell, int iStructureType)
 {
-    if (!game.m_map.isValidCell(iCell)) return 0;
+    if (!game.m_gameObjectsContext->getMap().isValidCell(iCell)) return 0;
 
     // checks if this structure can be placed on this cell
     int w = game.m_infoContext->getStructureInfo(iStructureType).bmp_width / TILESIZE_WIDTH_PIXELS;
@@ -322,19 +322,19 @@ int cStructureFactory::getSlabStatus(int iCell, int iStructureType)
 
     int slabs = 0;
 
-    int x = game.m_map.getCellX(iCell);
-    int y = game.m_map.getCellY(iCell);
+    int x = game.m_gameObjectsContext->getMap().getCellX(iCell);
+    int y = game.m_gameObjectsContext->getMap().getCellY(iCell);
 
     for (int cx = 0; cx < w; cx++) {
         for (int cy = 0; cy < h; cy++) {
-            int cll = game.m_map.getGeometry().getCellWithMapBorders(cx + x, cy + y);
+            int cll = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders(cx + x, cy + y);
 
             if (cll < 0) {
                 continue;
             }
 
             // If the 'terrain' type is 'slab' increase value of found slabs.
-            if (game.m_map.getCellType(cll) == TERRAIN_SLAB) {
+            if (game.m_gameObjectsContext->getMap().getCellType(cll) == TERRAIN_SLAB) {
                 slabs++;
             }
         }
@@ -351,15 +351,15 @@ void cStructureFactory::createSlabForStructureType(int iCell, int iStructureType
     int height = game.m_infoContext->getStructureInfo(iStructureType).bmp_height / 32;
     int width = game.m_infoContext->getStructureInfo(iStructureType).bmp_width / 32;
 
-    int cellX = game.m_map.getCellX(iCell);
-    int cellY = game.m_map.getCellY(iCell);
+    int cellX = game.m_gameObjectsContext->getMap().getCellX(iCell);
+    int cellY = game.m_gameObjectsContext->getMap().getCellY(iCell);
 
     int endCellX = cellX + width;
     int endCellY = cellY + height;
-    auto mapEditor = cMapEditor(game.m_map);
+    auto mapEditor = cMapEditor(game.m_gameObjectsContext->getMap());
     for (int y = cellY; y < endCellY; y++) {
         for (int x = cellX; x < endCellX; x++) {
-            int cell = game.m_map.getGeometry().getCellWithMapDimensions(x, y);
+            int cell = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapDimensions(x, y);
             mapEditor.createCell(cell, TERRAIN_SLAB, 0);
         }
     }
@@ -369,12 +369,12 @@ void cStructureFactory::deleteAllExistingStructures()
 {
     for (int i=0; i < MAX_STRUCTURES; i++) {
         // clear out all structures
-        cAbstractStructure *pStructure = game.m_pStructures[i];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[i];
         if (pStructure) {
             delete pStructure;
         }
         // clear pointer
-        game.m_pStructures[i] = nullptr;
+        game.m_gameObjectsContext->getStructures()[i] = nullptr;
     }
 }
 
@@ -391,15 +391,15 @@ void cStructureFactory::slabStructure(int iCll, int iStructureType, int iPlayer)
     int width = sStructures.bmp_width / TILESIZE_WIDTH_PIXELS;
     int height = sStructures.bmp_height / TILESIZE_HEIGHT_PIXELS;
 
-    int x = game.m_map.getCellX(iCll);
-    int y = game.m_map.getCellY(iCll);
+    int x = game.m_gameObjectsContext->getMap().getCellX(iCll);
+    int y = game.m_gameObjectsContext->getMap().getCellY(iCll);
 
     int endX = x + width;
     int endY = y + height;
 
     for (int sx = x; sx < endX; sx++) {
         for (int sy = y; sy < endY; sy++) {
-            createStructure(game.m_map.getGeometry().getCellWithMapBorders(sx, sy), SLAB1, iPlayer);
+            createStructure(game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders(sx, sy), SLAB1, iPlayer);
         }
     }
 }

--- a/src/gameobjects/structures/cStructureFactory.cpp
+++ b/src/gameobjects/structures/cStructureFactory.cpp
@@ -367,6 +367,8 @@ void cStructureFactory::createSlabForStructureType(int iCell, int iStructureType
 
 void cStructureFactory::deleteAllExistingStructures()
 {
+    if (game.m_gameObjectsContext == nullptr)
+        return;
     for (int i=0; i < MAX_STRUCTURES; i++) {
         // clear out all structures
         cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[i];

--- a/src/gameobjects/units/cPathFinder.cpp
+++ b/src/gameobjects/units/cPathFinder.cpp
@@ -97,11 +97,11 @@ int cPathFinder::createPath(int iUnitId, int iPathCountUnits)
     the_cll = -1;
     ex = -1;
     ey = -1;
-    cx = game.m_map.getCellX(iCell);
-    cy = game.m_map.getCellY(iCell);
+    cx = game.m_gameObjectsContext->getMap().getCellX(iCell);
+    cy = game.m_gameObjectsContext->getMap().getCellY(iCell);
 
     // set very first... our start cell
-    temp_map[iCell].cost = ABS_length(cx, cy, game.m_map.getCellX(goal_cell), game.m_map.getCellY(goal_cell));
+    temp_map[iCell].cost = ABS_length(cx, cy, game.m_gameObjectsContext->getMap().getCellX(goal_cell), game.m_gameObjectsContext->getMap().getCellY(goal_cell));
     temp_map[iCell].parent = -1;
     temp_map[iCell].state = OPEN; // this one is opened by default
 
@@ -120,7 +120,7 @@ int cPathFinder::createPath(int iUnitId, int iPathCountUnits)
             break;
         }
 
-        int idOfStructureAtCell = game.m_map.cellGetIdFromLayer(iCell, MAPID_STRUCTURES);
+        int idOfStructureAtCell = game.m_gameObjectsContext->getMap().cellGetIdFromLayer(iCell, MAPID_STRUCTURES);
         if (pUnit.iStructureID > -1) {
             if (idOfStructureAtCell == pUnit.iStructureID) {
                 valid = false;
@@ -139,8 +139,8 @@ int cPathFinder::createPath(int iUnitId, int iPathCountUnits)
             }
         }
 
-        cx = game.m_map.getCellX(iCell);
-        cy = game.m_map.getCellY(iCell);
+        cx = game.m_gameObjectsContext->getMap().getCellX(iCell);
+        cy = game.m_gameObjectsContext->getMap().getCellY(iCell);
 
         // starting position is cx-1 and cy-1
         sx = cx - 1;
@@ -151,8 +151,8 @@ int cPathFinder::createPath(int iUnitId, int iPathCountUnits)
         ey = cy + 1;
 
         // boundaries
-        cPoint::split(sx, sy) = game.m_map.fixCoordinatesToBeWithinPlayableMap(sx, sy);
-        cPoint::split(ex, ey) = game.m_map.fixCoordinatesToBeWithinPlayableMap(ex, ey);
+        cPoint::split(sx, sy) = game.m_gameObjectsContext->getMap().fixCoordinatesToBeWithinPlayableMap(sx, sy);
+        cPoint::split(ex, ey) = game.m_gameObjectsContext->getMap().fixCoordinatesToBeWithinPlayableMap(ex, ey);
 
 //        if (ex <= cx)
 //            pUnit.log("CX = EX");
@@ -170,7 +170,7 @@ int cPathFinder::createPath(int iUnitId, int iPathCountUnits)
             // circle around cell Y wise
             for (cy = sy; cy <= ey; cy++) {
                 // only check the 'cell' that is NOT the current cell.
-                int cll = game.m_map.getGeometry().getCellWithMapBorders(cx, cy);
+                int cll = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders(cx, cy);
 
                 // skip invalid cells
                 if (cll < 0)
@@ -188,15 +188,15 @@ int cPathFinder::createPath(int iUnitId, int iPathCountUnits)
                 bool good = false; // not good by default
 
                 // not a sandworm
-                int cellType = game.m_map.getCellType(cll);
+                int cellType = game.m_gameObjectsContext->getMap().getCellType(cll);
                 if (!pUnit.isSandworm()) {
                     // Step by step determine if its good
                     // 2 fases:
                     // 1 -> Occupation by unit/structures
                     // 2 -> Occupation by terrain (but only when it is visible, since we do not want to have an
                     //      advantage or some super intelligence by units for unknown territories!)
-                    int idOfUnitAtCell = game.m_map.getCellIdUnitLayer(cll);
-                    int idOfStructureAtCell = game.m_map.getCellIdStructuresLayer(cll);
+                    int idOfUnitAtCell = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(cll);
+                    int idOfStructureAtCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(cll);
 
                     if (idOfUnitAtCell == -1 && idOfStructureAtCell == -1) {
                         // there is nothing on this cell, that is good
@@ -245,7 +245,7 @@ int cPathFinder::createPath(int iUnitId, int iPathCountUnits)
                     }
 
                     // is not visible, always good (since we don't know yet if its blocked!)
-                    if (game.m_map.isVisible(cll, controller) == false) {
+                    if (game.m_gameObjectsContext->getMap().isVisible(cll, controller) == false) {
                         good = true;
                     }
                     else {
@@ -264,7 +264,7 @@ int cPathFinder::createPath(int iUnitId, int iPathCountUnits)
                 }
                 else {
                     // Sandworm only cares about terrain type for good/bad cells
-                    good = game.m_map.isCellPassableForWorm(cll);
+                    good = game.m_gameObjectsContext->getMap().isCellPassableForWorm(cll);
                 }
 
                 if (!good) {
@@ -289,12 +289,12 @@ int cPathFinder::createPath(int iUnitId, int iPathCountUnits)
                 // the cell is CLOSED (not checked yet)
                 if (cll != iCell &&         // not checking on our own
                         isClosed) {            // and is closed (else it's not valid to check)
-                    int gcx = game.m_map.getCellX(goal_cell);
-                    int gcy = game.m_map.getCellY(goal_cell);
+                    int gcx = game.m_gameObjectsContext->getMap().getCellX(goal_cell);
+                    int gcy = game.m_gameObjectsContext->getMap().getCellY(goal_cell);
 
                     // calculate the cost
                     int tempCost = temp_map[cll].cost;
-                    double distanceCost = game.m_map.distance(cx, cy, gcx, gcy);
+                    double distanceCost = game.m_gameObjectsContext->getMap().distance(cx, cy, gcx, gcy);
                     double newCost = distanceCost + tempCost;
 //                        pUnit.log(std::format(
 //                                "CREATE_PATH: tempCost [{}] + distanceCost [{}] = newCost = [{}] vs current cost [{}]",
@@ -441,7 +441,7 @@ int cPathFinder::createPath(int iUnitId, int iPathCountUnits)
                     for (int sz = z; sz > 0; sz--) {
                         if (temp_path[sz] > -1) {
 
-                            if (game.m_map.isCellAdjacentToOtherCell(iPrevCell, temp_path[sz])) {
+                            if (game.m_gameObjectsContext->getMap().isCellAdjacentToOtherCell(iPrevCell, temp_path[sz])) {
                                 iGoodZ = sz;
                             }
                             //if (ABS_length(iCellGiveX(iPrevCell), iCellGiveY(iPrevCell), iCellGiveX(temp_path[sz]), iCellGiveY(temp_path[sz])) <= 1)
@@ -470,7 +470,7 @@ int cPathFinder::createPath(int iUnitId, int iPathCountUnits)
         for (int i = 1; i < MAX_PATH_SIZE; i++) {
             int pathCell = pUnit.movement.iPath[i];
             if (pathCell > -1) {
-                if (game.m_map.isCellAdjacentToOtherCell(pUnit.getCell(), pathCell)) {
+                if (game.m_gameObjectsContext->getMap().isCellAdjacentToOtherCell(pUnit.getCell(), pathCell)) {
                     pUnit.movement.iPathIndex = i;
                 }
             }
@@ -511,44 +511,44 @@ int cPathFinder::returnCloseGoal(int iCll, int iMyCell, int iID)
 {
     //
     int iSize = 1;
-    int iStartX = game.m_map.getCellX(iCll) - iSize;
-    int iStartY = game.m_map.getCellY(iCll) - iSize;
-    int iEndX = game.m_map.getCellX(iCll) + iSize;
-    int iEndY = game.m_map.getCellX(iCll) + iSize;
+    int iStartX = game.m_gameObjectsContext->getMap().getCellX(iCll) - iSize;
+    int iStartY = game.m_gameObjectsContext->getMap().getCellY(iCll) - iSize;
+    int iEndX = game.m_gameObjectsContext->getMap().getCellX(iCll) + iSize;
+    int iEndY = game.m_gameObjectsContext->getMap().getCellX(iCll) + iSize;
 
     float dDistance = 9999;
 
-    int ix = game.m_map.getCellX(iMyCell);
-    int iy = game.m_map.getCellY(iMyCell);
+    int ix = game.m_gameObjectsContext->getMap().getCellX(iMyCell);
+    int iy = game.m_gameObjectsContext->getMap().getCellY(iMyCell);
 
     bool bSearch = true;
 
     int iTheClosest = -1;
 
     while (bSearch) {
-        iStartX = game.m_map.getCellX(iCll) - iSize;
-        iStartY = game.m_map.getCellY(iCll) - iSize;
-        iEndX = game.m_map.getCellX(iCll) + iSize;
-        iEndY = game.m_map.getCellY(iCll) + iSize;
+        iStartX = game.m_gameObjectsContext->getMap().getCellX(iCll) - iSize;
+        iStartY = game.m_gameObjectsContext->getMap().getCellY(iCll) - iSize;
+        iEndX = game.m_gameObjectsContext->getMap().getCellX(iCll) + iSize;
+        iEndY = game.m_gameObjectsContext->getMap().getCellY(iCll) + iSize;
 
         // Fix boundaries
-        cPoint::split(iStartX, iStartY) = game.m_map.fixCoordinatesToBeWithinPlayableMap(iStartX, iStartY);
-        cPoint::split(iEndX, iEndY) = game.m_map.fixCoordinatesToBeWithinPlayableMap(iEndX, iEndY);
+        cPoint::split(iStartX, iStartY) = game.m_gameObjectsContext->getMap().fixCoordinatesToBeWithinPlayableMap(iStartX, iStartY);
+        cPoint::split(iEndX, iEndY) = game.m_gameObjectsContext->getMap().fixCoordinatesToBeWithinPlayableMap(iEndX, iEndY);
 
         // search
         for (int iSX = iStartX; iSX < iEndX; iSX++)
             for (int iSY = iStartY; iSY < iEndY; iSY++) {
                 // find an empty cell
-                int cll = game.m_map.getGeometry().getCellWithMapDimensions(iSX, iSY);
+                int cll = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapDimensions(iSX, iSY);
 
                 float dDistance2 = ABS_length(iSX, iSY, ix, iy);
 
-                int idOfStructureAtCell = game.m_map.getCellIdStructuresLayer(cll);
-                int idOfUnitAtCell = game.m_map.getCellIdUnitLayer(cll);
+                int idOfStructureAtCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(cll);
+                int idOfUnitAtCell = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(cll);
 
                 if ((idOfStructureAtCell < 0) && (idOfUnitAtCell < 0)) { // no unit or structure at cell
                     // depending on unit type, do not choose walls (or mountains)
-                    int cellType = game.m_map.getCellType(cll);
+                    int cellType = game.m_gameObjectsContext->getMap().getCellType(cll);
                     if (game.m_infoContext->getUnitInfo(game.getUnit(iID).iType).infantry) {
                         if (cellType == TERRAIN_MOUNTAIN)
                             continue; // do not use this one

--- a/src/gameobjects/units/cReinforcements.cpp
+++ b/src/gameobjects/units/cReinforcements.cpp
@@ -165,7 +165,7 @@ void REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement)
     if (iPlr < 0 || iTpe < 0)
         return;
 
-    if (game.m_map.isValidCell(iCll) == false)
+    if (game.m_gameObjectsContext->getMap().isValidCell(iCll) == false)
         return;
 
     if (iStart < 0)
@@ -175,7 +175,7 @@ void REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement)
 
     if (iStartCell < 0) {
         iStart += RNG::rnd(64);
-        if (iStart >= game.m_map.getMaxCells())
+        if (iStart >= game.m_gameObjectsContext->getMap().getMaxCells())
             iStart -= 64;
 
         iStartCell = iFindCloseBorderCell(iStart);
@@ -198,10 +198,10 @@ void REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement)
     }
 
     // STEP 3: assign order to carryall
-    int iCellX = game.m_map.getCellX(iStartCell);
-    int iCellY = game.m_map.getCellY(iStartCell);
-    int cx = game.m_map.getCellX(iCll);
-    int cy = game.m_map.getCellY(iCll);
+    int iCellX = game.m_gameObjectsContext->getMap().getCellX(iStartCell);
+    int iCellY = game.m_gameObjectsContext->getMap().getCellY(iStartCell);
+    int cx = game.m_gameObjectsContext->getMap().getCellX(iCll);
+    int cy = game.m_gameObjectsContext->getMap().getCellY(iCll);
 
     int d = fDegrees(iCellX, iCellY, cx, cy);
     int f = faceAngle(d); // get the angle

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -164,7 +164,7 @@ void cUnit::die(bool bBlowUp, bool bSquish)
 
     // any damage particle dies with the unit?
     if (boundParticleId > -1) {
-        cParticle &pParticle = game.m_particles[boundParticleId];
+        cParticle &pParticle = game.m_gameObjectsContext->getParticles()[boundParticleId];
         if (pParticle.isValid()) {
             pParticle.die();
         }
@@ -174,7 +174,7 @@ void cUnit::die(bool bBlowUp, bool bSquish)
     // Animation / Sound
 
     // Anyone who was attacking this unit is on actionGuard
-    for (int i = 0; i < game.m_Units.size(); i++) {
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
         cUnit &pUnit = game.getUnit(i);
         if (!pUnit.isValid()) continue; // skip invalid
         if (pUnit.combat.iAttackUnit != iID) continue; // skip those who did not want to attack me
@@ -208,7 +208,7 @@ void cUnit::die(bool bBlowUp, bool bSquish)
     }
 
     if (iStructureID > -1) {
-        cAbstractStructure *pStructure = game.m_pStructures[iStructureID];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[iStructureID];
         if (pStructure && pStructure->isValid()) {
             // TODO: Use events, and let structure deal with this themselves!
         }
@@ -228,9 +228,9 @@ void cUnit::die(bool bBlowUp, bool bSquish)
 
     init(iID);    // re-init
 
-    game.m_map.remove_id(iID, MAPID_UNITS);
-    game.m_map.remove_id(iID, MAPID_AIR);
-    game.m_map.remove_id(iID, MAPID_WORMS);
+    game.m_gameObjectsContext->getMap().remove_id(iID, MAPID_UNITS);
+    game.m_gameObjectsContext->getMap().remove_id(iID, MAPID_AIR);
+    game.m_gameObjectsContext->getMap().remove_id(iID, MAPID_WORMS);
 }
 
 void cUnit::createSquishedParticle()
@@ -255,7 +255,7 @@ void cUnit::createExplosionParticle()
     int iDieX = pos_x_centered();
     int iDieY = pos_y_centered();
 
-    auto mapEditor = cMapEditor(game.m_map);
+    auto mapEditor = cMapEditor(game.m_gameObjectsContext->getMap());
 
     if (iType == TRIKE || iType == RAIDER || iType == QUAD) {
         // play quick 'boom' sound and show animation
@@ -325,27 +325,27 @@ void cUnit::createExplosionParticle()
                     game.playSoundWithDistance(SOUND_TANKDIE + RNG::rnd(2), distanceBetweenCellAndCenterOfScreen(position.iCell));
 
                 // calculate cell and damage stuff around this
-                int cll = game.m_map.getGeometry().getCellWithMapBorders((position.iCellX - 1) + cx, (position.iCellY - 1) + cy);
+                int cll = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders((position.iCellX - 1) + cx, (position.iCellY - 1) + cy);
 
                 if (cll < 0 || cll == position.iCell)
                     continue; // do not do own cell
 
-                if (game.m_map.getCellType(cll) == TERRAIN_WALL) {
+                if (game.m_gameObjectsContext->getMap().getCellType(cll) == TERRAIN_WALL) {
                     // damage this type of wall...
-                    game.m_map.cellTakeDamage(cll, 150);
+                    game.m_gameObjectsContext->getMap().cellTakeDamage(cll, 150);
 
-                    if (game.m_map.getCellHealth(cll) < 0) {
+                    if (game.m_gameObjectsContext->getMap().getCellHealth(cll) < 0) {
                         // remove wall, turn into smudge:
                         mapEditor.createCell(cll, TERRAIN_ROCK, 0);
 
                         mapEditor.smoothAroundCell(cll);
 
-                        game.m_map.smudge_increase(SmudgeType::S_WALL, cll);
+                        game.m_gameObjectsContext->getMap().smudge_increase(SmudgeType::S_WALL, cll);
                     }
                 }
 
                 // damage surrounding units
-                int idOfUnitAtCell = game.m_map.getCellIdUnitLayer(cll);
+                int idOfUnitAtCell = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(cll);
                 if (idOfUnitAtCell > -1) {
                     int id = idOfUnitAtCell;
 
@@ -358,12 +358,12 @@ void cUnit::createExplosionParticle()
                     } // only die when the unit is going to die
                 }
 
-                int idOfStructureAtCell = game.m_map.getCellIdStructuresLayer(cll);
+                int idOfStructureAtCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(cll);
                 if (idOfStructureAtCell > -1) {
                     // structure hit!
                     int id = idOfStructureAtCell;
 
-                    cAbstractStructure *pStructure = game.m_pStructures[id];
+                    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[id];
                     assert(pStructure);
                     if (pStructure->getHitPoints() > 0) {
 
@@ -385,14 +385,14 @@ void cUnit::createExplosionParticle()
                 }
 
 
-                int cellType = game.m_map.getCellType(cll);
+                int cellType = game.m_gameObjectsContext->getMap().getCellType(cll);
                 if (cellType == TERRAIN_ROCK) {
                     if (cellType != TERRAIN_WALL)
-                        game.m_map.cellTakeDamage(cll, 30);
+                        game.m_gameObjectsContext->getMap().cellTakeDamage(cll, 30);
 
-                    if (game.m_map.getCellHealth(cll) < -25) {
-                        game.m_map.smudge_increase(SmudgeType::S_ROCK, cll);
-                        game.m_map.cellGiveHealth(cll, RNG::rnd(25));
+                    if (game.m_gameObjectsContext->getMap().getCellHealth(cll) < -25) {
+                        game.m_gameObjectsContext->getMap().smudge_increase(SmudgeType::S_ROCK, cll);
+                        game.m_gameObjectsContext->getMap().cellGiveHealth(cll, RNG::rnd(25));
                     }
                 }
                 else if (cellType == TERRAIN_SAND ||
@@ -400,11 +400,11 @@ void cUnit::createExplosionParticle()
                          cellType == TERRAIN_SPICE ||
                          cellType == TERRAIN_SPICEHILL) {
                     if (cellType != TERRAIN_WALL)
-                        game.m_map.cellTakeDamage(cll, 30);
+                        game.m_gameObjectsContext->getMap().cellTakeDamage(cll, 30);
 
-                    if (game.m_map.getCellHealth(cll) < -25) {
-                        game.m_map.smudge_increase(SmudgeType::S_SAND, cll);
-                        game.m_map.cellGiveHealth(cll, RNG::rnd(25));
+                    if (game.m_gameObjectsContext->getMap().getCellHealth(cll) < -25) {
+                        game.m_gameObjectsContext->getMap().smudge_increase(SmudgeType::S_SAND, cll);
+                        game.m_gameObjectsContext->getMap().cellGiveHealth(cll, RNG::rnd(25));
                     }
                 }
             }
@@ -465,7 +465,7 @@ bool cUnit::isValid() const
         return false;
 
     // invalid cell, not good
-    if (position.iCell < 0 || position.iCell >= game.m_map.getMaxCells())
+    if (position.iCell < 0 || position.iCell >= game.m_gameObjectsContext->getMap().getMaxCells())
         return false;
 
     // not marked (not dying) so do a health check. Else, don't care about health check.
@@ -801,8 +801,8 @@ void cUnit::draw()
 // TODO: only do this when iCell is updated
 void cUnit::updateCellXAndY()
 {
-    position.iCellX = game.m_map.getCellX(position.iCell);
-    position.iCellY = game.m_map.getCellY(position.iCell);
+    position.iCellX = game.m_gameObjectsContext->getMap().getCellX(position.iCell);
+    position.iCellY = game.m_gameObjectsContext->getMap().getCellY(position.iCell);
 }
 
 /**
@@ -827,7 +827,7 @@ void cUnit::attackUnit(int targetUnit, bool chaseWhenOutOfRange)
 void cUnit::attackStructure(int targetStructure)
 {
     log(std::format("attackStructure() : target is [{}]", targetStructure));
-    attack(game.m_pStructures[targetStructure]->getCell(), -1, targetStructure, -1, true);
+    attack(game.m_gameObjectsContext->getStructures()[targetStructure]->getCell(), -1, targetStructure, -1, true);
 }
 
 void cUnit::attackCell(int cell)
@@ -874,14 +874,14 @@ void cUnit::attackAt(int cell)
 {
     log(std::format("attackAt() : cell target is [{}]", cell));
 
-    if (!game.m_map.isWithinBoundaries(cell)) {
+    if (!game.m_gameObjectsContext->getMap().isWithinBoundaries(cell)) {
         log("attackAt() : Invalid cell, aborting");
         return;
     }
 
-    int unitId = game.m_map.getCellIdUnitLayer(cell);
-    int structureId = game.m_map.getCellIdStructuresLayer(cell);
-    int wormId = game.m_map.getCellIdWormsLayer(cell);
+    int unitId = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(cell);
+    int structureId = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(cell);
+    int wormId = game.m_gameObjectsContext->getMap().getCellIdWormsLayer(cell);
     log(std::format("attackAt() : cell target is [{}], structureId [{}], unitId [{}], wormId [{}]", cell, structureId, unitId, wormId));
 
     if (structureId > -1) {
@@ -927,7 +927,7 @@ void cUnit::move_to(int iCll, int iStructureIdToEnter, int iUnitIdToPickup, eUni
     iStructureID = iStructureIdToEnter;
 
     if (iStructureIdToEnter > -1) {
-        cAbstractStructure *pStructure = game.m_pStructures[iStructureIdToEnter];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[iStructureIdToEnter];
         if (!pStructure->hasUnitHeadingTowards() && !pStructure->hasUnitWithin()) {
             pStructure->unitHeadsTowardsStructure(iID);
         }
@@ -1136,9 +1136,9 @@ void cUnit::thinkActionAgnostic()
         return;
 
     // when any non-airborn, non-sandworm unit is on a spice bloom, it dies
-    int cellType = game.m_map.getCellType(position.iCell);
+    int cellType = game.m_gameObjectsContext->getMap().getCellType(position.iCell);
     if (!isAirbornUnit() && !isSandworm() && cellType == TERRAIN_BLOOM) {
-        game.m_map.detonateSpiceBloom(position.iCell);
+        game.m_gameObjectsContext->getMap().detonateSpiceBloom(position.iCell);
         die(true, false);
         return;
     }
@@ -1162,17 +1162,17 @@ void cUnit::thinkActionAgnostic()
 
 cAbstractStructure *cUnit::findClosestAvailableStructureTypeWhereNoUnitIsHeadingTo(int structureType)
 {
-    return game.m_map.findClosestAvailableStructureTypeWhereNoUnitIsHeadingTo(position.iCell, structureType, getPlayer());
+    return game.m_gameObjectsContext->getMap().findClosestAvailableStructureTypeWhereNoUnitIsHeadingTo(position.iCell, structureType, getPlayer());
 }
 
 cAbstractStructure *cUnit::findClosestAvailableStructureType(int structureType)
 {
-    return game.m_map.findClosestAvailableStructureType(position.iCell, structureType, getPlayer());
+    return game.m_gameObjectsContext->getMap().findClosestAvailableStructureType(position.iCell, structureType, getPlayer());
 }
 
 cAbstractStructure *cUnit::findClosestStructureType(int structureType)
 {
-    return game.m_map.findClosestStructureType(position.iCell, structureType, getPlayer());
+    return game.m_gameObjectsContext->getMap().findClosestStructureType(position.iCell, structureType, getPlayer());
 }
 
 void cUnit::think_carryAll()  // A carry-all has something when:
@@ -1221,7 +1221,7 @@ void cUnit::selectTargetForOrnithopter(cPlayer *pPlayer)
     int iDistance = 9999;
     int iTarget = -1;
 
-    for (int i = 0; i < game.m_Units.size(); i++) {
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
         cUnit &target = game.getUnit(i);
         if (target.isValid() && i != iID) {
             if (pPlayer->isSameTeamAs(target.getPlayer()))
@@ -1229,7 +1229,7 @@ void cUnit::selectTargetForOrnithopter(cPlayer *pPlayer)
 
             // not ours and its visible
             if (target.iPlayer != iPlayer &&
-                    game.m_map.isVisible(target.position.iCell, iPlayer) &&
+                    game.m_gameObjectsContext->getMap().isVisible(target.position.iCell, iPlayer) &&
                     !target.isAirbornUnit()) { // for now, to prevent orni's taking down carry-alls?
                 int distance = ABS_length(position.iCellX, position.iCellY, target.position.iCellX, target.position.iCellY);
 
@@ -1255,7 +1255,7 @@ void cUnit::selectTargetForOrnithopter(cPlayer *pPlayer)
         int iTarget = -1;
 
         for (int i = 0; i < MAX_STRUCTURES; i++) {
-            cAbstractStructure *pStructure = game.m_pStructures[i];
+            cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[i];
             if (!pStructure) continue;
             if (!pStructure->isValid()) continue;
 
@@ -1265,9 +1265,9 @@ void cUnit::selectTargetForOrnithopter(cPlayer *pPlayer)
 
             // not ours and its visible
             if (pStructure->getPlayerId() != iPlayer && // enemy
-                    game.m_map.isStructureVisible(pStructure, iPlayer)) {
+                    game.m_gameObjectsContext->getMap().isStructureVisible(pStructure, iPlayer)) {
                 int c = pStructure->getCell();
-                int distance = game.m_map.distance(position.iCell, c);
+                int distance = game.m_gameObjectsContext->getMap().distance(position.iCell, c);
 
                 // attack closest structure
                 if (distance < iDistance) {
@@ -1291,14 +1291,14 @@ void cUnit::think_turn_to_desired_body_facing()
     float turnspeed = game.m_infoContext->getUnitInfo(iType).turnspeed;
     if (isAirbornUnit()) {
         // when closer to goal, turnspeed decreases.
-        double distance = game.m_map.distance(position.iCell, movement.iGoalCell);
+        double distance = game.m_gameObjectsContext->getMap().distance(position.iCell, movement.iGoalCell);
         int distanceInCells = 8;
         if (distance < distanceInCells) {
             turnspeed = (turnspeed/distanceInCells) * distance;
         }
         else {
             // when close to a border, then reduce turnspeed so that orni's wont crash over the map borders
-            if ((position.iCellX < 4 || position.iCellX >= (game.m_map.getWidth()-4)) || (position.iCellY < 4 || position.iCellY >= (game.m_map.getHeight()-4))) {
+            if ((position.iCellX < 4 || position.iCellX >= (game.m_gameObjectsContext->getMap().getWidth()-4)) || (position.iCellY < 4 || position.iCellY >= (game.m_gameObjectsContext->getMap().getHeight()-4))) {
                 turnspeed = 0;
             }
         }
@@ -1350,7 +1350,7 @@ void cUnit::thinkFast_move_airUnit()
 
     movement.iNextCell = getNextCellToMoveTo();
 
-    if (!game.m_map.isValidCell(position.iCell)) {
+    if (!game.m_gameObjectsContext->getMap().isValidCell(position.iCell)) {
         die(true, false);
 
         // KILL UNITS WHO SOMEHOW GET INVALID
@@ -1359,7 +1359,7 @@ void cUnit::thinkFast_move_airUnit()
         return;
     }
 
-    if (game.m_map.isAtMapBoundaries(position.iCell)) {
+    if (game.m_gameObjectsContext->getMap().isAtMapBoundaries(position.iCell)) {
         if (!isReinforcement) {
             // let unit face directly to ideal angle, so it won't fly into its doom (out of map)
             rendering.iBodyFacing = rendering.iBodyShouldFace;
@@ -1367,16 +1367,16 @@ void cUnit::thinkFast_move_airUnit()
         }
     }
 
-    if (!game.m_map.isValidCell(movement.iNextCell))
+    if (!game.m_gameObjectsContext->getMap().isValidCell(movement.iNextCell))
         movement.iNextCell = position.iCell;
 
-    if (!game.m_map.isValidCell(movement.iGoalCell)) {
+    if (!game.m_gameObjectsContext->getMap().isValidCell(movement.iGoalCell)) {
         setGoalCell(position.iCell);
     }
 
     // same cell (no goal specified or something)
     if (movement.iNextCell == position.iCell) {
-        bool isWithinMapBoundaries = game.m_map.isWithinBoundaries(position.iCellX, position.iCellY);
+        bool isWithinMapBoundaries = game.m_gameObjectsContext->getMap().isWithinBoundaries(position.iCellX, position.iCellY);
 
         // reinforcement stuff happens here...
         if (m_transferType == eTransferType::DIE) {
@@ -1417,7 +1417,7 @@ void cUnit::thinkFast_move_airUnit()
                                 unitToPickupOrDrop.iHitPoints = -1;
 
                                 // remove unit from map id (so it wont block other units)
-                                game.m_map.cellResetIdFromLayer(position.iCell, MAPID_UNITS);
+                                game.m_gameObjectsContext->getMap().cellResetIdFromLayer(position.iCell, MAPID_UNITS);
 
                                 // now move air unit to the 'bring target'
                                 setGoalCell(iBringTarget);
@@ -1455,12 +1455,12 @@ void cUnit::thinkFast_move_airUnit()
                         lastDroppedOffCell = position.iCell; // remember this cell
 
                         // check if its valid for this unit...
-                        if (!game.m_map.occupied(position.iCell, iUnitID) && isWithinMapBoundaries) {
+                        if (!game.m_gameObjectsContext->getMap().occupied(position.iCell, iUnitID) && isWithinMapBoundaries) {
                             // valid structure
                             cAbstractStructure *structureUnitWantsToEnter = unitToPickupOrDrop.getStructureUnitWantsToEnter();
 
                             if (structureUnitWantsToEnter) {
-                                bool isAttemptingDeployingAtStructure = game.m_map.getCellIdStructuresLayer(position.iCell) == structureUnitWantsToEnter->getStructureId();
+                                bool isAttemptingDeployingAtStructure = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(position.iCell) == structureUnitWantsToEnter->getStructureId();
 
                                 if (isAttemptingDeployingAtStructure) {
                                     if (structureUnitWantsToEnter->isInProcessOfBeingEnteredOrOccupiedByUnit(unitToPickupOrDrop.iID)) {
@@ -1477,7 +1477,7 @@ void cUnit::thinkFast_move_airUnit()
                                         }
                                         else {
                                             // !?
-                                            int dropLocation = game.m_map.findNearByValidDropLocation(position.iCell, 3, unitToPickupOrDrop.iType);
+                                            int dropLocation = game.m_gameObjectsContext->getMap().findNearByValidDropLocation(position.iCell, 3, unitToPickupOrDrop.iType);
 //                                            carryAll_transferUnitTo(iUnitID, dropLocation);
                                             setGoalCell(dropLocation);
                                             iBringTarget = dropLocation;
@@ -1491,7 +1491,7 @@ void cUnit::thinkFast_move_airUnit()
                             unitToPickupOrDrop.setCell(position.iCell);
                             unitToPickupOrDrop.setGoalCell(position.iCell);
                             unitToPickupOrDrop.updateCellXAndY(); // update cellx and celly
-                            game.m_map.cellSetIdForLayer(position.iCell, MAPID_UNITS, iUnitID);
+                            game.m_gameObjectsContext->getMap().cellSetIdForLayer(position.iCell, MAPID_UNITS, iUnitID);
 
                             unitToPickupOrDrop.iHitPoints = unitToPickupOrDrop.iTempHitPoints;
                             unitToPickupOrDrop.iTempHitPoints = -1;
@@ -1507,8 +1507,7 @@ void cUnit::thinkFast_move_airUnit()
                             unitToPickupOrDrop.rendering.iBodyShouldFace = rendering.iBodyShouldFace;
 
                             // clear spot
-                            game.m_map.clearShroud(position.iCell, unitToPickupOrDrop.getUnitInfo().sight, iPlayer);
-
+            game.m_gameObjectsContext->getMap().clearShroud(position.iCell, unitToPickupOrDrop.getUnitInfo().sight, iPlayer);
                             int unitIdOfUnitThatHasBeenPickedUp = iUnitID;
 
                             iUnitID = -1;         // reset this
@@ -1548,15 +1547,15 @@ void cUnit::thinkFast_move_airUnit()
             // bring a new unit
 
             if (iType == FRIGATE) {
-                int iStrucId = game.m_map.getCellIdStructuresLayer(position.iCell);
+                int iStrucId = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(position.iCell);
 
                 if (iStrucId > -1) {
                     setGoalCell(iFindCloseBorderCell(position.iCell));
                     m_transferType = eTransferType::DIE;
 
-                    game.m_pStructures[iStrucId]->setFrame(4); // show package on this structure
-                    game.m_pStructures[iStrucId]->setAnimating(true); // keep animating
-                    dynamic_cast<cStarPort *>(game.m_pStructures[iStrucId])->setFrigateDroppedPackage(true);
+                    game.m_gameObjectsContext->getStructures()[iStrucId]->setFrame(4); // show package on this structure
+                    game.m_gameObjectsContext->getStructures()[iStrucId]->setAnimating(true); // keep animating
+                    dynamic_cast<cStarPort *>(game.m_gameObjectsContext->getStructures()[iStrucId])->setFrigateDroppedPackage(true);
                 }
                 else {
                     // we don't expect this to go wrong :/
@@ -1576,10 +1575,10 @@ void cUnit::thinkFast_move_airUnit()
                 return; // override for frigates
             }
 
-            bool canDeployAtCell = game.m_map.occupied(position.iCell, iID) == false;
+            bool canDeployAtCell = game.m_gameObjectsContext->getMap().occupied(position.iCell, iID) == false;
 
             if (iNewUnitType > -1) {
-                canDeployAtCell = game.m_map.canDeployUnitAtCell(position.iCell, iID);
+                canDeployAtCell = game.m_gameObjectsContext->getMap().canDeployUnitAtCell(position.iCell, iID);
             }
 
             // first check if this cell is clear
@@ -1589,7 +1588,7 @@ void cUnit::thinkFast_move_airUnit()
                     int id = cUnits::unitCreate(position.iCell, iNewUnitType, iPlayer, true, isReinforcement);
 
                     if (id > -1) {
-                        game.m_map.cellSetIdForLayer(position.iCell, MAPID_UNITS, id);
+                        game.m_gameObjectsContext->getMap().cellSetIdForLayer(position.iCell, MAPID_UNITS, id);
                     }
                 }
 
@@ -1624,7 +1623,7 @@ void cUnit::thinkFast_move_airUnit()
         if (cell < 0) {
             cell = getPlayer()->getFocusCell();
         }
-        setGoalCell(game.m_map.getRandomCellFromWithRandomDistance(cell, 12));
+        setGoalCell(game.m_gameObjectsContext->getMap().getRandomCellFromWithRandomDistance(cell, 12));
         return;
     }
 
@@ -1632,8 +1631,8 @@ void cUnit::thinkFast_move_airUnit()
     moveTimer.increment();
 
     // now move
-    int goalCellX = game.m_map.getCellX(movement.iGoalCell);
-    int goalCellY = game.m_map.getCellY(movement.iGoalCell);
+    int goalCellX = game.m_gameObjectsContext->getMap().getCellX(movement.iGoalCell);
+    int goalCellY = game.m_gameObjectsContext->getMap().getCellY(movement.iGoalCell);
 
     // use this when picking something up
     if (iUnitID > -1 || (m_transferType != eTransferType::DIE && m_transferType != eTransferType::NONE)) {
@@ -1647,7 +1646,7 @@ void cUnit::thinkFast_move_airUnit()
             float slowDownStep = maxSlowDown / dist;
             if (iLength < dist) {
                 if (RNG::rnd(100) < 5) {
-                    int cellType = game.m_map.getCellType(position.iCell);
+                    int cellType = game.m_gameObjectsContext->getMap().getCellType(position.iCell);
                     if (cellType == TERRAIN_SAND ||
                             cellType == TERRAIN_SPICE ||
                             cellType == TERRAIN_HILL ||
@@ -1735,7 +1734,7 @@ void cUnit::thinkFast_move_airUnit()
 
     rendering.iHeadFacing = f;
 
-    game.m_map.cellResetIdFromLayer(position.iCell, MAPID_AIR);
+    game.m_gameObjectsContext->getMap().cellResetIdFromLayer(position.iCell, MAPID_AIR);
 
 //    int movespeed = getUnitInfo().speed;
     int movespeed = 2; // 2 pixels, the actual 'speed' is done by the delay above using TIMER_move! :/
@@ -1748,7 +1747,7 @@ void cUnit::thinkFast_move_airUnit()
     position.iCell = game.m_mapCamera->getCellFromAbsolutePosition(pos_x_centered(), pos_y_centered());
 
     updateCellXAndY();
-    game.m_map.cellSetIdForLayer(position.iCell, MAPID_AIR, iID);
+    game.m_gameObjectsContext->getMap().cellSetIdForLayer(position.iCell, MAPID_AIR, iID);
 }
 
 void cUnit::setPosX(float newVal)
@@ -1756,7 +1755,7 @@ void cUnit::setPosX(float newVal)
     float diff = newVal - position.posX;
     position.posX = newVal;
     if (boundParticleId > -1) {
-        cParticle &pParticle = game.m_particles[boundParticleId];
+        cParticle &pParticle = game.m_gameObjectsContext->getParticles()[boundParticleId];
         pParticle.addPosX(diff);
     }
 }
@@ -1766,7 +1765,7 @@ void cUnit::setPosY(float newVal)
     float diff = newVal - position.posY;
     position.posY = newVal;
     if (boundParticleId > -1) {
-        cParticle &pParticle = game.m_particles[boundParticleId];
+        cParticle &pParticle = game.m_gameObjectsContext->getParticles()[boundParticleId];
         pParticle.addPosY(diff);
     }
 }
@@ -1788,7 +1787,7 @@ cAbstractStructure *cUnit::getStructureUnitWantsToEnter() const
 {
     cAbstractStructure *structureUnitWantsToEnter = nullptr;
     if (iStructureID > -1) {
-        structureUnitWantsToEnter = game.m_pStructures[iStructureID];
+        structureUnitWantsToEnter = game.m_gameObjectsContext->getStructures()[iStructureID];
         if (structureUnitWantsToEnter && !structureUnitWantsToEnter->isValid()) {
             structureUnitWantsToEnter = nullptr;
         }
@@ -1798,12 +1797,12 @@ cAbstractStructure *cUnit::getStructureUnitWantsToEnter() const
 
 int cUnit::findNewDropLocation(int unitTypeToDrop, int cell) const
 {
-    int dropLocation = game.m_map.findNearByValidDropLocation(cell, 4, unitTypeToDrop);
+    int dropLocation = game.m_gameObjectsContext->getMap().findNearByValidDropLocation(cell, 4, unitTypeToDrop);
     if (dropLocation < 0) {
-        dropLocation = game.m_map.findNearByValidDropLocation(cell, 8, unitTypeToDrop);
+        dropLocation = game.m_gameObjectsContext->getMap().findNearByValidDropLocation(cell, 8, unitTypeToDrop);
     }
     if (dropLocation < 0) {
-        dropLocation = game.m_map.findNearByValidDropLocation(cell, 16, unitTypeToDrop);
+        dropLocation = game.m_gameObjectsContext->getMap().findNearByValidDropLocation(cell, 16, unitTypeToDrop);
     }
     return dropLocation;
 }
@@ -1883,7 +1882,7 @@ void cUnit::shoot(int iTargetCell)
     int bulletType = unitInfo.bulletType;
     // if secondary fire is configured properly
     if (unitInfo.fireSecondaryWithinRange > -1 && unitInfo.bulletTypeSecondary > -1) {
-        if (game.m_map.distance(position.iCell, iTargetCell) <= unitInfo.fireSecondaryWithinRange) {
+        if (game.m_gameObjectsContext->getMap().distance(position.iCell, iTargetCell) <= unitInfo.fireSecondaryWithinRange) {
             bulletType = unitInfo.bulletTypeSecondary;
         }
     }
@@ -1899,8 +1898,8 @@ void cUnit::shoot(int iTargetCell)
         if (attackUnit && !attackUnit->isValid()) {
             // allowing homing bullets towards air units from the ground
             if (iBull > -1 && attackUnit->isAirbornUnit()) {
-                game.m_Bullets[iBull].iHoming = combat.iAttackUnit;
-                game.m_Bullets[iBull].TIMER_homing = 200;
+                game.m_gameObjectsContext->getBullets()[iBull].iHoming = combat.iAttackUnit;
+                game.m_gameObjectsContext->getBullets()[iBull].TIMER_homing = 200;
             }
         }
     }
@@ -1987,10 +1986,10 @@ void cUnit::think_hit(int iShotUnit, int iShotStructure)
                             double distance = 9999;
                             if (movement.iGoalCell != position.iCell && m_action == eActionType::MOVE) {
                                 // moving towards a goal already
-                                distance = game.m_map.distance(position.iCell, unitCellWhichShotMe);
+                                distance = game.m_gameObjectsContext->getMap().distance(position.iCell, unitCellWhichShotMe);
                             }
                             // found a unit closer to squish, so move towards it
-                            if (distance < game.m_map.distance(position.iCell, movement.iGoalCell)) {
+                            if (distance < game.m_gameObjectsContext->getMap().distance(position.iCell, movement.iGoalCell)) {
                                 // AI tries to run over infantry units that attack it
                                 move_to(unitCellWhichShotMe);
                             }
@@ -1999,7 +1998,7 @@ void cUnit::think_hit(int iShotUnit, int iShotStructure)
                     else {
                         if (!unitWhoShotMeIsAirborn) {
                             if (isSandworm()) {
-                                if (game.m_map.isCellPassableForWorm(unitWhoShotMe.position.iCell)) {
+                                if (game.m_gameObjectsContext->getMap().isCellPassableForWorm(unitWhoShotMe.position.iCell)) {
                                     attackUnit(iShotUnit);
                                 }
                                 else {
@@ -2022,14 +2021,14 @@ void cUnit::think_hit(int iShotUnit, int iShotStructure)
                             iDestCell = game.getUnit(combat.iAttackUnit).position.iCell;
 
                         if (combat.iAttackStructure > -1) {
-                            cAbstractStructure *pStructure = game.m_pStructures[combat.iAttackStructure];
+                            cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[combat.iAttackStructure];
                             // it can become null, so check!
                             if (pStructure && pStructure->isValid()) {
                                 iDestCell = pStructure->getCell();
                             }
                         }
 
-                        if (game.m_map.distance(position.iCell, iDestCell) < getRange()) {
+                        if (game.m_gameObjectsContext->getMap().distance(position.iCell, iDestCell) < getRange()) {
                             // within range, don't move (just prepare retaliation fire)
                         }
                         else {
@@ -2124,7 +2123,7 @@ void cUnit::think_attack()
 
     cAbstractStructure *pStructure = nullptr;
     if (combat.iAttackStructure > -1) {
-        pStructure = game.m_pStructures[combat.iAttackStructure];
+        pStructure = game.m_gameObjectsContext->getStructures()[combat.iAttackStructure];
         if (pStructure && pStructure->isValid()) {
             setGoalCell(pStructure->getCell());
         }
@@ -2147,11 +2146,11 @@ void cUnit::think_attack()
         setGoalCell(combat.iAttackCell);
 
         bool isBloomOrWallTerrain =
-            game.m_map.getCellType(combat.iAttackCell) == TERRAIN_BLOOM || game.m_map.getCellType(combat.iAttackCell) == TERRAIN_WALL;
+            game.m_gameObjectsContext->getMap().getCellType(combat.iAttackCell) == TERRAIN_BLOOM || game.m_gameObjectsContext->getMap().getCellType(combat.iAttackCell) == TERRAIN_WALL;
 
         if (isBloomOrWallTerrain) {
             // stop attacking a spice bloom or a wall when it got destroyed
-            if (game.m_map.getCellHealth(combat.iAttackCell) < 0) {
+            if (game.m_gameObjectsContext->getMap().getCellHealth(combat.iAttackCell) < 0) {
                 actionGuard();
                 return;
             }
@@ -2166,7 +2165,7 @@ void cUnit::think_attack()
     }
 
     // Distance check
-    int distance = game.m_map.distance(position.iCell, movement.iGoalCell);
+    int distance = game.m_gameObjectsContext->getMap().distance(position.iCell, movement.iGoalCell);
 
     if (isAirbornUnit()) {
         // AIRBORN UNITS ATTACK THINKING
@@ -2175,14 +2174,14 @@ void cUnit::think_attack()
         if (distance > minDistance && distance <= getRange()) {
             // when this function returns true, it is done firing bullets
             if (setAngleTowardsTargetAndFireBullets(distance)) {
-                int randomCellFrom = game.m_map.getRandomCellFrom(movement.iGoalCell, 16);
-                int rx = game.m_map.getCellX(randomCellFrom);
-                int ry = game.m_map.getCellY(randomCellFrom);
+                int randomCellFrom = game.m_gameObjectsContext->getMap().getRandomCellFrom(movement.iGoalCell, 16);
+                int rx = game.m_gameObjectsContext->getMap().getCellX(randomCellFrom);
+                int ry = game.m_gameObjectsContext->getMap().getCellY(randomCellFrom);
 
                 combat.iAttackUnit = -1;
                 combat.iAttackStructure = -1;
                 setAction(eActionType::MOVE);
-                setGoalCell(game.m_map.getGeometry().getCellWithMapDimensions(rx, ry));
+                setGoalCell(game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapDimensions(rx, ry));
             }
         }
         else {
@@ -2271,7 +2270,7 @@ void cUnit::think_attack_sandworm()
         return;
     }
 
-    if (attackUnit->isIdle() && !game.m_map.isCellPassableForWorm(attackUnit->position.iCell)) {
+    if (attackUnit->isIdle() && !game.m_gameObjectsContext->getMap().isCellPassableForWorm(attackUnit->position.iCell)) {
         // forget about unit that is not reachable
         actionGuard();
         return;
@@ -2291,7 +2290,7 @@ void cUnit::actionGuard()
 
 int cUnit::getFaceAngleToCell(int cell) const
 {
-    int d = fDegrees(position.iCellX, position.iCellY, game.m_map.getCellX(cell), game.m_map.getCellY(cell));
+    int d = fDegrees(position.iCellX, position.iCellY, game.m_gameObjectsContext->getMap().getCellX(cell), game.m_gameObjectsContext->getMap().getCellY(cell));
     return faceAngle(d); // get the angle
 }
 
@@ -2343,8 +2342,8 @@ bool cUnit::setAngleTowardsTargetAndFireBullets(int distance)
 
             if (iType == LAUNCHER || iType == DEVIATOR) {
                 if (distance < unitType.range) {
-                    int dx = game.m_map.getCellX(shootCell);
-                    int dy = game.m_map.getCellY(shootCell);
+                    int dx = game.m_gameObjectsContext->getMap().getCellX(shootCell);
+                    int dy = game.m_gameObjectsContext->getMap().getCellY(shootCell);
 
                     int inaccuracy = ((unitType.range - distance) / 3) + 1; // at 'perfect' range, we always have a inaccuracy of 1 at minimum
 
@@ -2354,7 +2353,7 @@ bool cUnit::setAngleTowardsTargetAndFireBullets(int distance)
                     dy -= inaccuracy;
                     dy += RNG::rnd((inaccuracy * 2)+1); // we need + 1, because it is 'until'
 
-                    shootCell = game.m_map.getGeometry().getCellWithMapDimensions(dx, dy);
+                    shootCell = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapDimensions(dx, dy);
                 }
             }
 
@@ -2453,8 +2452,8 @@ void cUnit::thinkFast_move()
                     // simply failed
                     if (iResult == -1) {
                         // Check why, is our goal cell occupied?
-                        int uID = game.m_map.getCellIdUnitLayer(movement.iGoalCell);
-                        int sID = game.m_map.getCellIdStructuresLayer(movement.iGoalCell);
+                        int uID = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(movement.iGoalCell);
+                        int sID = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(movement.iGoalCell);
 
                         // Other unit is on goal cell, do something about it.
 
@@ -2553,7 +2552,7 @@ void cUnit::thinkFast_move()
     // check
     bool bOccupied = false;
 
-    int idOfUnitAtNextCell = game.m_map.getCellIdUnitLayer(movement.iNextCell);
+    int idOfUnitAtNextCell = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(movement.iNextCell);
 
     // Cell is occupied, not by self, so it is occupied...
     if (idOfUnitAtNextCell > -1 &&
@@ -2575,7 +2574,7 @@ void cUnit::thinkFast_move()
     }
 
     // structure is NOT matching our structure ID, then its blocking us
-    int idOfStructureAtNextCell = game.m_map.getCellIdStructuresLayer(movement.iNextCell);
+    int idOfStructureAtNextCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(movement.iNextCell);
 
     if (idOfStructureAtNextCell > -1) {
         if (iStructureID < 0) {
@@ -2585,7 +2584,7 @@ void cUnit::thinkFast_move()
         else if (iStructureID > -1) {
             if (iStructureID == idOfStructureAtNextCell) {
                 // it is the structure this unit intents to go to...
-                cAbstractStructure *pStructure = game.m_pStructures[iStructureID];
+                cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[iStructureID];
                 // we may enter, only if its empty
                 if (pStructure && pStructure->isValid()) {
                     // repair/spice unloading structures can only 'contain' ONE unit. So if it is occupied, find another.
@@ -2658,7 +2657,7 @@ void cUnit::thinkFast_move()
         }
     }
 
-    int cellTypeAtNextCell = game.m_map.getCellType(movement.iNextCell);
+    int cellTypeAtNextCell = game.m_gameObjectsContext->getMap().getCellType(movement.iNextCell);
     if (!isInfantryUnit()) {
         if (cellTypeAtNextCell == TERRAIN_MOUNTAIN) {
             bOccupied = true;
@@ -2720,12 +2719,12 @@ void cUnit::thinkFast_move()
         if (result == eUnitMoveToCellResult::MOVERESULT_AT_GOALCELL ||
                 result == eUnitMoveToCellResult::MOVERESULT_AT_CELL) {
             // not occupied cell;
-            int idOfStructureAtCurrentCell = game.m_map.getCellIdStructuresLayer(position.iCell);
+            int idOfStructureAtCurrentCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(position.iCell);
 
             // we wanted to enter this structure
             if (iStructureID > -1 &&
                     idOfStructureAtCurrentCell > -1 && idOfStructureAtCurrentCell == iStructureID) {
-                cAbstractStructure *pStructure = game.m_pStructures[iStructureID];
+                cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[iStructureID];
                 if (pStructure && pStructure->isValid()) {
                     if (intent == eUnitActionIntent::INTENT_REPAIR ||
                             intent == eUnitActionIntent::INTENT_UNLOAD_SPICE) {
@@ -2779,8 +2778,8 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
     int bToLeft = -1;         // 0 = go left, 1 = go right
     int bToDown = -1;         // 0 = go down, 1 = go up
 
-    int iNextX = game.m_map.getCellX(movement.iNextCell);
-    int iNextY = game.m_map.getCellY(movement.iNextCell);
+    int iNextX = game.m_gameObjectsContext->getMap().getCellX(movement.iNextCell);
+    int iNextY = game.m_gameObjectsContext->getMap().getCellY(movement.iNextCell);
 
     // Compare X, Y coordinates
     if (iNextX < position.iCellX)
@@ -2802,8 +2801,8 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
 
 
     // Influenced by the terrain type
-    int cellType = game.m_map.getCellType(position.iCell);
-    int iSlowDown = game.m_map.getCellSlowDown(position.iCell);
+    int cellType = game.m_gameObjectsContext->getMap().getCellType(position.iCell);
+    int iSlowDown = game.m_gameObjectsContext->getMap().getCellSlowDown(position.iCell);
 
     cPlayerDifficultySettings *difficultySettings = game.getPlayer(iPlayer).getDifficultySettings();
     if (moveTimer.get() < ((difficultySettings->getMoveSpeed(iType, iSlowDown)))) {
@@ -2815,10 +2814,10 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
     // from here on, set the map id, so no other unit can take its place
     if (!isSandworm()) {
         // note, no AIRBORN here (27/03/2021 - I guess this is because this method is not called by thinkFast_move_airUnit())
-        game.m_map.cellSetIdForLayer(movement.iNextCell, MAPID_UNITS, iID);
+        game.m_gameObjectsContext->getMap().cellSetIdForLayer(movement.iNextCell, MAPID_UNITS, iID);
     }
     else {
-        game.m_map.cellSetIdForLayer(movement.iNextCell, MAPID_WORMS, iID);
+        game.m_gameObjectsContext->getMap().cellSetIdForLayer(movement.iNextCell, MAPID_WORMS, iID);
     }
 
     // 100% on cell, no offset
@@ -2909,10 +2908,10 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
 
         // movement to cell complete
         if (isSandworm()) {
-            game.m_map.cellResetIdFromLayer(position.iCell, MAPID_WORMS);
+            game.m_gameObjectsContext->getMap().cellResetIdFromLayer(position.iCell, MAPID_WORMS);
         }
         else {
-            game.m_map.cellResetIdFromLayer(position.iCell, MAPID_UNITS);
+            game.m_gameObjectsContext->getMap().cellResetIdFromLayer(position.iCell, MAPID_UNITS);
         }
 
         setCell(movement.iNextCell);
@@ -2926,7 +2925,7 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
         // this). An alternative is to have a function return per 'segment' the units within it (so we don't need to
         // iterate over all units)
         if (canSquishInfantry()) {
-            for (int iq = 0; iq < game.m_Units.size(); iq++) {
+            for (int iq = 0; iq < game.m_gameObjectsContext->getUnits().size(); iq++) {
                 cUnit &potentialDeadUnit = game.getUnit(iq);
                 if (iq == iID) continue; // skip self
                 if (!potentialDeadUnit.isValid()) continue;
@@ -2946,10 +2945,10 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
         if (iPlayer == AI_CPU5 && game.getPlayer(HUMAN).isHouse(ATREIDES)) {
             // TODO: make this work for all allied forces
             // hackish way to get Fog of war clearance by allied fremen units (super weapon).
-            game.m_map.clearShroud(position.iCell, game.m_infoContext->getUnitInfo(iType).sight, HUMAN);
+            game.m_gameObjectsContext->getMap().clearShroud(position.iCell, game.m_infoContext->getUnitInfo(iType).sight, HUMAN);
         }
 
-        game.m_map.clearShroud(position.iCell, game.m_infoContext->getUnitInfo(iType).sight, iPlayer);
+        game.m_gameObjectsContext->getMap().clearShroud(position.iCell, game.m_infoContext->getUnitInfo(iType).sight, iPlayer);
 
         // The goal did change probably, or something else forces us to reconsider
         if (movement.bCalculateNewPath) {
@@ -3086,12 +3085,12 @@ void cUnit::move_to(int iGoalCell)
     int structureID = -1;
     int unitID = -1;
     if (iGoalCell > -1) {
-        structureID = game.m_map.getCellIdStructuresLayer(iGoalCell);
-        unitID = game.m_map.getCellIdUnitLayer(iGoalCell);
+        structureID = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(iGoalCell);
+        unitID = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(iGoalCell);
     }
 
     if (structureID > -1) {
-        cAbstractStructure *pStructure = game.m_pStructures[structureID];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[structureID];
         if (pStructure && pStructure->isValid()) {
             bool friendlyStructure = getPlayer()->isSameTeamAs(pStructure->getPlayer());
             if (friendlyStructure) {
@@ -3131,8 +3130,8 @@ void cUnit::move_to(int iGoalCell)
 void cUnit::setCell(int cll)
 {
     this->position.iCell = cll;
-    setPosX(game.m_map.getAbsoluteXPositionFromCell(cll));
-    setPosY(game.m_map.getAbsoluteYPositionFromCell(cll));
+    setPosX(game.m_gameObjectsContext->getMap().getAbsoluteXPositionFromCell(cll));
+    setPosY(game.m_gameObjectsContext->getMap().getAbsoluteYPositionFromCell(cll));
 }
 
 void cUnit::assignMission(int aMission)
@@ -3194,14 +3193,14 @@ std::string cUnit::eUnitActionIntentString(eUnitActionIntent intent)
  */
 bool cUnit::isUnableToMove()
 {
-    if (game.m_map.occupied(game.m_map.getCellLeft(position.iCell), iID) &&
-            game.m_map.occupied(game.m_map.getCellRight(position.iCell), iID) &&
-            game.m_map.occupied(game.m_map.getCellAbove(position.iCell), iID) &&
-            game.m_map.occupied(game.m_map.getCellBelow(position.iCell), iID) &&
-            game.m_map.occupied(game.m_map.getCellLowerLeft(position.iCell), iID) &&
-            game.m_map.occupied(game.m_map.getCellLowerRight(position.iCell), iID) &&
-            game.m_map.occupied(game.m_map.getCellUpperRight(position.iCell), iID) &&
-            game.m_map.occupied(game.m_map.getCellUpperLeft(position.iCell), iID)) {
+    if (game.m_gameObjectsContext->getMap().occupied(game.m_gameObjectsContext->getMap().getCellLeft(position.iCell), iID) &&
+            game.m_gameObjectsContext->getMap().occupied(game.m_gameObjectsContext->getMap().getCellRight(position.iCell), iID) &&
+            game.m_gameObjectsContext->getMap().occupied(game.m_gameObjectsContext->getMap().getCellAbove(position.iCell), iID) &&
+            game.m_gameObjectsContext->getMap().occupied(game.m_gameObjectsContext->getMap().getCellBelow(position.iCell), iID) &&
+            game.m_gameObjectsContext->getMap().occupied(game.m_gameObjectsContext->getMap().getCellLowerLeft(position.iCell), iID) &&
+            game.m_gameObjectsContext->getMap().occupied(game.m_gameObjectsContext->getMap().getCellLowerRight(position.iCell), iID) &&
+            game.m_gameObjectsContext->getMap().occupied(game.m_gameObjectsContext->getMap().getCellUpperRight(position.iCell), iID) &&
+            game.m_gameObjectsContext->getMap().occupied(game.m_gameObjectsContext->getMap().getCellUpperLeft(position.iCell), iID)) {
         return true;
     }
 
@@ -3303,7 +3302,7 @@ eHeadTowardsStructureResult cUnit::findBestStructureCandidateAndHeadTowardsItOrW
 
         // try to get a carry-all to help when a bit bigger distance
         int distanceWeAllowDriving = 4;
-        if (game.m_map.distance(position.iCell, destCell) > distanceWeAllowDriving) {
+        if (game.m_gameObjectsContext->getMap().distance(position.iCell, destCell) > distanceWeAllowDriving) {
             if (findAndOrderCarryAllToBringMeToStructureAtCell(pStructure, destCell)) {
                 return eHeadTowardsStructureResult::SUCCESS_AWAITING_CARRYALL;
             }
@@ -3430,7 +3429,7 @@ void cUnit::takeDamage(int damage, int unitWhoDealsDamage, int structureWhoDeals
                 }
             }
             else if (structureWhoDealsDamage > -1) {
-                cAbstractStructure *pStructure = game.m_pStructures[structureWhoDealsDamage];
+                cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[structureWhoDealsDamage];
                 if (pStructure) { // can be NULL (destroyed after firing this bullet)
                     originId = structureWhoDealsDamage;
                     originType = eBuildType::STRUCTURE;
@@ -3491,15 +3490,15 @@ void cUnit::thinkFast_guard_sandworm()
     int iDistance = 9999;
     int unitIdToAttack = -1;
 
-    for (int i = 0; i < game.m_Units.size(); i++) {
-        cUnit &potentialDinner = game.getUnit(i);
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        cUnit &potentialDinner = game.m_gameObjectsContext->getUnits()[i];
         if (i == iID) continue;
         if (!potentialDinner.isValid()) continue;
         if (potentialDinner.getPlayer()->isSameTeamAs(getPlayer())) continue;
         if (potentialDinner.isAirbornUnit()) continue;
         if (potentialDinner.isSandworm()) continue; // don't eat other worms
 
-        double distance = game.m_map.distance(position.iCell, potentialDinner.position.iCell);
+        double distance = game.m_gameObjectsContext->getMap().distance(position.iCell, potentialDinner.position.iCell);
 
         if (distance <= getSight() && distance < iDistance) {
             iDistance = distance;
@@ -3542,16 +3541,16 @@ int cUnit::findNearbyGroundUnitToAttack(int range)
     int iDistance = 9999;
     int unitIdToAttack = -1;
 
-    for (int i = 0; i < game.m_Units.size(); i++) {
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
         if (i == iID) continue; // skip self
-        cUnit &potentialThreat = game.getUnit(i);
+        cUnit &potentialThreat = game.m_gameObjectsContext->getUnits()[i];
         if (!potentialThreat.isValid()) continue;
         if (potentialThreat.belongsTo(getPlayer())) continue; // skip own units
         if (potentialThreat.isAirbornUnit()) continue; // skip all airborn units (only focus on ground units)
         if (getPlayer()->isSameTeamAs(potentialThreat.getPlayer())) continue; // skip same team players / allies
-        if (!game.m_map.isVisible(potentialThreat.position.iCell, iPlayer)) continue; // skip non-visible potential enemy units
+        if (!game.m_gameObjectsContext->getMap().isVisible(potentialThreat.position.iCell, iPlayer)) continue; // skip non-visible potential enemy units
 
-        int distance = game.m_map.distance(position.iCell, potentialThreat.position.iCell);
+        int distance = game.m_gameObjectsContext->getMap().distance(position.iCell, potentialThreat.position.iCell);
 
         if (distance <= range && distance < iDistance) {
             iDistance = distance;
@@ -3567,17 +3566,17 @@ int cUnit::findNearbyAirUnitToAttack(int range)
     int iDistance = 9999;
     int airUnitToAttack = -1;
 
-    for (int i = 0; i < game.m_Units.size(); i++) {
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
         if (i == iID) continue; // skip self
-        cUnit &potentialThreat = game.getUnit(i);
+        cUnit &potentialThreat = game.m_gameObjectsContext->getUnits()[i];
         if (!potentialThreat.isValid()) continue;
         if (!potentialThreat.isAirbornUnit()) continue; // skip all non-airborn units right away
         if (potentialThreat.getPlayerId() == getPlayerId()) continue; // skip own units
         if (getPlayer()->isSameTeamAs(potentialThreat.getPlayer())) continue; // skip same team players / allies
         if (!potentialThreat.isAttackableAirUnit()) continue;
-        if (!game.m_map.isVisible(potentialThreat.position.iCell, iPlayer)) continue; // skip non-visible potential enemy units
+        if (!game.m_gameObjectsContext->getMap().isVisible(potentialThreat.position.iCell, iPlayer)) continue; // skip non-visible potential enemy units
 
-        int distance = game.m_map.distance(position.iCell, potentialThreat.position.iCell);
+        int distance = game.m_gameObjectsContext->getMap().distance(position.iCell, potentialThreat.position.iCell);
 
         if (distance <= range &&
                 distance < iDistance) { // closer than found thus far
@@ -3599,18 +3598,18 @@ int cUnit::findNearbyStructureThatCanDamageUnitsToAttack(int range)
     int iDistance = 9999;
 
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *pStructure = game.m_pStructures[i];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[i];
         if (!pStructure) continue;
         if (!pStructure->isValid()) continue;
         if (getPlayer()->isSameTeamAs(pStructure->getPlayer())) continue;
-        if (!game.m_map.isStructureVisible(pStructure, iPlayer)) continue; // not visible
+        if (!game.m_gameObjectsContext->getMap().isStructureVisible(pStructure, iPlayer)) continue; // not visible
 
         // ignore structures which cannot attack air or ground units
         if (!pStructure->canAttackAirUnits()) continue;
         if (!pStructure->canAttackGroundUnits()) continue;
 
         // see big comment about this in findNearbyStructureToAttack
-        int distance = game.m_map.distance(position.iCell, pStructure->getRandomStructureCell());
+        int distance = game.m_gameObjectsContext->getMap().distance(position.iCell, pStructure->getRandomStructureCell());
 
         if (distance <= range && distance < iDistance) {
             iDistance = distance;
@@ -3631,11 +3630,11 @@ int cUnit::findNearbyStructureToAttack(int range)
     int iDistance = 9999;
 
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *pStructure = game.m_pStructures[i];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[i];
         if (!pStructure) continue;
         if (!pStructure->isValid()) continue;
         if (getPlayer()->isSameTeamAs(pStructure->getPlayer())) continue;
-        if (!game.m_map.isStructureVisible(pStructure, iPlayer)) continue; // not visible
+        if (!game.m_gameObjectsContext->getMap().isStructureVisible(pStructure, iPlayer)) continue; // not visible
 
         // TODO: this is a bit tricky and hacky
         // basically you want to check against the 'closest' cell from that structure.
@@ -3653,7 +3652,7 @@ int cUnit::findNearbyStructureToAttack(int range)
         // cells to evaluate. For every unit * 10 = 240 cells to evaluate.
         //
         // Regardless, this is something to think about. There are probably better/smarter ways to do this.
-        int distance = game.m_map.distance(position.iCell, pStructure->getRandomStructureCell());
+        int distance = game.m_gameObjectsContext->getMap().distance(position.iCell, pStructure->getRandomStructureCell());
 
         if (distance <= range && distance < iDistance) {
             iDistance = distance;
@@ -3675,7 +3674,7 @@ void cUnit::think_harvester()
 
     // cell = goal cell (doing nothing)
     if (position.iCell == movement.iGoalCell) {
-        int cellType = game.m_map.getCellType(position.iCell);
+        int cellType = game.m_gameObjectsContext->getMap().getCellType(position.iCell);
         // when on spice, harvest
         if (cellType == TERRAIN_SPICE ||
                 cellType == TERRAIN_SPICEHILL) {
@@ -3712,22 +3711,22 @@ void cUnit::think_harvester()
                 rendering.iFrame = 1;
 
             iCredits += game.m_infoContext->getUnitInfo(iType).harvesting_amount;
-            game.m_map.cellTakeCredits(position.iCell, game.m_infoContext->getUnitInfo(iType).harvesting_amount);
+            game.m_gameObjectsContext->getMap().cellTakeCredits(position.iCell, game.m_infoContext->getUnitInfo(iType).harvesting_amount);
 
             // turn into sand/spice (when spicehill)
-            if (game.m_map.getCellCredits(position.iCell) <= 0) {
+            if (game.m_gameObjectsContext->getMap().getCellCredits(position.iCell) <= 0) {
                 if (cellType == TERRAIN_SPICEHILL) {
-                    game.m_map.cellChangeType(position.iCell, TERRAIN_SPICE);
-                    game.m_map.cellGiveCredits(position.iCell, RNG::rnd(100));
+                    game.m_gameObjectsContext->getMap().cellChangeType(position.iCell, TERRAIN_SPICE);
+                    game.m_gameObjectsContext->getMap().cellGiveCredits(position.iCell, RNG::rnd(100));
                 }
                 else {
-                    game.m_map.cellChangeType(position.iCell, TERRAIN_SAND);
-                    game.m_map.cellChangeTile(position.iCell, 0);
+                    game.m_gameObjectsContext->getMap().cellChangeType(position.iCell, TERRAIN_SAND);
+                    game.m_gameObjectsContext->getMap().cellChangeTile(position.iCell, 0);
                 }
 
                 move_to(findHarvestSpot(iID), -1, -1);
 
-                cMapEditor(game.m_map).smoothAroundCell(position.iCell);
+                cMapEditor(game.m_gameObjectsContext->getMap()).smoothAroundCell(position.iCell);
             }
         }
 
@@ -3763,7 +3762,7 @@ void cUnit::retreatToNearbyBase()
         return;
     }
     const sEntityForDistance &closest = result[0];
-    cAbstractStructure *pStructure = game.m_pStructures[closest.entityId];
+    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[closest.entityId];
     // use the 'drop location' function, as it will circle around a given cell until a valid cell is found
     int cellToRetreatTo = findNewDropLocation(iType, pStructure->getCell());
 
@@ -3850,14 +3849,14 @@ int cUnit::findHarvestSpot(int id)
     int TargetSpiceHillDistance = 40;
 
 
-    for (int i = 0; i < game.m_map.getMaxCells(); i++)
-        if (game.m_map.getCellCredits(i) > 0 && i != cUnit.getCell()) {
+    for (int i = 0; i < game.m_gameObjectsContext->getMap().getMaxCells(); i++)
+        if (game.m_gameObjectsContext->getMap().getCellCredits(i) > 0 && i != cUnit.getCell()) {
             // check if its not out of reach
-            int dx = game.m_map.getCellX(i);
-            int dy = game.m_map.getCellY(i);
+            int dx = game.m_gameObjectsContext->getMap().getCellX(i);
+            int dy = game.m_gameObjectsContext->getMap().getCellY(i);
 
             // skip bordered ones
-            if (game.m_map.isWithinBoundaries(dx, dy) == false)
+            if (game.m_gameObjectsContext->getMap().isWithinBoundaries(dx, dy) == false)
                 continue;
 
             /*
@@ -3870,16 +3869,16 @@ int cUnit::findHarvestSpot(int id)
             if (dy >= (game.map_height-1))
               continue;*/
 
-            int idOfUnitAtCell = game.m_map.getCellIdUnitLayer(i);
+            int idOfUnitAtCell = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(i);
             if (idOfUnitAtCell > -1)
                 continue;
 
-            if (game.m_map.occupied(i, id))
+            if (game.m_gameObjectsContext->getMap().occupied(i, id))
                 continue; // occupied
 
-            int d = ABS_length(cx, cy, game.m_map.getCellX(i), game.m_map.getCellY(i));
+            int d = ABS_length(cx, cy, game.m_gameObjectsContext->getMap().getCellX(i), game.m_gameObjectsContext->getMap().getCellY(i));
 
-            int cellType = game.m_map.getCellType(i);
+            int cellType = game.m_gameObjectsContext->getMap().getCellType(i);
             if (cellType == TERRAIN_SPICE) {
                 if (d < TargetSpiceDistance) {
                     TargetSpice = i;
@@ -3914,8 +3913,8 @@ int cUnit::findHarvestSpot(int id)
 int cUnit::carryallFreeForTransfer(int iPlayer)
 {
     // find a free carry all
-    for (int i = 0; i < game.m_Units.size(); i++) {
-        cUnit &cUnit = game.getUnit(i);
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        cUnit &cUnit = game.m_gameObjectsContext->getUnits()[i];
         if (!cUnit.isValid()) continue;
         if (cUnit.iPlayer != iPlayer) continue;
         if (cUnit.iType != CARRYALL) continue; // skip non-carry-all units
@@ -3973,9 +3972,9 @@ int cUnit::freeAroundMove(int iUnit)
 
     for (int x = iStartX; x < iEndX; x++) {
         for (int y = iStartY; y < iEndY; y++) {
-            int cll = game.m_map.getGeometry().getCellWithMapBorders(x, y);
+            int cll = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders(x, y);
 
-            if (cll > -1 && !game.m_map.occupied(cll)) {
+            if (cll > -1 && !game.m_gameObjectsContext->getMap().occupied(cll)) {
                 iClls[foundCoordinates] = cll;
                 foundCoordinates++;
             }

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -1899,8 +1899,8 @@ void cUnit::shoot(int iTargetCell)
         if (attackUnit && !attackUnit->isValid()) {
             // allowing homing bullets towards air units from the ground
             if (iBull > -1 && attackUnit->isAirbornUnit()) {
-                game.g_Bullets[iBull].iHoming = combat.iAttackUnit;
-                game.g_Bullets[iBull].TIMER_homing = 200;
+                game.m_Bullets[iBull].iHoming = combat.iAttackUnit;
+                game.m_Bullets[iBull].TIMER_homing = 200;
             }
         }
     }

--- a/src/gameobjects/units/cUnitUtils.cpp
+++ b/src/gameobjects/units/cUnitUtils.cpp
@@ -24,12 +24,12 @@ int cUnitUtils::findUnit(int type, int iPlayerId)
 // find the first unit of type belonging to player Id, and is not the same Id as iIgnoreUnitId.
 int cUnitUtils::findUnit(int type, int iPlayerId, int iIgnoreUnitId)
 {
-    for (int i=0; i < game.m_Units.size(); i++) {
-        if (i == iIgnoreUnitId || !game.getUnit(i).isValid()) {
+    for (int i=0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        if (i == iIgnoreUnitId || !game.m_gameObjectsContext->getUnits()[i].isValid()) {
             continue;
         }
 
-        if (game.getUnit(i).iPlayer == iPlayerId && game.getUnit(i).iType == type) {
+        if (game.m_gameObjectsContext->getUnits()[i].iPlayer == iPlayerId && game.m_gameObjectsContext->getUnits()[i].iType == type) {
             return i;
         }
     }

--- a/src/gameobjects/units/cUnits.cpp
+++ b/src/gameobjects/units/cUnits.cpp
@@ -74,7 +74,7 @@ int cUnits::getValidUnitsCount() const {
 // return new valid ID
 static int unitNewID()
 {
-    for (int i = 0; i < game.m_Units.size(); i++)
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++)
         if (!game.getUnit(i).isValid())
             return i;
 
@@ -87,7 +87,7 @@ static int unitNewID()
 // }
 
 int cUnits::unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool isReinforcement, float hpPercentage) {
-    if (!game.m_map.isValidCell(iCll)) {
+    if (!game.m_gameObjectsContext->getMap().isValidCell(iCll)) {
         logbook("UNIT_CREATE: Invalid cell as param");
         return -1;
     }
@@ -95,7 +95,7 @@ int cUnits::unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool 
     s_UnitInfo &sUnitType = game.m_infoContext->getUnitInfo(unitType);
 
     // check if unit already exists on location
-    if (!sUnitType.airborn && game.m_map.cellGetIdFromLayer(iCll, MAPID_STRUCTURES) > -1) {
+    if (!sUnitType.airborn && game.m_gameObjectsContext->getMap().cellGetIdFromLayer(iCll, MAPID_STRUCTURES) > -1) {
         return -1; // cannot place unit, structure exists at location
     }
 
@@ -108,18 +108,18 @@ int cUnits::unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool 
     }
 
     // check if unit already exists on location
-    if (game.m_map.cellGetIdFromLayer(iCll, mapIdIndex) > -1) {
+    if (game.m_gameObjectsContext->getMap().cellGetIdFromLayer(iCll, mapIdIndex) > -1) {
         return -1; // cannot place unit
     }
 
     // check if placed on invalid terrain type
     if (unitType == SANDWORM) {
-        if (!game.m_map.isCellPassableForWorm(iCll)) {
+        if (!game.m_gameObjectsContext->getMap().isCellPassableForWorm(iCll)) {
             return -1;
         }
     }
 
-    bool validCell = game.m_map.canDeployUnitTypeAtCell(iCll, unitType);
+    bool validCell = game.m_gameObjectsContext->getMap().canDeployUnitTypeAtCell(iCll, unitType);
     if (!validCell) {
         return -1;
     }
@@ -176,11 +176,11 @@ int cUnits::unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool 
     }
 
     // Put on map too!:
-    game.m_map.cellSetIdForLayer(iCll, mapIdIndex, iNewId);
+    game.m_gameObjectsContext->getMap().cellSetIdForLayer(iCll, mapIdIndex, iNewId);
 
     newUnit.updateCellXAndY();
 
-    game.m_map.clearShroud(iCll, sUnitType.sight, iPlayer);
+    game.m_gameObjectsContext->getMap().clearShroud(iCll, sUnitType.sight, iPlayer);
 
     s_GameEvent event {
         .eventType = eGameEventType::GAME_EVENT_CREATED,

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -43,12 +43,12 @@ void cGamePlaying::thinkFast()
 
     game.m_mapCamera->thinkFast();
 
-    for (cPlayer &pPlayer : game.m_Players) {
+    for (cPlayer &pPlayer : game.m_gameObjectsContext->getPlayers()) {
         pPlayer.thinkFast();
     }
 
     // structures think
-    for (cAbstractStructure *pStructure : game.m_pStructures) {
+    for (cAbstractStructure *pStructure : game.m_gameObjectsContext->getStructures()) {
         if (pStructure == nullptr) continue;
         if (pStructure->isValid()) {
             pStructure->thinkFast();       // think about actions going on
@@ -61,31 +61,31 @@ void cGamePlaying::thinkFast()
         }
     }
 
-    for (cPlayer &pPlayer : game.m_Players) {
+    for (cPlayer &pPlayer : game.m_gameObjectsContext->getPlayers()) {
         cItemBuilder *itemBuilder = pPlayer.getItemBuilder();
         if (itemBuilder) {
             itemBuilder->thinkFast();
         }
     }
 
-    game.m_map.thinkFast();
+    game.m_gameObjectsContext->getMap().thinkFast();
 
     game.reduceShaking();
 
     // units think (move only)
-    for (cUnit &cUnit : game.m_Units) {
+    for (cUnit &cUnit : game.m_gameObjectsContext->getUnits()) {
         if (!cUnit.isValid()) continue;
         cUnit.thinkFast();
     }
 
-    for (cParticle &pParticle : game.m_particles) {
+    for (cParticle &pParticle : game.m_gameObjectsContext->getParticles()) {
         if (!pParticle.isValid()) continue;
         pParticle.thinkFast();
     }
 
     // when not drawing the options, the game does all it needs to do
     // bullets think
-    for (cBullet &cBullet : game.m_Bullets) {
+    for (cBullet &cBullet : game.m_gameObjectsContext->getBullets()) {
         if (!cBullet.bAlive) continue;
         cBullet.thinkFast();
     }
@@ -94,8 +94,8 @@ void cGamePlaying::thinkFast()
 void cGamePlaying::thinkNormal()
 {
         // units think
-        for (int i = 0; i < game.m_Units.size(); i++) {
-            cUnit &cUnit = game.getUnit(i);
+        for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+            cUnit &cUnit = game.m_gameObjectsContext->getUnits()[i];
             if (cUnit.isValid()) {
                 cUnit.think();
             }
@@ -121,7 +121,7 @@ void cGamePlaying::thinkSlow()
 
     // starports think per second for deployment (if any)
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *pStructure = game.m_pStructures[i];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[i];
         if (pStructure && pStructure->isValid()) {
             pStructure->thinkSlow();
         }
@@ -253,7 +253,7 @@ void cGamePlaying::onKeyDownGamePlaying(const cKeyboardEvent &event)
         if (event.hasKey(SDL_SCANCODE_F4)) {
             int mouseCell = humanPlayer.getGameControlsContext()->getMouseCell();
             if (mouseCell > -1) {
-                game.m_map.clearShroud(mouseCell, 6, HUMAN);
+                game.m_gameObjectsContext->getMap().clearShroud(mouseCell, 6, HUMAN);
             }
         }
     }
@@ -296,8 +296,8 @@ void cGamePlaying::onKeyPressedGamePlaying(const cKeyboardEvent &event)
     }
 
     if (event.hasKey(SDL_SCANCODE_D)) {
-        for (int i = 0; i < game.m_Units.size(); i++) {
-            cUnit &u = game.getUnit(i);
+        for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+            cUnit &u = game.m_gameObjectsContext->getUnits()[i];
             if (u.isSelected() && u.iType == MCV && u.getPlayer()->isHuman()) {
                 bool canPlace = u.getPlayer()->canPlaceStructureAt(u.getCell(), CONSTYARD, u.iID).success;
                 if (canPlace) {
@@ -387,19 +387,19 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
     if (event.hasKeys(SDL_SCANCODE_F4, SDL_SCANCODE_LSHIFT)) {
         int mc = humanPlayer.getGameControlsContext()->getMouseCell();
         if (mc > -1) {
-            int idOfUnitAtCell = game.m_map.getCellIdUnitLayer(mc);
+            int idOfUnitAtCell = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(mc);
             if (idOfUnitAtCell > -1) {
-                game.getUnit(idOfUnitAtCell).die(true, false);
+                game.m_gameObjectsContext->getUnits()[idOfUnitAtCell].die(true, false);
             }
 
-            int idOfStructureAtCell = game.m_map.getCellIdStructuresLayer(mc);
+            int idOfStructureAtCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(mc);
             if (idOfStructureAtCell > -1) {
-                game.m_pStructures[idOfStructureAtCell]->die();
+                game.m_gameObjectsContext->getStructures()[idOfStructureAtCell]->die();
             }
 
-            idOfUnitAtCell = game.m_map.getCellIdWormsLayer(mc);
+            idOfUnitAtCell = game.m_gameObjectsContext->getMap().getCellIdWormsLayer(mc);
             if (idOfUnitAtCell > -1) {
-                game.getUnit(idOfUnitAtCell).die(false, false);
+                game.m_gameObjectsContext->getUnits()[idOfUnitAtCell].die(false, false);
             }
         }
     }
@@ -408,9 +408,9 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
     if (event.hasKeys(SDL_SCANCODE_F5, SDL_SCANCODE_LSHIFT)) {
         int mc = humanPlayer.getGameControlsContext()->getMouseCell();
         if (mc > -1) {
-            int idOfUnitAtCell = game.m_map.getCellIdUnitLayer(mc);
+            int idOfUnitAtCell = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(mc);
             if (idOfUnitAtCell > -1) {
-                cUnit &pUnit = game.getUnit(idOfUnitAtCell);
+                cUnit &pUnit = game.m_gameObjectsContext->getUnits()[idOfUnitAtCell];
                 int damageToTake = pUnit.getHitPoints() - 25;
                 if (damageToTake > 0) {
                     pUnit.takeDamage(damageToTake, -1, -1);
@@ -421,7 +421,7 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
     else {
         // REVEAL MAP
         if (event.hasKey(SDL_SCANCODE_F5)) {
-            game.m_map.clear_all(HUMAN);
+            game.m_gameObjectsContext->getMap().clear_all(HUMAN);
         }
     }
 
@@ -429,7 +429,7 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
         // kill all carry-all's
         const std::vector<int> &myUnitsForType = humanPlayer.getAllMyUnitsForType(CARRYALL);
         for (auto &unitId : myUnitsForType) {
-            cUnit &pUnit = game.getUnit(unitId);
+            cUnit &pUnit = game.m_gameObjectsContext->getUnits()[unitId];
             pUnit.die(true, false);
         }
     }
@@ -437,7 +437,7 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
 
 void cGamePlaying::update()
 {
-    for (auto &pPlayer : game.m_Players) {
+    for (auto &pPlayer : game.m_gameObjectsContext->getPlayers()) {
         pPlayer.update();
     }
 }

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -85,7 +85,7 @@ void cGamePlaying::thinkFast()
 
     // when not drawing the options, the game does all it needs to do
     // bullets think
-    for (cBullet &cBullet : game.g_Bullets) {
+    for (cBullet &cBullet : game.m_Bullets) {
         if (!cBullet.bAlive) continue;
         cBullet.thinkFast();
     }

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -587,10 +587,10 @@ void cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState(in
     startCellsOnSkirmishMap = iStartPositions.size();
 
     // REGENERATE MAP DATA FROM INFO
-    game.m_map.init(selectedMap.width, selectedMap.height);
+    game.m_gameObjectsContext->getMap().init(selectedMap.width, selectedMap.height);
 
-    auto mapEditor = cMapEditor(game.m_map);
-    for (int c = 0; c < game.m_map.getMaxCells(); c++) {
+    auto mapEditor = cMapEditor(game.m_gameObjectsContext->getMap());
+    for (int c = 0; c < game.m_gameObjectsContext->getMap().getMaxCells(); c++) {
         mapEditor.createCell(c, selectedMap.terrainType[c], 0);
     }
     mapEditor.smoothMap();
@@ -762,7 +762,7 @@ void cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState(in
 
             int minRange = 3;
             int maxRange = 12;
-            int cell = game.m_map.getRandomCellFromWithRandomDistanceValidForUnitType(pPlayer.getFocusCell(),
+            int cell = game.m_gameObjectsContext->getMap().getRandomCellFromWithRandomDistanceValidForUnitType(pPlayer.getFocusCell(),
                        minRange,
                        maxRange,
                        iPlayerUnitType);
@@ -810,20 +810,20 @@ void cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState(in
 
     m_game.playMusicByType(MUSIC_PEACE);
 
-    game.m_map.setAutoSpawnSpiceBlooms(spawnBlooms);
-    game.m_map.setAutoDetonateSpiceBlooms(detonateBlooms);
-    game.m_map.setDesiredAmountOfWorms(spawnWorms);
+    game.m_gameObjectsContext->getMap().setAutoSpawnSpiceBlooms(spawnBlooms);
+    game.m_gameObjectsContext->getMap().setAutoDetonateSpiceBlooms(detonateBlooms);
+    game.m_gameObjectsContext->getMap().setDesiredAmountOfWorms(spawnWorms);
 
     // spawn requested amount of worms at start
     if (spawnWorms > 0) {
         int worms = spawnWorms;
         int minDistance = worms * 12; // so on 64x64 maps this still could work
         int maxDistance = worms * 32; // 128 / 4
-        int wormCell = game.m_map.getRandomCell();
+        int wormCell = game.m_gameObjectsContext->getMap().getRandomCell();
         int failures = 0;
         logbook(std::format("Skirmish game with {} sandworms, minDistance {}, maxDistance {}", worms, minDistance, maxDistance));
         while (worms > 0) {
-            int cell = game.m_map.getRandomCellFromWithRandomDistanceValidForUnitType(wormCell, minDistance, maxDistance,
+            int cell = game.m_gameObjectsContext->getMap().getRandomCellFromWithRandomDistanceValidForUnitType(wormCell, minDistance, maxDistance,
                        SANDWORM);
             if (cell < 0) {
                 // retry
@@ -1166,7 +1166,7 @@ void cSetupSkirmishState::generateRandomMap()
 
     randomMapGenerator->generateRandomMap(randomMapWidth, randomMapHeight, iStartingPoints, randomMap);
 
-    // @mira do better than (game.m_map.getWidth() * game.m_map.getHeight() > 64 * 64)
+    // @mira do better than (game.m_gameObjectsContext->getMap().getWidth() * game.m_gameObjectsContext->getMap().getHeight() > 64 * 64)
     spawnWorms = (randomMapWidth * randomMapHeight > 64 * 64) ? 4 : 2;
 
     randomMap.validMap = true;

--- a/src/managers/cDrawManager.cpp
+++ b/src/managers/cDrawManager.cpp
@@ -123,7 +123,7 @@ void cDrawManager::drawDebugInfoUsages() const
     }
 
     int bulletsUsed = 0;
-    for (const auto& bullet : game.g_Bullets) {
+    for (const auto& bullet : game.m_Bullets) {
         if (bullet.bAlive) {
             bulletsUsed++;
         }
@@ -140,7 +140,7 @@ void cDrawManager::drawDebugInfoUsages() const
     int height = 14;
     m_textDrawer->drawText(0, startY, std::format("Units {}/{}", unitsUsed, game.m_Units.size()));
     m_textDrawer->drawText(0, startY + 1*height, std::format("Structures %d/%d", structuresUsed, MAX_STRUCTURES));
-    m_textDrawer->drawText(0, startY + 2*height, std::format("Bullets %d/%d", bulletsUsed, game.g_Bullets.size()));
+    m_textDrawer->drawText(0, startY + 2*height, std::format("Bullets %d/%d", bulletsUsed, game.m_Bullets.size()));
     m_textDrawer->drawText(0, startY + 3*height, std::format("Particles %d/%d", particlesUsed, game.m_particles.size()));
 }
 

--- a/src/managers/cDrawManager.cpp
+++ b/src/managers/cDrawManager.cpp
@@ -32,8 +32,8 @@ cDrawManager::cDrawManager(GameContext *ctx, cPlayer *thePlayer) :
     m_sidebarDrawer = std::make_unique<cSideBarDrawer>(ctx, thePlayer);
     m_creditsDrawer = std::make_unique<CreditsDrawer>(ctx, thePlayer);
     m_orderDrawer = std::make_unique<cOrderDrawer>(ctx, thePlayer);
-    m_mapDrawer = std::make_unique<cMapDrawer>(ctx, &game.m_map, thePlayer, game.m_mapCamera);
-    m_miniMapDrawer = std::make_unique<cMiniMapDrawer>(ctx, &game.m_map, thePlayer, game.m_mapCamera);
+    m_mapDrawer = std::make_unique<cMapDrawer>(ctx, &game.m_gameObjectsContext->getMap(), thePlayer, game.m_mapCamera);
+    m_miniMapDrawer = std::make_unique<cMiniMapDrawer>(ctx, &game.m_gameObjectsContext->getMap(), thePlayer, game.m_mapCamera);
     m_particleDrawer = std::make_unique<cParticleDrawer>();
     m_messageDrawer = std::make_unique<cMessageDrawer>(ctx);
     m_placeitDrawer = std::make_unique<cPlaceItDrawer>(ctx,thePlayer);
@@ -63,13 +63,13 @@ void cDrawManager::drawCombatState()
     m_particleDrawer->determineParticlesToDraw(*game.m_mapViewport);
     m_particleDrawer->drawLowerLayer();
 
-    game.m_map.draw_units();
+    game.m_gameObjectsContext->getMap().draw_units();
 
-    game.m_map.draw_bullets();
+    game.m_gameObjectsContext->getMap().draw_bullets();
 
     m_structureDrawer->drawStructuresSecondLayer();
 
-    game.m_map.draw_units_2nd();
+    game.m_gameObjectsContext->getMap().draw_units_2nd();
 
     m_particleDrawer->drawTopLayer();
     m_structureDrawer->drawStructuresHealthBars();
@@ -108,7 +108,7 @@ void cDrawManager::drawCombatState()
 void cDrawManager::drawDebugInfoUsages() const
 {
     int unitsUsed = 0;
-    for (int i = 0; i < game.m_Units.size(); i++) {
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
         if (game.getUnit(i).isValid()) {
             unitsUsed++;
         }
@@ -116,21 +116,21 @@ void cDrawManager::drawDebugInfoUsages() const
 
     int structuresUsed = 0;
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *pStructure = game.m_pStructures[i];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[i];
         if (pStructure) {
             structuresUsed++;
         }
     }
 
     int bulletsUsed = 0;
-    for (const auto& bullet : game.m_Bullets) {
+    for (const auto& bullet : game.m_gameObjectsContext->getBullets()) {
         if (bullet.bAlive) {
             bulletsUsed++;
         }
     }
 
     int particlesUsed = 0;
-    for (const auto& particle : game.m_particles) {
+    for (const auto& particle : game.m_gameObjectsContext->getParticles()) {
         if (particle.isValid()) {
             particlesUsed++;
         }
@@ -138,10 +138,10 @@ void cDrawManager::drawDebugInfoUsages() const
 
     int startY = 74;
     int height = 14;
-    m_textDrawer->drawText(0, startY, std::format("Units {}/{}", unitsUsed, game.m_Units.size()));
+    m_textDrawer->drawText(0, startY, std::format("Units {}/{}", unitsUsed, game.m_gameObjectsContext->getUnits().size()));
     m_textDrawer->drawText(0, startY + 1*height, std::format("Structures %d/%d", structuresUsed, MAX_STRUCTURES));
-    m_textDrawer->drawText(0, startY + 2*height, std::format("Bullets %d/%d", bulletsUsed, game.m_Bullets.size()));
-    m_textDrawer->drawText(0, startY + 3*height, std::format("Particles %d/%d", particlesUsed, game.m_particles.size()));
+    m_textDrawer->drawText(0, startY + 2*height, std::format("Bullets %d/%d", bulletsUsed, game.m_gameObjectsContext->getBullets().size()));
+    m_textDrawer->drawText(0, startY + 3*height, std::format("Particles %d/%d", particlesUsed, game.m_gameObjectsContext->getParticles().size()));
 }
 
 void cDrawManager::drawCredits()
@@ -153,7 +153,7 @@ void cDrawManager::drawRallyPoint()
 {
     cPlayer &humanPlayer = game.getPlayer(HUMAN);
     if (humanPlayer.selected_structure < 0) return;
-    cAbstractStructure *theStructure = game.m_pStructures[humanPlayer.selected_structure];
+    cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[humanPlayer.selected_structure];
     if (!theStructure) return;
     int rallyPointCell = theStructure->getRallyPoint();
     if (rallyPointCell < 0) return;

--- a/src/map/cMap.cpp
+++ b/src/map/cMap.cpp
@@ -109,7 +109,7 @@ void cMap::init(int width, int height)
 
     cStructureFactory::getInstance()->deleteAllExistingStructures();
 
-    for (auto& bullet : game.g_Bullets) {
+    for (auto& bullet : game.m_Bullets) {
         bullet.init();
     }
 
@@ -446,7 +446,7 @@ void cMap::thinkAutoDetonateSpiceBlooms()  // let spice bloom detonate after X a
 void cMap::draw_bullets()
 {
     // Loop through all units, check if they should be drawn, and if so, draw them
-    for (auto& bullet : game.g_Bullets) {
+    for (auto& bullet : game.m_Bullets) {
         if (bullet.bAlive) {
             bullet.draw();
         }

--- a/src/map/cMap.cpp
+++ b/src/map/cMap.cpp
@@ -55,12 +55,12 @@ cMap::~cMap()
     // do not trigger getInstance from structure factory
     for (int i = 0; i < MAX_STRUCTURES; i++) {
         // clear out all structures
-        cAbstractStructure *pStructure = game.m_pStructures[i];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[i];
         if (pStructure) {
             delete pStructure;
         }
         // clear pointer
-        game.m_pStructures[i] = nullptr;
+        game.m_gameObjectsContext->getStructures()[i] = nullptr;
     }
 }
 
@@ -109,16 +109,16 @@ void cMap::init(int width, int height)
 
     cStructureFactory::getInstance()->deleteAllExistingStructures();
 
-    for (auto& bullet : game.m_Bullets) {
+    for (auto& bullet : game.m_gameObjectsContext->getBullets()) {
         bullet.init();
     }
 
-    for (auto& particle : game.m_particles) {
+    for (auto& particle : game.m_gameObjectsContext->getParticles()) {
         particle.init();
     }
 
-    for (int i = 0; i < game.m_Units.size(); i++) {
-        game.getUnit(i).init(i);
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        game.m_gameObjectsContext->getUnits()[i].init(i);
     }
 
     m_TIMER_scroll = 0;
@@ -242,7 +242,7 @@ bool cMap::canDeployUnitAtCell(int iCell, int iUnitID)
     if (iCell < 0 || iUnitID < 0)
         return false;
 
-    cUnit &pUnit = game.getUnit(iUnitID);
+    cUnit &pUnit = game.m_gameObjectsContext->getUnits()[iUnitID];
     if (!pUnit.isAirbornUnit()) return false; // weird unit passed in
     if (pUnit.iNewUnitType < 0) return false; // safe-guard when this unit has no new unit to spawn
 
@@ -299,7 +299,7 @@ bool cMap::occupied(int iCll, int iUnitID)
     if (iCll < 0 || iUnitID < 0)
         return true;
 
-    cUnit &pUnit = game.getUnit(iUnitID);
+    cUnit &pUnit = game.m_gameObjectsContext->getUnits()[iUnitID];
 
     int structureIdOnMap = getCellIdStructuresLayer(iCll);
     if (structureIdOnMap > -1) {
@@ -446,7 +446,7 @@ void cMap::thinkAutoDetonateSpiceBlooms()  // let spice bloom detonate after X a
 void cMap::draw_bullets()
 {
     // Loop through all units, check if they should be drawn, and if so, draw them
-    for (auto& bullet : game.m_Bullets) {
+    for (auto& bullet : game.m_gameObjectsContext->getBullets()) {
         if (bullet.bAlive) {
             bullet.draw();
         }
@@ -497,7 +497,7 @@ void cMap::clearShroud(int c, int size, int playerId)
 
                 int structureId = getCellIdStructuresLayer(cl);
                 if (structureId > -1) {
-                    cAbstractStructure *pStructure = game.m_pStructures[structureId];
+                    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[structureId];
                     s_GameEvent event {
                         .eventType = eGameEventType::GAME_EVENT_DISCOVERED,
                         .entityType = eBuildType::STRUCTURE,
@@ -512,7 +512,7 @@ void cMap::clearShroud(int c, int size, int playerId)
 
                 int unitId = getCellIdUnitLayer(cl);
                 if (unitId > -1) {
-                    cUnit &cUnit = game.getUnit(unitId);
+                    cUnit &cUnit = game.m_gameObjectsContext->getUnits()[unitId];
                     if (cUnit.isValid()) {
                         s_GameEvent event {
                             .eventType = eGameEventType::GAME_EVENT_DISCOVERED,
@@ -550,8 +550,8 @@ void cMap::draw_units()
     //// @Mira fix trasnparency set_trans_blender(0, 0, 0, 160);
 
     // draw all worms first
-    for (int i = 0; i < game.m_Units.size(); i++) {
-        cUnit &pUnit = game.getUnit(i);
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        cUnit &pUnit = game.m_gameObjectsContext->getUnits()[i];
         if (!pUnit.isValid()) continue;
 
         // DEBUG MODE: DRAW PATHS
@@ -570,8 +570,8 @@ void cMap::draw_units()
     }
 
     // then: draw infantry units
-    for (int i = 0; i < game.m_Units.size(); i++) {
-        cUnit &pUnit = game.getUnit(i);
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        cUnit &pUnit = game.m_gameObjectsContext->getUnits()[i];
         if (!pUnit.isValid()) continue;
 
         if (!pUnit.isInfantryUnit())
@@ -586,8 +586,8 @@ void cMap::draw_units()
     }
 
     // then: draw ground units
-    for (int i = 0; i < game.m_Units.size(); i++) {
-        cUnit &pUnit = game.getUnit(i);
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        cUnit &pUnit = game.m_gameObjectsContext->getUnits()[i];
         if (!pUnit.isValid()) continue;
 
         if (pUnit.isAirbornUnit() ||
@@ -615,8 +615,8 @@ void cMap::drawUnitDebug(cUnit &pUnit) const
 void cMap::draw_units_2nd()
 {
     // draw health of units
-    for (int i = 0; i < game.m_Units.size(); i++) {
-        cUnit &pUnit = game.getUnit(i);
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        cUnit &pUnit = game.m_gameObjectsContext->getUnits()[i];
         if (!pUnit.isValid()) continue;
         if (!pUnit.rendering.bHovered && !pUnit.isSelected()) continue;
         if (!pUnit.isWithinViewport(game.m_mapViewport)) continue;
@@ -631,8 +631,8 @@ void cMap::draw_units_2nd()
     }
 
     // draw airborn units
-    for (int i = 0; i < game.m_Units.size(); i++) {
-        cUnit &pUnit = game.getUnit(i);
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        cUnit &pUnit = game.m_gameObjectsContext->getUnits()[i];
         if (!pUnit.isValid()) continue;
         if (!pUnit.isAirbornUnit()) continue;
 
@@ -1316,7 +1316,7 @@ cAbstractStructure *cMap::findClosestStructureType(int cell, int structureType, 
 
     const std::vector<int> &myStructuresAsId = player->getAllMyStructuresAsId();
     for (auto &i: myStructuresAsId) {
-        cAbstractStructure *pStructure = game.m_pStructures[i];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[i];
         if (pStructure == nullptr) continue;
         if (pStructure->getType() != structureType) continue;
 
@@ -1330,7 +1330,7 @@ cAbstractStructure *cMap::findClosestStructureType(int cell, int structureType, 
     }
 
     if (foundStructureId > -1) {
-        return game.m_pStructures[foundStructureId];
+        return game.m_gameObjectsContext->getStructures()[foundStructureId];
     }
 
     return nullptr;
@@ -1406,7 +1406,7 @@ cAbstractStructure *cMap::findClosestAvailableStructureType(int cell, int struct
 
     const std::vector<int> &myStructuresAsId = pPlayer->getAllMyStructuresAsId();
     for (auto &i: myStructuresAsId) {
-        cAbstractStructure *pStructure = game.m_pStructures[i];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[i];
         if (pStructure == nullptr) continue;
         if (pStructure->getType() != structureType) continue;
         if (pStructure->hasUnitWithin()) continue; // already occupied
@@ -1421,7 +1421,7 @@ cAbstractStructure *cMap::findClosestAvailableStructureType(int cell, int struct
     }
 
     if (foundStructureId > -1) {
-        return game.m_pStructures[foundStructureId];
+        return game.m_gameObjectsContext->getStructures()[foundStructureId];
     }
 
     return nullptr;
@@ -1441,7 +1441,7 @@ cMap::findClosestAvailableStructureTypeWhereNoUnitIsHeadingTo(int cell, int stru
 
     const std::vector<int> &myStructuresAsId = pPlayer->getAllMyStructuresAsId();
     for (auto &i: myStructuresAsId) {
-        cAbstractStructure *pStructure = game.m_pStructures[i];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[i];
         if (pStructure == nullptr) continue;
         if (pStructure->getOwner() != playerId) continue;
         if (pStructure->getType() != structureType) continue;
@@ -1459,7 +1459,7 @@ cMap::findClosestAvailableStructureTypeWhereNoUnitIsHeadingTo(int cell, int stru
     }
 
     if (foundStructureId > -1) {
-        return game.m_pStructures[foundStructureId];
+        return game.m_gameObjectsContext->getStructures()[foundStructureId];
     }
 
     return nullptr;
@@ -1473,7 +1473,7 @@ int cMap::getRandomCellFromWithRandomDistanceValidForUnitType(int cell, int minR
 int cMap::findRandomCellToMoveToForSandworm() const {
     for (int iTries = 0; iTries < 5; iTries++) {
         int iMoveTo = getRandomCellWithinMapWithSafeDistanceFromBorder(2);
-        if (game.m_map.isCellPassableForWorm(iMoveTo)) {
+        if (game.m_gameObjectsContext->getMap().isCellPassableForWorm(iMoveTo)) {
             return iMoveTo;
         }
     }

--- a/src/map/cMap.cpp
+++ b/src/map/cMap.cpp
@@ -109,18 +109,6 @@ void cMap::init(int width, int height)
 
     cStructureFactory::getInstance()->deleteAllExistingStructures();
 
-    for (auto& bullet : game.m_gameObjectsContext->getBullets()) {
-        bullet.init();
-    }
-
-    for (auto& particle : game.m_gameObjectsContext->getParticles()) {
-        particle.init();
-    }
-
-    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
-        game.m_gameObjectsContext->getUnits()[i].init(i);
-    }
-
     m_TIMER_scroll = 0;
     m_iScrollSpeed = 1;
 

--- a/src/map/cMapCamera.cpp
+++ b/src/map/cMapCamera.cpp
@@ -106,12 +106,12 @@ void cMapCamera::keepViewportWithinReasonableBounds()
         m_viewportStartY = -halfViewportHeight;
     }
 
-    int maxWidth = (game.m_map.getWidth() * TILESIZE_WIDTH_PIXELS) + halfViewportWidth;
+    int maxWidth = (game.m_gameObjectsContext->getMap().getWidth() * TILESIZE_WIDTH_PIXELS) + halfViewportWidth;
     if (getViewportEndX() > maxWidth) {
         m_viewportStartX = maxWidth - m_viewportWidth;
     }
 
-    int maxHeight = (game.m_map.getHeight() * TILESIZE_HEIGHT_PIXELS) + halfViewportHeight;
+    int maxHeight = (game.m_gameObjectsContext->getMap().getHeight() * TILESIZE_HEIGHT_PIXELS) + halfViewportHeight;
     if ((getViewportEndY()) > maxHeight) {
         m_viewportStartY = maxHeight - m_viewportHeight;
     }
@@ -121,7 +121,7 @@ void cMapCamera::centerAndJumpViewPortToCell(int cell)
 {
     // fix any boundaries
     if (cell < 0) cell = 0;
-    if (cell >= game.m_map.getMaxCells()) cell = (game.m_map.getMaxCells()-1);
+    if (cell >= game.m_gameObjectsContext->getMap().getMaxCells()) cell = (game.m_gameObjectsContext->getMap().getMaxCells()-1);
 
     int mapCellX = m_pMap->getAbsoluteXPositionFromCell(cell);
     int mapCellY = m_pMap->getAbsoluteYPositionFromCell(cell);
@@ -170,7 +170,7 @@ void cMapCamera::setViewportPosition(int x, int y)
 
 int cMapCamera::getCellFromAbsolutePosition(int x, int y)
 {
-    return game.m_map.getGeometry().getCellWithMapDimensions((x / 32), (y / 32));
+    return game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapDimensions((x / 32), (y / 32));
 }
 
 void cMapCamera::onNotifyMouseEvent(const s_MouseEvent &event)

--- a/src/map/cRandomMapGenerator.cpp
+++ b/src/map/cRandomMapGenerator.cpp
@@ -19,8 +19,8 @@ cRandomMapGenerator::cRandomMapGenerator()
 void cRandomMapGenerator::generateRandomMap(int width, int height, int startingPoints, s_PreviewMap &randomMapEntry)
 {
     // create random map
-    game.m_map.init(width, height);
-    auto mapEditor = cMapEditor(game.m_map);
+    game.m_gameObjectsContext->getMap().init(width, height);
+    auto mapEditor = cMapEditor(game.m_gameObjectsContext->getMap());
 
     int a_spice = RNG::rnd((startingPoints * 8)) + (startingPoints * 12);
     int a_rock = 32 + RNG::rnd(startingPoints * 3);
@@ -48,15 +48,15 @@ void cRandomMapGenerator::generateRandomMap(int width, int height, int startingP
 
     // draw
     while (a_rock > 0) {
-        int iCll = game.m_map.getRandomCellWithinMapWithSafeDistanceFromBorder(4);
+        int iCll = game.m_gameObjectsContext->getMap().getRandomCellWithinMapWithSafeDistanceFromBorder(4);
         if (iCll < 0) continue;
 
         bool bOk = true;
         if (iSpot < maxRockSpots) {
             for (int s = 0; s < maxRockSpots; s++) {
                 if (iSpotRock[s] > -1) {
-                    if (ABS_length(game.m_map.getCellX(iCll), game.m_map.getCellY(iCll), game.m_map.getCellX(iSpotRock[s]),
-                                   game.m_map.getCellY(iSpotRock[s])) < iDistance) {
+                    if (ABS_length(game.m_gameObjectsContext->getMap().getCellX(iCll), game.m_gameObjectsContext->getMap().getCellY(iCll), game.m_gameObjectsContext->getMap().getCellX(iSpotRock[s]),
+                                   game.m_gameObjectsContext->getMap().getCellY(iSpotRock[s])) < iDistance) {
                         bOk = false;
                     }
                     else {
@@ -98,13 +98,13 @@ void cRandomMapGenerator::generateRandomMap(int width, int height, int startingP
     mapEditor.removeSingleRockSpots();
 
     while (a_spice > 0) {
-        int iCll = game.m_map.getRandomCellWithinMapWithSafeDistanceFromBorder(0);
+        int iCll = game.m_gameObjectsContext->getMap().getRandomCellWithinMapWithSafeDistanceFromBorder(0);
         mapEditor.createRandomField(iCll, TERRAIN_SPICE, 2500);
         a_spice--;
     }
 
     while (a_hill > 0) {
-        int cell = game.m_map.getRandomCellWithinMapWithSafeDistanceFromBorder(0);
+        int cell = game.m_gameObjectsContext->getMap().getRandomCellWithinMapWithSafeDistanceFromBorder(0);
         mapEditor.createRandomField(cell, TERRAIN_HILL, 500 + RNG::rnd(500));
         a_hill--;
     }
@@ -122,16 +122,16 @@ void cRandomMapGenerator::generateRandomMap(int width, int height, int startingP
     global_renderDrawer->FillWithColor(randomMapEntry.terrain, Color::black());
 
     // now put in previewmap 0
-    for (int x = 0; x < game.m_map.getWidth(); x++) {
-        for (int y = 0; y < game.m_map.getHeight(); y++) {
+    for (int x = 0; x < game.m_gameObjectsContext->getMap().getWidth(); x++) {
+        for (int y = 0; y < game.m_gameObjectsContext->getMap().getHeight(); y++) {
 
-            int cll = game.m_map.getGeometry().getCellWithMapDimensions(x, y);
+            int cll = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapDimensions(x, y);
             if (cll < 0) continue;
 
             Color iColor = Color{194, 125, 60,255};
 
             // rock
-            int cellType = game.m_map.getCellType(cll);
+            int cellType = game.m_gameObjectsContext->getMap().getCellType(cll);
             if (cellType == TERRAIN_ROCK) iColor = Color{80, 80, 60,255};
             if (cellType == TERRAIN_MOUNTAIN) iColor = Color{48, 48, 36,255};
             if (cellType == TERRAIN_SPICEHILL) iColor = Color{180, 90, 25,255}; // a bit darker
@@ -142,8 +142,8 @@ void cRandomMapGenerator::generateRandomMap(int width, int height, int startingP
 
             for (int s = 0; s < 4; s++) {
                 if (randomMapEntry.iStartCell[s] > -1) {
-                    int sx = game.m_map.getCellX(randomMapEntry.iStartCell[s]);
-                    int sy = game.m_map.getCellY(randomMapEntry.iStartCell[s]);
+                    int sx = game.m_gameObjectsContext->getMap().getCellX(randomMapEntry.iStartCell[s]);
+                    int sy = game.m_gameObjectsContext->getMap().getCellY(randomMapEntry.iStartCell[s]);
 
                     if (sx == x && sy == y)
                         iColor = Color::white();

--- a/src/player/brains/cPlayerBrainCampaign.cpp
+++ b/src/player/brains/cPlayerBrainCampaign.cpp
@@ -169,7 +169,7 @@ void cPlayerBrainCampaign::onNotifyGameEvent(const s_GameEvent &event)
 void cPlayerBrainCampaign::onMyStructureCreated(const s_GameEvent &event)
 {
     // a structure was created, update our baseplan
-    cAbstractStructure *pStructure = game.m_pStructures[event.entityID];
+    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
     int placedAtCell = pStructure->getCell();
     bool foundExistingStructureInBase = false;
     for (auto &structurePosition : m_myBase) {
@@ -245,7 +245,7 @@ void cPlayerBrainCampaign::onMyUnitAttacked(const s_GameEvent &event)
 void cPlayerBrainCampaign::onMyStructureAttacked(const s_GameEvent &event)
 {
     if (player->hasEnoughCreditsFor(50)) {
-        cAbstractStructure *pStructure = game.m_pStructures[event.entityID];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
         if (!pStructure->isRepairing()) {
             s_StructureInfo &sStructures = game.m_infoContext->getStructureInfo(event.entitySpecificType);
             if (pStructure->getHitPoints() < sStructures.hp * 0.75) {
@@ -272,7 +272,7 @@ void cPlayerBrainCampaign::onMyStructureAttacked(const s_GameEvent &event)
 void cPlayerBrainCampaign::onMyStructureDecayed(const s_GameEvent &event)
 {
     if (player->hasEnoughCreditsFor(50)) {
-        cAbstractStructure *pStructure = game.m_pStructures[event.entityID];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
         if (!pStructure->isRepairing()) {
             s_StructureInfo &sStructures = game.m_infoContext->getStructureInfo(event.entitySpecificType);
             if (pStructure->getHitPoints() < sStructures.hp * 0.75) {
@@ -1735,13 +1735,13 @@ void cPlayerBrainCampaign::onEntityDiscoveredEvent(const s_GameEvent &event)
                         m_TIMER_rest = 0; // if we where still 'resting' then stop this now.
                         m_discoveredEnemyAtCell.insert(event.atCell);
 
-                        if (m_centerOfBaseCell > -1 && game.m_map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
+                        if (m_centerOfBaseCell > -1 && game.m_gameObjectsContext->getMap().distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
                             respondToThreat(&pUnit, nullptr, event.atCell, 2 + RNG::rnd(4));
                         }
                     }
                 }
                 else if (event.entityType == eBuildType::STRUCTURE) {
-                    cAbstractStructure *pStructure = game.m_pStructures[event.entityID];
+                    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
                     if (!pStructure->getPlayer()->isSameTeamAs(player)) {
                         // found enemy structure
                         m_state = ePlayerBrainState::PLAYERBRAIN_ENEMY_DETECTED;
@@ -1767,7 +1767,7 @@ void cPlayerBrainCampaign::onEntityDiscoveredEvent(const s_GameEvent &event)
                         }
                     }
                     else if (event.entityType == eBuildType::STRUCTURE) {
-                        cAbstractStructure *pStructure = game.m_pStructures[event.entityID];
+                        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
                         // the other player discovered a structure of mine
                         if (pStructure->getPlayer() == player) {
                             // found my structure
@@ -1794,7 +1794,7 @@ void cPlayerBrainCampaign::onEntityDiscoveredEvent(const s_GameEvent &event)
                 if (event.entityType == eBuildType::UNIT) {
                     cUnit &pUnit = game.getUnit(event.entityID);
                     if (pUnit.isValid() && !pUnit.getPlayer()->isSameTeamAs(player)) {
-                        if (m_centerOfBaseCell > -1 && game.m_map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
+                        if (m_centerOfBaseCell > -1 && game.m_gameObjectsContext->getMap().distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
                             respondToThreat(&pUnit, nullptr, event.atCell, 2 + RNG::rnd(4));
                         }
                     }

--- a/src/player/brains/cPlayerBrainSandworm.cpp
+++ b/src/player/brains/cPlayerBrainSandworm.cpp
@@ -42,7 +42,7 @@ void cPlayerBrainSandworm::think()
 
 void cPlayerBrainSandworm::findRandomValidLocationToMoveToAndGoThere(cUnit &pSandWorm) const
 {
-    int placeToMoveTo = game.m_map.findRandomCellToMoveToForSandworm();
+    int placeToMoveTo = game.m_gameObjectsContext->getMap().findRandomCellToMoveToForSandworm();
 
     if (placeToMoveTo > -1) {
         pSandWorm.move_to(placeToMoveTo);

--- a/src/player/brains/cPlayerBrainSkirmish.cpp
+++ b/src/player/brains/cPlayerBrainSkirmish.cpp
@@ -188,7 +188,7 @@ void cPlayerBrainSkirmish::onNotifyGameEvent(const s_GameEvent &event)
 void cPlayerBrainSkirmish::onMyStructureCreated(const s_GameEvent &event)
 {
     // a structure was created, update our baseplan
-    cAbstractStructure *pStructure = game.m_pStructures[event.entityID];
+    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
 
     if (event.entitySpecificType == PALACE) {
         // built a palace, create super weapon missions asap!
@@ -258,7 +258,7 @@ void cPlayerBrainSkirmish::onMyStructureDestroyed(const s_GameEvent &event)
 void cPlayerBrainSkirmish::onMyStructureAttacked(const s_GameEvent &event)
 {
     if (player->hasEnoughCreditsFor(50)) {
-        cAbstractStructure *pStructure = game.m_pStructures[event.entityID];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
         if (!pStructure->isRepairing()) {
             s_StructureInfo &sStructures = game.m_infoContext->getStructureInfo(event.entitySpecificType);
             if (pStructure->getHitPoints() < sStructures.hp * 0.75) {
@@ -294,7 +294,7 @@ void cPlayerBrainSkirmish::respondToThreat(cUnit *threat, cUnit *victim, int cel
 void cPlayerBrainSkirmish::onMyStructureDecayed(const s_GameEvent &event)
 {
     if (player->hasEnoughCreditsFor(50)) {
-        cAbstractStructure *pStructure = game.m_pStructures[event.entityID];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
         if (!pStructure->isRepairing()) {
             s_StructureInfo &sStructures = game.m_infoContext->getStructureInfo(event.entitySpecificType);
             if (pStructure->getHitPoints() < sStructures.hp * 0.75) {
@@ -971,7 +971,7 @@ void cPlayerBrainSkirmish::thinkState_EndGame()
 
     int cellToAttack = -1;
     if (RNG::rnd(100) < 50) {
-        for (int i = 0; i < game.m_Units.size(); i++) {
+        for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
             cUnit &cUnit = game.getUnit(i);
             if (!cUnit.isValid()) continue;
             if (cUnit.getPlayer()->isSameTeamAs(player)) continue; // skip allies and self
@@ -985,7 +985,7 @@ void cPlayerBrainSkirmish::thinkState_EndGame()
     }
     else {
         for (int i = 0; i < MAX_STRUCTURES; i++) {
-            cAbstractStructure *theStructure = game.m_pStructures[i];
+            cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
             if (!theStructure) continue;
             if (!theStructure->isValid()) continue;
             if (theStructure->getPlayer()->isSameTeamAs(player)) continue; // skip allies and self
@@ -1182,7 +1182,7 @@ void cPlayerBrainSkirmish::findNewLocationOrMoveAnyBlockingUnitsOrCancelBuild(s_
                 }
                 // move it when idle, else don't do a thing
                 if (aUnit.isIdle()) {
-                    aUnit.move_to(game.m_map.getRandomCellFrom(aUnit.getCell(), 3));
+                    aUnit.move_to(game.m_gameObjectsContext->getMap().getRandomCellFrom(aUnit.getCell(), 3));
                 }
             }
             else {
@@ -1248,13 +1248,13 @@ void cPlayerBrainSkirmish::onEntityDiscoveredEvent(const s_GameEvent &event)
                         m_TIMER_rest = 0; // if we were still 'resting' then stop this now.
                         m_discoveredEnemyAtCell.insert(event.atCell);
 
-                        if (m_centerOfBaseCell > -1 && game.m_map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
+                        if (m_centerOfBaseCell > -1 && game.m_gameObjectsContext->getMap().distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
                             respondToThreat(&pUnit, nullptr, event.atCell, 2 + RNG::rnd(4));
                         }
                     }
                 }
                 else if (event.entityType == eBuildType::STRUCTURE) {
-                    cAbstractStructure *pStructure = game.m_pStructures[event.entityID];
+                    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
                     if (!pStructure->getPlayer()->isSameTeamAs(player)) {
                         // found enemy structure
                         m_TIMER_produceMissionCooldown = 0;
@@ -1282,7 +1282,7 @@ void cPlayerBrainSkirmish::onEntityDiscoveredEvent(const s_GameEvent &event)
                         }
                     }
                     else if (event.entityType == eBuildType::STRUCTURE) {
-                        cAbstractStructure *pStructure = game.m_pStructures[event.entityID];
+                        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
                         // the other player discovered a structure of mine
                         if (pStructure->getPlayer() == player) {
                             // found my structure
@@ -1310,7 +1310,7 @@ void cPlayerBrainSkirmish::onEntityDiscoveredEvent(const s_GameEvent &event)
                 if (event.entityType == eBuildType::UNIT) {
                     cUnit &pUnit = game.getUnit(event.entityID);
                     if (pUnit.isValid() && !pUnit.getPlayer()->isSameTeamAs(player)) {
-                        if (m_centerOfBaseCell > -1 && game.m_map.distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
+                        if (m_centerOfBaseCell > -1 && game.m_gameObjectsContext->getMap().distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
                             respondToThreat(&pUnit, nullptr, event.atCell, 2 + RNG::rnd(4));
                         }
                     }

--- a/src/player/brains/missions/cPlayerBrainMissionKindAttack.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKindAttack.cpp
@@ -48,12 +48,12 @@ int cPlayerBrainMissionKindAttack::findEnemyStructure() const
 {
     int target = -1;
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_pStructures[i];
+        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
         if (!theStructure) continue;
         if (!theStructure->isValid()) continue;
         if (theStructure->getPlayer() == player) continue; // skip self
         if (theStructure->getPlayer()->isSameTeamAs(player)) continue; // skip allies
-        if (!game.m_map.isStructureVisible(theStructure, player)) continue; // skip non-visible targets
+        if (!game.m_gameObjectsContext->getMap().isStructureVisible(theStructure, player)) continue; // skip non-visible targets
 
         // enemy structure
         target =  theStructure->getStructureId();
@@ -67,12 +67,12 @@ int cPlayerBrainMissionKindAttack::findEnemyStructure() const
 int cPlayerBrainMissionKindAttack::findEnemyUnit() const
 {
     int target = -1;
-    for (int i = 0; i < game.m_Units.size(); i++) {
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
         cUnit &pUnit = game.getUnit(i);
         if (!pUnit.isValid()) continue;
         if (pUnit.getPlayer() == player) continue; // skip self
         if (pUnit.getPlayer()->isSameTeamAs(player)) continue; // skip allies and self
-        if (!game.m_map.isVisible(pUnit.getCell(), player)) continue; // skip non visible targets
+        if (!game.m_gameObjectsContext->getMap().isVisible(pUnit.getCell(), player)) continue; // skip non visible targets
         if (pUnit.isSandworm() || pUnit.isAirbornUnit()) continue; // don't attack air units or sandworms
 
         // enemy unit
@@ -92,7 +92,7 @@ void cPlayerBrainMissionKindAttack::think_Execute()
     }
 
     if (targetStructureID > -1) {
-        cAbstractStructure *pStructure = game.m_pStructures[targetStructureID];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[targetStructureID];
         if (!pStructure || !pStructure->isValid()) {
             mission->changeState(PLAYERBRAINMISSION_STATE_SELECT_TARGET);
             return;

--- a/src/player/brains/missions/cPlayerBrainMissionKindDeathHand.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKindDeathHand.cpp
@@ -33,12 +33,12 @@ bool cPlayerBrainMissionKindDeathHand::think_SelectTarget()
 {
     // and execute whatever?? (can merge with select target state?)
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_pStructures[i];
+        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
         if (!theStructure) continue;
         if (!theStructure->isValid()) continue;
         if (theStructure->getPlayer() == player) continue; // skip self
         if (theStructure->getPlayer()->isSameTeamAs(player)) continue; // skip allies
-        if (!game.m_map.isStructureVisible(theStructure, player)) continue; // skip non-visible targets
+        if (!game.m_gameObjectsContext->getMap().isStructureVisible(theStructure, player)) continue; // skip non-visible targets
 
         // enemy structure
         target = theStructure->getCell();
@@ -49,12 +49,12 @@ bool cPlayerBrainMissionKindDeathHand::think_SelectTarget()
 
     if (target < 0) {
         // find any unit to attack instead
-        for (int i = 0; i < game.m_Units.size(); i++) {
+        for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
             cUnit &pUnit = game.getUnit(i);
             if (!pUnit.isValid()) continue;
             if (pUnit.getPlayer() == player) continue; // skip self
             if (pUnit.getPlayer()->isSameTeamAs(player)) continue; // skip allies and self
-            if (!game.m_map.isVisible(pUnit.getCell(), player)) continue; // skip non visible targets
+            if (!game.m_gameObjectsContext->getMap().isVisible(pUnit.getCell(), player)) continue; // skip non visible targets
             // enemy unit
             target = i;
             if (RNG::rnd(100) < 5) {

--- a/src/player/brains/missions/cPlayerBrainMissionKindExplore.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKindExplore.cpp
@@ -22,7 +22,7 @@ cPlayerBrainMissionKindExplore::~cPlayerBrainMissionKindExplore()
 
 bool cPlayerBrainMissionKindExplore::think_SelectTarget()
 {
-    targetCell = game.m_map.getRandomCellWithinMapWithSafeDistanceFromBorder(2);
+    targetCell = game.m_gameObjectsContext->getMap().getRandomCellWithinMapWithSafeDistanceFromBorder(2);
     return true;
 }
 
@@ -33,7 +33,7 @@ void cPlayerBrainMissionKindExplore::think_Execute()
         cUnit &aUnit = game.getUnit(myUnit);
         if (aUnit.isValid()) {
             if (aUnit.isIdle()) {
-                if (game.m_map.distance(aUnit.getCell(), targetCell) < 4) {
+                if (game.m_gameObjectsContext->getMap().distance(aUnit.getCell(), targetCell) < 4) {
                     targetCell = -1;
                     mission->changeState(PLAYERBRAINMISSION_STATE_SELECT_TARGET); // select new target
                 }
@@ -42,7 +42,7 @@ void cPlayerBrainMissionKindExplore::think_Execute()
                 }
             }
             else {
-                if (game.m_map.distance(aUnit.getCell(), targetCell) < 2) {
+                if (game.m_gameObjectsContext->getMap().distance(aUnit.getCell(), targetCell) < 2) {
                     // almost there. Select new target.
                     targetCell = -1;
                     mission->changeState(PLAYERBRAINMISSION_STATE_SELECT_TARGET); // select new target

--- a/src/player/brains/missions/cPlayerBrainMissionKindSaboteur.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKindSaboteur.cpp
@@ -30,12 +30,12 @@ bool cPlayerBrainMissionKindSaboteur::think_SelectTarget()
 
     // TODO: based on priority?
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_pStructures[i];
+        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
         if (!theStructure) continue;
         if (!theStructure->isValid()) continue;
         if (theStructure->getPlayer() == player) continue; // skip self
         if (theStructure->getPlayer()->isSameTeamAs(player)) continue; // skip allies
-        if (!game.m_map.isStructureVisible(theStructure, player)) continue; // skip non-visible targets
+        if (!game.m_gameObjectsContext->getMap().isStructureVisible(theStructure, player)) continue; // skip non-visible targets
 
         // enemy structure
         targetStructureID = theStructure->getStructureId();
@@ -54,7 +54,7 @@ void cPlayerBrainMissionKindSaboteur::think_Execute()
     }
 
     if (targetStructureID > -1) {
-        cAbstractStructure *pStructure = game.m_pStructures[targetStructureID];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[targetStructureID];
         assert(pStructure != nullptr);
         if (pStructure->isValid()) {
             const std::vector<int> &units = mission->getUnits();

--- a/src/player/brains/superweapon/cPlayerBrainFremenSuperWeapon.cpp
+++ b/src/player/brains/superweapon/cPlayerBrainFremenSuperWeapon.cpp
@@ -68,7 +68,7 @@ void cPlayerBrainFremenSuperWeapon::think()
         if (!structureIds.empty()) {
             // pick structure to attack
             std::shuffle(structureIds.begin(), structureIds.end(), g);
-            cellToAttack = game.m_pStructures[structureIds.front()]->getCell();
+            cellToAttack = game.m_gameObjectsContext->getStructures()[structureIds.front()]->getCell();
             if (RNG::rnd(100) > 30) break;
         }
     }

--- a/src/player/cPlayer.cpp
+++ b/src/player/cPlayer.cpp
@@ -395,7 +395,7 @@ void cPlayer::markUnitsForGroup(const int groupId) const
 {
     // go over all units, and mark units for this group if selected.
     // and unmark them for the group when not/no longer selected.
-    for (auto &pUnit : game.m_Units) {
+    for (auto &pUnit : game.m_gameObjectsContext->getUnits()) {
         if (!pUnit.isValid()) continue;
         if (!pUnit.belongsTo(this)) continue;
         if (pUnit.isSelected()) {
@@ -413,8 +413,8 @@ void cPlayer::markUnitsForGroup(const int groupId) const
 std::vector<int> cPlayer::getAllMyUnitsForGroupNr(const int groupId) const
 {
     std::vector<int> ids = std::vector<int>();
-    for (int i = 0; i < game.m_Units.size(); i++) {
-        cUnit &pUnit = game.getUnit(i);
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        cUnit &pUnit = game.m_gameObjectsContext->getUnits()[i];
         if (!pUnit.isValid()) continue;
         if (pUnit.isDead()) continue;
         if (!pUnit.belongsTo(this)) continue;
@@ -430,8 +430,8 @@ std::vector<int> cPlayer::getAllMyUnitsForGroupNr(const int groupId) const
 std::vector<int> cPlayer::getAllMyUnitsWithinViewportRect(const cRectangle &rect) const
 {
     std::vector<int> ids = std::vector<int>();
-    for (int i = 0; i < game.m_Units.size(); i++) {
-        cUnit &pUnit = game.getUnit(i);
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        cUnit &pUnit = game.m_gameObjectsContext->getUnits()[i];
         if (!pUnit.isValid()) continue;
         if (pUnit.isDead()) continue;
         if (!pUnit.belongsTo(this)) continue;
@@ -456,8 +456,8 @@ std::vector<int> cPlayer::getAllMyUnitsWithinViewportRect(const cRectangle &rect
 int cPlayer::getAmountOfUnitsForType(std::vector<int> unitTypes) const
 {
     int count = 0;
-    for (int i = 0; i < game.m_Units.size(); i++) {
-        cUnit &cUnit = game.getUnit(i);
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        cUnit &cUnit = game.m_gameObjectsContext->getUnits()[i];
         if (!cUnit.isValid()) continue;
         if (cUnit.iPlayer != this->getId()) continue;
         if (std::find(unitTypes.begin(), unitTypes.end(), cUnit.iType) != unitTypes.end()) {
@@ -751,7 +751,7 @@ std::vector<int> cPlayer::getAllMyStructuresAsIdForType(int structureType)
 {
     std::vector<int> ids = std::vector<int>();
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *abstractStructure = game.m_pStructures[i];
+        cAbstractStructure *abstractStructure = game.m_gameObjectsContext->getStructures()[i];
         if (!abstractStructure) continue;
         if (!abstractStructure->isValid()) continue;
         if (!abstractStructure->belongsTo(this)) continue;
@@ -1141,11 +1141,11 @@ int cPlayer::findCellToPlaceStructure(int structureType)
     int iHeight = game.m_infoContext->getStructureInfo(structureType).bmp_height / TILESIZE_HEIGHT_PIXELS;
 
     for (auto &id : allMyStructuresAsId) {
-        cAbstractStructure *aStructure = game.m_pStructures[id];
+        cAbstractStructure *aStructure = game.m_gameObjectsContext->getStructures()[id];
 
         // go around any structure, and try to find a cell where we can place a structure.
-        int iStartX = game.m_map.getCellX(aStructure->getCell());
-        int iStartY = game.m_map.getCellY(aStructure->getCell());
+        int iStartX = game.m_gameObjectsContext->getMap().getCellX(aStructure->getCell());
+        int iStartY = game.m_gameObjectsContext->getMap().getCellY(aStructure->getCell());
 
         int iEndX = iStartX + aStructure->getWidth(); // not plus 1 because iStartX is 1st cell
         int iEndY = iStartY + aStructure->getHeight(); // not plus 1 because iStartY is 1st cell
@@ -1158,7 +1158,7 @@ int cPlayer::findCellToPlaceStructure(int structureType)
 
         // check: from top left to top right
         for (int sx = topLeftX; sx < iEndX; sx++) {
-            int cell = game.m_map.getGeometry().getCellWithMapBorders(sx, topLeftY);
+            int cell = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders(sx, topLeftY);
             if (cell < 0) continue;
 
             const s_PlaceResult &result = canPlaceStructureAt(cell, structureType);
@@ -1172,7 +1172,7 @@ int cPlayer::findCellToPlaceStructure(int structureType)
         int bottomLeftY = iEndY;
         // check: from bottom left to bottom right
         for (int sx = bottomLeftX; sx < iEndX; sx++) {
-            int cell = game.m_map.getGeometry().getCellWithMapBorders(sx, bottomLeftY);
+            int cell = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders(sx, bottomLeftY);
             if (cell < 0) continue;
 
             const s_PlaceResult &result = canPlaceStructureAt(cell, structureType);
@@ -1186,7 +1186,7 @@ int cPlayer::findCellToPlaceStructure(int structureType)
         int justLeftX = topLeftX;
         int justLeftY = iStartY - (iHeight - 1);
         for (int sy = justLeftY; sy < iEndY; sy++) {
-            int cell = game.m_map.getGeometry().getCellWithMapBorders(justLeftX, sy);
+            int cell = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders(justLeftX, sy);
             if (cell < 0) continue;
 
             const s_PlaceResult &result = canPlaceStructureAt(cell, structureType);
@@ -1200,7 +1200,7 @@ int cPlayer::findCellToPlaceStructure(int structureType)
         int justRightX = iEndX;
         int justRightY = iStartY - (iHeight - 1);
         for (int sy = justRightY; sy < iEndY; sy++) {
-            int cell = game.m_map.getGeometry().getCellWithMapBorders(justRightX, sy);
+            int cell = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders(justRightX, sy);
             if (cell < 0) continue;
 
             const s_PlaceResult &result = canPlaceStructureAt(cell, structureType);
@@ -1357,13 +1357,13 @@ int cPlayer::findRandomUnitTarget(int playerIndexToAttack)
 
     int maxTargets = 0;
 
-    for (int i = 0; i < game.m_Units.size(); i++) {
-        cUnit &cUnit = game.getUnit(i);
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
+        cUnit &cUnit = game.m_gameObjectsContext->getUnits()[i];
         if (!cUnit.isValid()) continue;
         if (cUnit.iPlayer != playerIndexToAttack) continue;
         // unit belongs to player of the player we wish to attack
 
-        bool isVisibleForPlayer = game.m_map.isVisible(cUnit.getCell(), this);
+        bool isVisibleForPlayer = game.m_gameObjectsContext->getMap().isVisible(cUnit.getCell(), this);
 
         if (game.isDebugMode()) {
             log(std::format("Visible = {}", isVisibleForPlayer));
@@ -1395,9 +1395,9 @@ int cPlayer::findRandomStructureTarget(int iAttackPlayer)
     int iT = 0;
 
     for (int i = 0; i < MAX_STRUCTURES; i++)
-        if (game.m_pStructures[i])
-            if (game.m_pStructures[i]->getOwner() == iAttackPlayer)
-                if (game.m_map.isVisible(game.m_pStructures[i]->getCell(), this) ||
+        if (game.m_gameObjectsContext->getStructures()[i])
+            if (game.m_gameObjectsContext->getStructures()[i]->getOwner() == iAttackPlayer)
+                if (game.m_gameObjectsContext->getMap().isVisible(game.m_gameObjectsContext->getStructures()[i]->getCell(), this) ||
                         game.m_skirmish) {
                     iTargets[iT] = i;
 
@@ -1759,7 +1759,7 @@ s_PlaceResult cPlayer::canPlaceStructureAt(int iCell, int iStructureType, int iU
 {
     s_PlaceResult result;
 
-    if (!game.m_map.isValidCell(iCell)) {
+    if (!game.m_gameObjectsContext->getMap().isValidCell(iCell)) {
         result.outOfBounds = true;
         return result;
     }
@@ -1768,28 +1768,28 @@ s_PlaceResult cPlayer::canPlaceStructureAt(int iCell, int iStructureType, int iU
     int w = game.m_infoContext->getStructureInfo(iStructureType).bmp_width / TILESIZE_WIDTH_PIXELS;
     int h = game.m_infoContext->getStructureInfo(iStructureType).bmp_height / TILESIZE_HEIGHT_PIXELS;
 
-    int x = game.m_map.getCellX(iCell);
-    int y = game.m_map.getCellY(iCell);
+    int x = game.m_gameObjectsContext->getMap().getCellX(iCell);
+    int y = game.m_gameObjectsContext->getMap().getCellY(iCell);
 
     bool foundUnitFromOtherPlayerThanMe = false;
 
     for (int cx = 0; cx < w; cx++) {
         for (int cy = 0; cy < h; cy++) {
-            int cll = game.m_map.getGeometry().getCellWithMapBorders(cx + x, cy + y);
+            int cll = game.m_gameObjectsContext->getMap().getGeometry().getCellWithMapBorders(cx + x, cy + y);
 
-            if (!result.badTerrain && !game.m_map.isValidTerrainForStructureAtCell(cll)) {
+            if (!result.badTerrain && !game.m_gameObjectsContext->getMap().isValidTerrainForStructureAtCell(cll)) {
                 result.badTerrain = true;
             }
 
             // another structure found on this location, "blocked"
-            int structureId = game.m_map.getCellIdStructuresLayer(cll);
+            int structureId = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(cll);
             if (structureId > -1) {
                 result.structureIds.insert(structureId);
             }
 
-            int idOfUnitAtCell = game.m_map.getCellIdUnitLayer(cll);
+            int idOfUnitAtCell = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(cll);
             if (idOfUnitAtCell > -1) {
-                if (game.getUnit(idOfUnitAtCell).isValid() && game.getUnit(idOfUnitAtCell).getPlayer() != this) {
+                if (game.m_gameObjectsContext->getUnits()[idOfUnitAtCell].isValid() && game.m_gameObjectsContext->getUnits()[idOfUnitAtCell].getPlayer() != this) {
                     foundUnitFromOtherPlayerThanMe = true;
                 }
                 if (iUnitIDToIgnore > -1) {
@@ -1877,7 +1877,7 @@ void cPlayer::onEntityDiscovered(const s_GameEvent &event)
         }
     }
     else if (event.entityType == eBuildType::STRUCTURE) {
-        cAbstractStructure *pStructure = game.m_pStructures[event.entityID];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
         bool detectedEntityIsHuman = pStructure->getPlayer()->isHuman();
 
         // structure discovered is NOT the same team, so enemy detected / music trigger
@@ -1977,7 +1977,7 @@ s_PlaceResult cPlayer::canPlaceConcreteAt(int iCell)
 {
     s_PlaceResult result;
 
-    if (!game.m_map.isValidCell(iCell)) {
+    if (!game.m_gameObjectsContext->getMap().isValidCell(iCell)) {
         result.outOfBounds = true;
         return result;
     }
@@ -2009,7 +2009,7 @@ void cPlayer::onMyUnitDestroyed(const s_GameEvent &event)
             reinforceHarvesterIfNeeded(pUnit.getCell());
 
             for (auto &structureId: refineries) {
-                cAbstractStructure *pStructure = game.m_pStructures[structureId];
+                cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[structureId];
                 pStructure->unitIsNoLongerInteractingWithStructure(event.entityID);
             }
         }
@@ -2039,7 +2039,7 @@ void cPlayer::reinforceHarvesterIfNeeded(int cell)
             addNotification("No more Harvester left, reinforcing...", BAD);
 
             // deliver
-            cAbstractStructure *refinery = game.m_map.findClosestStructureType(cell, REFINERY, this);
+            cAbstractStructure *refinery = game.m_gameObjectsContext->getMap().findClosestStructureType(cell, REFINERY, this);
 
             // found a refinery, deliver harvester to that
             if (refinery) {
@@ -2061,7 +2061,7 @@ std::vector<sEntityForDistance> cPlayer::getAllMyUnitsOrderClosestToCell(int cel
 
     for (auto &unitId : ids) {
         cUnit aUnit = game.getUnit(unitId);
-        double dist = game.m_map.distance(aUnit.getCell(), cell);
+        double dist = game.m_gameObjectsContext->getMap().distance(aUnit.getCell(), cell);
         const sEntityForDistance &entry = sEntityForDistance{
             .distance = (int)dist,
             .entityId = unitId
@@ -2079,8 +2079,8 @@ std::vector<sEntityForDistance> cPlayer::getAllMyStructuresOrderClosestToCell(in
     std::vector<sEntityForDistance> result = std::vector<sEntityForDistance>(0);
 
     for (auto &structureId : ids) {
-        cAbstractStructure *pStructure = game.m_pStructures[structureId];
-        double dist = game.m_map.distance(pStructure->getCell(), cell);
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[structureId];
+        double dist = game.m_gameObjectsContext->getMap().distance(pStructure->getCell(), cell);
         const sEntityForDistance &entry = sEntityForDistance{
             .distance = (int)dist,
             .entityId = structureId
@@ -2114,7 +2114,7 @@ std::vector<int> cPlayer::getAllMyUnits()
 std::vector<int> cPlayer::getAllMyUnitsForType(int unitType) const
 {
     std::vector<int> ids = std::vector<int>();
-    for (int i = 0; i < game.m_Units.size(); i++) {
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
         cUnit &pUnit = game.getUnit(i);
         if (!pUnit.isValid()) continue;
         if (pUnit.isDead() && !pUnit.isHidden()) continue; // hidden units play "dead" :/
@@ -2141,7 +2141,7 @@ bool cPlayer::evaluateStillAlive()
 {
     alive = false;
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *abstractStructure = game.m_pStructures[i];
+        cAbstractStructure *abstractStructure = game.m_gameObjectsContext->getStructures()[i];
         if (!abstractStructure) continue;
         if (!abstractStructure->isValid()) continue;
         if (!abstractStructure->belongsTo(this)) continue;
@@ -2151,7 +2151,7 @@ bool cPlayer::evaluateStillAlive()
 
     if (!alive) {
         // check units now
-        for (int i = 0; i < game.m_Units.size(); i++) {
+        for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
             cUnit &pUnit = game.getUnit(i);
             if (!pUnit.isValid()) continue;
             if (pUnit.isAirbornUnit()) continue; // do not count airborn units
@@ -2184,7 +2184,7 @@ void cPlayer::addNotification(const std::string &msg, eNotificationType type)
 cAbstractStructure *cPlayer::getSelectedStructure() const
 {
     if (selected_structure < 0) return nullptr;
-    return game.m_pStructures[selected_structure];
+    return game.m_gameObjectsContext->getStructures()[selected_structure];
 }
 
 void cPlayer::deselectStructure()
@@ -2195,7 +2195,7 @@ void cPlayer::deselectStructure()
 std::vector<int> cPlayer::getSelectedUnits() const
 {
     std::vector<int> ids = std::vector<int>();
-    for (int i = 0; i < game.m_Units.size(); i++) {
+    for (int i = 0; i < game.m_gameObjectsContext->getUnits().size(); i++) {
         cUnit &cUnit = game.getUnit(i);
         if (!cUnit.isValid()) continue;
         if (!cUnit.belongsTo(this)) continue;

--- a/src/utils/cStructureUtils.cpp
+++ b/src/utils/cStructureUtils.cpp
@@ -49,7 +49,7 @@ int cStructureUtils::findStarportToDeployUnit(cPlayer *pPlayer)
     int primaryBuildingOfStructureType = pPlayer->getPrimaryStructureForStructureType(STARPORT);
 
     if (primaryBuildingOfStructureType > -1) {
-        cAbstractStructure *theStructure = game.m_pStructures[primaryBuildingOfStructureType];
+        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[primaryBuildingOfStructureType];
         if (theStructure && theStructure->getNonOccupiedCellAroundStructure() > -1) {
             return primaryBuildingOfStructureType;
         }
@@ -60,7 +60,7 @@ int cStructureUtils::findStarportToDeployUnit(cPlayer *pPlayer)
     int firstFoundStarportId = -1;
     bool foundStarportWithFreeAround = false;
     for (int i=0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_pStructures[i];
+        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
         if (theStructure && theStructure->getOwner() == playerId) {
             if (theStructure->getType() == STARPORT) {
                 // when no id set, always set one id
@@ -118,7 +118,7 @@ int cStructureUtils::findStructureToDeployUnit(cPlayer *pPlayer, int structureTy
     int primaryBuildingOfStructureType = pPlayer->getPrimaryStructureForStructureType(structureType);
 
     if (primaryBuildingOfStructureType > -1) {
-        cAbstractStructure *theStructure = game.m_pStructures[primaryBuildingOfStructureType];
+        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[primaryBuildingOfStructureType];
         // this IF is needed, because the structure could be destroyed/replaced
         if (theStructure &&
                 theStructure->isValid() &&
@@ -228,12 +228,12 @@ void cStructureUtils::putStructureOnDimension(int dimensionId, cAbstractStructur
 
     for (int w = 0; w < theStructure->getWidth(); w++) {
         for (int h = 0; h < theStructure->getHeight(); h++)	{
-            int xOfStructureCell = game.m_map.getCellX(cellOfStructure);
-            int yOfStructureCell = game.m_map.getCellY(cellOfStructure);
+            int xOfStructureCell = game.m_gameObjectsContext->getMap().getCellX(cellOfStructure);
+            int yOfStructureCell = game.m_gameObjectsContext->getMap().getCellY(cellOfStructure);
 
-            int iCell = game.m_map.getGeometry().makeCell(xOfStructureCell + w, yOfStructureCell + h);
+            int iCell = game.m_gameObjectsContext->getMap().getGeometry().makeCell(xOfStructureCell + w, yOfStructureCell + h);
 
-            game.m_map.cellSetIdForLayer(iCell, dimensionId, theStructure->getStructureId());
+            game.m_gameObjectsContext->getMap().cellSetIdForLayer(iCell, dimensionId, theStructure->getStructureId());
         }
     }
 }
@@ -271,7 +271,7 @@ int cStructureUtils::getTotalPowerUsageForPlayer(cPlayer *pPlayer)
     int totalPowerUsage = 0;
 
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_pStructures[i];
+        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
         if (theStructure) {
             if (theStructure->getPlayer()->getId() == pPlayer->getId()) {
                 int powerUsageOfStructure = theStructure->getPowerUsage();
@@ -289,7 +289,7 @@ int cStructureUtils::getTotalSpiceCapacityForPlayer(cPlayer *pPlayer)
 
     int totalCapacity = 0;
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_pStructures[i];
+        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
         if (theStructure == nullptr) continue;
         if (!theStructure->isValid()) continue;
         if (theStructure->getPlayer()->getId() != pPlayer->getId()) continue; // does not belong to pPlayer
@@ -317,7 +317,7 @@ int cStructureUtils::getTotalPowerOutForPlayer(cPlayer *pPlayer)
 
     int totalPowerOut = 0;
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_pStructures[i];
+        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
         if (theStructure == nullptr) continue;
         if (!theStructure->isValid()) continue;
         if (theStructure->getPlayer()->getId() != pPlayer->getId()) continue; // not for pPlayer
@@ -349,7 +349,7 @@ int cStructureUtils::findHiTechToDeployAirUnit(cPlayer *pPlayer)
     int primaryBuildingOfStructureType = pPlayer->getPrimaryStructureForStructureType(HIGHTECH);
 
     if (primaryBuildingOfStructureType > -1) {
-        cAbstractStructure *theStructure = game.m_pStructures[primaryBuildingOfStructureType];
+        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[primaryBuildingOfStructureType];
         // this IF is needed, because the structure could be destroyed/replaced
         if (theStructure &&
                 theStructure->isValid() &&
@@ -377,7 +377,7 @@ int cStructureUtils::findStructureBy(int iPlayer, int iType, bool bFreeAround)
     if (iType < 0) return -1;
 
     for (int i=0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_pStructures[i];
+        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
         if (theStructure &&
                 theStructure->isValid() &&
                 theStructure->belongsTo(iPlayer) &&

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -186,7 +186,7 @@ int createBullet(int type, int fromCell, int targetCell, int unitWhichShoots, in
     int new_id = -1;
 
     int i = 0;
-    for (auto &bullet : game.g_Bullets) {
+    for (auto &bullet : game.m_Bullets) {
         if (!bullet.bAlive) {
             new_id = i;
             break;
@@ -201,7 +201,7 @@ int createBullet(int type, int fromCell, int targetCell, int unitWhichShoots, in
         return -1; // failed
 
 
-    cBullet &newBullet = game.g_Bullets[new_id];
+    cBullet &newBullet = game.m_Bullets[new_id];
     newBullet.init();
 
     newBullet.iType = type;

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -152,18 +152,18 @@ float healthBar(float max_w, int i, int w)
 // return a border cell, close to iCll
 int iFindCloseBorderCell(int iCll)
 {
-    return game.m_map.findCloseMapBorderCellRelativelyToDestinationCel(iCll);
+    return game.m_gameObjectsContext->getMap().findCloseMapBorderCellRelativelyToDestinationCel(iCll);
 }
 
 
 int distanceBetweenCellAndCenterOfScreen(int iCell)
 {
-    if (game.m_map.isValidCell(iCell)) {
+    if (game.m_gameObjectsContext->getMap().isValidCell(iCell)) {
         int centerX = game.m_mapCamera->getViewportCenterX();
         int centerY = game.m_mapCamera->getViewportCenterY();
 
-        int cellX = game.m_map.getAbsoluteXPositionFromCell(iCell);
-        int cellY = game.m_map.getAbsoluteYPositionFromCell(iCell);
+        int cellX = game.m_gameObjectsContext->getMap().getAbsoluteXPositionFromCell(iCell);
+        int cellY = game.m_gameObjectsContext->getMap().getAbsoluteYPositionFromCell(iCell);
 
         return ABS_length(centerX, centerY, cellX, cellY);
     }
@@ -186,7 +186,7 @@ int createBullet(int type, int fromCell, int targetCell, int unitWhichShoots, in
     int new_id = -1;
 
     int i = 0;
-    for (auto &bullet : game.m_Bullets) {
+    for (auto &bullet : game.m_gameObjectsContext->getBullets()) {
         if (!bullet.bAlive) {
             new_id = i;
             break;
@@ -201,25 +201,25 @@ int createBullet(int type, int fromCell, int targetCell, int unitWhichShoots, in
         return -1; // failed
 
 
-    cBullet &newBullet = game.m_Bullets[new_id];
+    cBullet &newBullet = game.m_gameObjectsContext->getBullets()[new_id];
     newBullet.init();
 
     newBullet.iType = type;
-    newBullet.posX = game.m_map.getAbsoluteXPositionFromCellCentered(fromCell);
-    newBullet.posY = game.m_map.getAbsoluteYPositionFromCellCentered(fromCell);
+    newBullet.posX = game.m_gameObjectsContext->getMap().getAbsoluteXPositionFromCellCentered(fromCell);
+    newBullet.posY = game.m_gameObjectsContext->getMap().getAbsoluteYPositionFromCellCentered(fromCell);
     newBullet.iOwnerStructure = structureWhichShoots;
     newBullet.iOwnerUnit = unitWhichShoots;
 
-    newBullet.targetX = game.m_map.getAbsoluteXPositionFromCellCentered(targetCell);
-    newBullet.targetY = game.m_map.getAbsoluteYPositionFromCellCentered(targetCell);
+    newBullet.targetX = game.m_gameObjectsContext->getMap().getAbsoluteXPositionFromCellCentered(targetCell);
+    newBullet.targetY = game.m_gameObjectsContext->getMap().getAbsoluteYPositionFromCellCentered(targetCell);
 
     // if we start firing from a mountain, flag it so the bullet won't be blocked by mountains along
     // the way
-    newBullet.bStartedFromMountain = game.m_map.getCell(fromCell)->type == TERRAIN_MOUNTAIN;
+    newBullet.bStartedFromMountain = game.m_gameObjectsContext->getMap().getCell(fromCell)->type == TERRAIN_MOUNTAIN;
 
-    int structureIdAtTargetCell = game.m_map.getCellIdStructuresLayer(targetCell);
+    int structureIdAtTargetCell = game.m_gameObjectsContext->getMap().getCellIdStructuresLayer(targetCell);
     if (structureIdAtTargetCell > -1) {
-        cAbstractStructure *pStructure = game.m_pStructures[structureIdAtTargetCell];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[structureIdAtTargetCell];
         if (pStructure && pStructure->isValid()) {
             newBullet.targetX = pStructure->getRandomPosX();
             newBullet.targetY = pStructure->getRandomPosY();
@@ -236,26 +236,26 @@ int createBullet(int type, int fromCell, int targetCell, int unitWhichShoots, in
         newBullet.iPlayer = cUnit.iPlayer;
         // if an airborn unit shoots (ie Ornithopter), reveal on map for everyone
         if (cUnit.isAirbornUnit()) {
-            game.m_map.clearShroudForAllPlayers(fromCell, 2);
+            game.m_gameObjectsContext->getMap().clearShroudForAllPlayers(fromCell, 2);
         }
     }
 
     if (structureWhichShoots > -1) {
-        cAbstractStructure *pStructure = game.m_pStructures[structureWhichShoots];
+        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[structureWhichShoots];
         newBullet.iPlayer = pStructure->getOwner();
 
-        int unitIdAtTargetCell = game.m_map.getCellIdUnitLayer(targetCell);
+        int unitIdAtTargetCell = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(targetCell);
         if (unitIdAtTargetCell > -1) {
-            cUnit &unitTarget = game.getUnit(unitIdAtTargetCell);
+            cUnit &unitTarget = game.m_gameObjectsContext->getUnits()[unitIdAtTargetCell];
             // reveal for player which is being attacked
-            game.m_map.clearShroud(fromCell, 2, unitTarget.iPlayer);
+            game.m_gameObjectsContext->getMap().clearShroud(fromCell, 2, unitTarget.iPlayer);
         }
 
-        unitIdAtTargetCell = game.m_map.getCellIdAirUnitLayer(targetCell);
+        unitIdAtTargetCell = game.m_gameObjectsContext->getMap().getCellIdAirUnitLayer(targetCell);
         if (unitIdAtTargetCell > -1) {
-            cUnit &unitTarget = game.getUnit(unitIdAtTargetCell);
+            cUnit &unitTarget = game.m_gameObjectsContext->getUnits()[unitIdAtTargetCell];
             // reveal for player which is being attacked
-            game.m_map.clearShroud(fromCell, 2, unitTarget.iPlayer);
+            game.m_gameObjectsContext->getMap().clearShroud(fromCell, 2, unitTarget.iPlayer);
         }
     }
 

--- a/src/utils/ini.cpp
+++ b/src/utils/ini.cpp
@@ -371,11 +371,11 @@ void cIni::INI_Load_seed(int seed)
     auto seedMap = seedGenerator.generateSeedMap();
     logbook("Seedmap generated");
 
-    auto mapEditor = cMapEditor(game.m_map);
+    auto mapEditor = cMapEditor(game.m_gameObjectsContext->getMap());
     for (int mapY = 0; mapY < 64; mapY++) {
         for (int mapX = 0; mapX < 64; mapX++) {
             int type = seedMap.getCellType(mapX, mapY);
-            int iCell = game.m_map.getGeometry().makeCell(mapX, mapY);
+            int iCell = game.m_gameObjectsContext->getMap().getGeometry().makeCell(mapX, mapY);
             mapEditor.createCell(iCell, type, 0);
         }
     }
@@ -558,7 +558,7 @@ void cIni::loadScenario(/*int iHouse, int iRegion,*/ AbstractMentat *pMentat, cR
     memset(iPl_house, -1, sizeof(iPl_house));
     memset(iPl_quota, 0, sizeof(iPl_quota));
 
-    auto mapEditor = cMapEditor(game.m_map);
+    auto mapEditor = cMapEditor(game.m_gameObjectsContext->getMap());
         // char linefeed[MAX_LINE_LENGTH];
         char lineword[30];
         std::string linesection;
@@ -673,7 +673,7 @@ void cIni::loadScenario(/*int iHouse, int iRegion,*/ AbstractMentat *pMentat, cR
     // }
 
     mapEditor.smoothMap();
-    game.m_map.setDesiredAmountOfWorms(game.getPlayer(AI_WORM).getAmountOfUnitsForType(SANDWORM));
+    game.m_gameObjectsContext->getMap().setDesiredAmountOfWorms(game.getPlayer(AI_WORM).getAmountOfUnitsForType(SANDWORM));
 }
 
 void cIni::INI_Scenario_Section_Basic(AbstractMentat *pMentat, int wordtype, const std::string& linefeed)
@@ -735,7 +735,7 @@ int cIni::INI_Scenario_Section_House(int wordtype, int iPlayerID, int *iPl_credi
 
 void cIni::INI_Scenario_Section_MAP(int *blooms, int *fields, int wordtype, const std::string& slinefeed)
 {
-    game.m_map.init(64, 64);
+    game.m_gameObjectsContext->getMap().init(64, 64);
 
     // original dune 2 maps have 64x64 maps
     if (wordtype == WORD_MAPSEED) {
@@ -779,7 +779,7 @@ void cIni::INI_Scenario_Section_MAP(int *blooms, int *fields, int wordtype, cons
                 int iCellY = (original_dune2_cell / 64);
 
                 // Now recalculate it
-                d2tm_cell = game.m_map.getGeometry().makeCell(iCellX, iCellY);
+                d2tm_cell = game.m_gameObjectsContext->getMap().getGeometry().makeCell(iCellX, iCellY);
                 blooms[iBloomID] = d2tm_cell;
                 memset(word, 0, sizeof(word)); // clear string
 
@@ -832,7 +832,7 @@ void cIni::INI_Scenario_Section_MAP(int *blooms, int *fields, int wordtype, cons
                 int iCellY = (original_dune2_cell / 64);
 
                 // Now recalculate it
-                d2tm_cell = game.m_map.getGeometry().makeCell(iCellX, iCellY);
+                d2tm_cell = game.m_gameObjectsContext->getMap().getGeometry().makeCell(iCellX, iCellY);
                 fields[iFieldID] = d2tm_cell;
                 memset(word, 0, sizeof(word)); // clear string
 


### PR DESCRIPTION
## **Goal**

- Move out `cGame` all `GameObject`  to another structured class to provide a hub to acces on it without  global var `cgame`
- Remove all unnecessary dependency from `cGame`

### Changes

- I fix the scope: that did i want to move outside `cGame`
- Creation of `cGameObectContext` who handle and give `GameObject` to working classes
- Creation of `cGameObectContextCreator` who create all `GameObjects`
- Migration of all references to `cgame.gameObjectContext->getXXXX` 
