### PR TITLE
Improvement coding : removing define and transform it as constexpr if possible

### DIFF
--- a/src/controls/cGameControlsContext.cpp
+++ b/src/controls/cGameControlsContext.cpp
@@ -43,23 +43,22 @@ cGameControlsContext::~cGameControlsContext()
     delete m_mouseDeployState;
 }
 
-
 void cGameControlsContext::updateMouseCell(const cPoint &coords)
 {
     if (coords.y < cSideBar::TopBarHeight) {
-        m_mouseCell = MOUSECELL_TOPBAR; // at the top bar or higher, so no mouse cell id.
+        m_mouseCell = MOUSE_CELL_HOVER_TOPBAR; // at the top bar or higher, so no mouse cell id.
         m_mouseOnBattleField = false;
         return;
     }
 
     if (game.m_drawManager->getMiniMapDrawer()->isMouseOver()) {
-        m_mouseCell = MOUSECELL_MINIMAP; // on minimap
+        m_mouseCell = MOUSE_CELL_HOVER_MINIMAP; // on minimap
         m_mouseOnBattleField = false;
         return;
     }
 
     if (coords.x > (game.m_screenW - cSideBar::SidebarWidth)) {
-        m_mouseCell = MOUSECELL_SIDEBAR; // on sidebar
+        m_mouseCell = MOUSE_CELL_HOVER_SIDEBAR; // on sidebar
         m_mouseOnBattleField = false;
         return;
     }

--- a/src/controls/cGameControlsContext.h
+++ b/src/controls/cGameControlsContext.h
@@ -21,6 +21,10 @@
 #include "controls/mousestates/cMousePlaceState.h"
 #include "controls/mousestates/cMouseDeployState.h"
 
+#define MOUSECELL_TOPBAR  -1
+#define MOUSECELL_MINIMAP -2
+#define MOUSECELL_SIDEBAR -3
+
 class cAbstractStructure;
 
 class cGameControlsContext : public cInputObserver, cScenarioObserver {

--- a/src/controls/cGameControlsContext.h
+++ b/src/controls/cGameControlsContext.h
@@ -21,10 +21,6 @@
 #include "controls/mousestates/cMousePlaceState.h"
 #include "controls/mousestates/cMouseDeployState.h"
 
-#define MOUSECELL_TOPBAR  -1
-#define MOUSECELL_MINIMAP -2
-#define MOUSECELL_SIDEBAR -3
-
 class cAbstractStructure;
 
 class cGameControlsContext : public cInputObserver, cScenarioObserver {
@@ -51,13 +47,13 @@ public:
     }
 
     bool isMouseOnSidebar() const {
-        return m_mouseCell == MOUSECELL_SIDEBAR;
+        return m_mouseCell == MOUSE_CELL_HOVER_SIDEBAR;
     }
     bool isMouseOnTopBar() const {
-        return m_mouseCell == MOUSECELL_TOPBAR;
+        return m_mouseCell == MOUSE_CELL_HOVER_TOPBAR;
     }
     bool isMouseOnMiniMap() const {
-        return m_mouseCell == MOUSECELL_MINIMAP;
+        return m_mouseCell == MOUSE_CELL_HOVER_MINIMAP;
     }
     bool isMouseOnSidebarOrMinimap() const {
         return isMouseOnSidebar() || isMouseOnMiniMap();
@@ -124,4 +120,8 @@ private:
     void onBlurMouseStateEvent();
     void onMouseMovedTo(const s_MouseEvent &event);
     void updateMouseCell(const cPoint &coords);
+
+    static constexpr int MOUSE_CELL_HOVER_TOPBAR = -1;
+    static constexpr int MOUSE_CELL_HOVER_MINIMAP = -2;
+    static constexpr int MOUSE_CELL_HOVER_SIDEBAR = -3;
 };

--- a/src/controls/cGameControlsContext.h
+++ b/src/controls/cGameControlsContext.h
@@ -12,7 +12,7 @@
 // 01/01/2022 -> Move this into a `Combat` state object; or within player object as state.
 
 // #include "gameobjects/structures/cAbstractStructure.h"
-#include "include/definitions.h"
+// #include "include/definitions.h"
 
 #include "controls/mousestates/eMouseStates.h"
 #include "controls/mousestates/cMouseNormalState.h"

--- a/src/game/cGameConditionChecker.cpp
+++ b/src/game/cGameConditionChecker.cpp
@@ -7,6 +7,11 @@
 
 #include <cassert>
 
+#define WINLOSEFLAGS_AI_NO_BUILDINGS        0x01
+#define WINLOSEFLAGS_HUMAN_HAS_BUILDINGS    0x02
+#define WINLOSEFLAGS_QUOTA                  0x04
+#define WINLOSEFLAGS_TIMEOUT                0x08
+
 cGameConditionChecker::cGameConditionChecker(cGame* game) : m_game(game)
 {   
     assert(game != nullptr); 

--- a/src/gameobjects/units/cPathFinder.cpp
+++ b/src/gameobjects/units/cPathFinder.cpp
@@ -8,15 +8,12 @@
 #include "map/MapGeometry.hpp"
 #include "utils/d2tm_math.h"
 
+// Initialize the static temp_map
+ASTAR cPathFinder::temp_map[16384];
+
 // Path creation definitions / var
 #define CLOSED        -1
 #define OPEN          0
-
-struct ASTAR {
-    int cost;
-    int parent;
-    int state;
-};
 
 /*
   Pathfinder
@@ -43,8 +40,6 @@ struct ASTAR {
   */
 int cPathFinder::createPath(int iUnitId, int iPathCountUnits)
 {
-    ASTAR temp_map[16384]; // 4096 = 64x64 map, 16384 = 128x128 map
-
     logbook("CREATE_PATH -- START");
     if (iUnitId < 0) {
         logbook("CREATE_PATH -- END 1");

--- a/src/gameobjects/units/cPathFinder.h
+++ b/src/gameobjects/units/cPathFinder.h
@@ -2,10 +2,16 @@
 
 #include <vector>
 
+struct ASTAR {
+    int cost;
+    int parent;
+    int state;
+};
+
 class cPathFinder {
 public:
     static int createPath(int iUnitId, int iPathCountUnits);
     static int returnCloseGoal(int iCll, int iMyCell, int iID);
-private: 
-
+private:
+    static ASTAR temp_map[16384];
 };

--- a/src/gameobjects/units/cUnit.h
+++ b/src/gameobjects/units/cUnit.h
@@ -19,6 +19,8 @@
 #include <memory>
 #include <string>
 
+static constexpr int MAX_PATH_SIZE = 256;
+
 class cPlayer;
 class cTextDrawer;
 class cAbstractStructure;

--- a/src/gamestates/cSelectYourNextConquestState.h
+++ b/src/gamestates/cSelectYourNextConquestState.h
@@ -2,7 +2,7 @@
 
 #include "definitions.h"
 #include "cGameState.h"
-#include "definitions.h"
+// #include "definitions.h"
 #include "drawers/cTextDrawer.h"
 
 class cGame;
@@ -15,8 +15,6 @@ class GameContext;
 class SDLDrawer;
 
 struct s_DataCampaign;
-
-
 enum eRegionState {
     REGSTATE_INIT,                   // Initialization
     REGSTATE_INTRODUCTION,           // The very beginning, ie "3 houses have come to Dune" and ends with drawing the dune regions
@@ -51,7 +49,9 @@ class cSelectYourNextConquestState : public cGameState {
 public:
     explicit cSelectYourNextConquestState(cGame &theGame, GameContext *ctx, s_DataCampaign* dataCompaign);
     ~cSelectYourNextConquestState() override;
+static constexpr int MAX_REGIONS = 27;
 
+    
     void thinkFast() override;
     void draw() const override;
 

--- a/src/include/definitions.h
+++ b/src/include/definitions.h
@@ -15,7 +15,7 @@
 // #define MAX_REGIONS		27			// not more then 27 regions as dune 2 has
 
 // Max length of a path (per unit)
-#define MAX_PATH_SIZE    256
+// #define MAX_PATH_SIZE    256
 
 // // INTRO SCENES:
 // #define SCENE_NONE		-1

--- a/src/include/definitions.h
+++ b/src/include/definitions.h
@@ -46,7 +46,7 @@
 // #define MAP_FOG           2   // area is still fogged
 
 // SCROLLING (on a map)
-#define MAP_SCROLLSPEED   TILE_SIZE_PIXELS   // pixels per frames scrolling.
+// #define MAP_SCROLLSPEED   TILE_SIZE_PIXELS   // pixels per frames scrolling.
 
 // MEMORY USAGE: (units, structures, etc , more info below)
 // #define MAX_UNITS        300     // max of units in the game

--- a/src/include/definitions.h
+++ b/src/include/definitions.h
@@ -51,7 +51,7 @@
 // MEMORY USAGE: (units, structures, etc , more info below)
 // #define MAX_UNITS        300     // max of units in the game
 #define MAX_STRUCTURES   200     // max of structures in the game
-#define MAX_SKIRMISHMAPS 100     // max of 100 skirmish maps
+// #define MAX_SKIRMISHMAPS 100     // max of 100 skirmish maps
 
 #define HUMAN			0  // 0 = HUMAN			== ALLIES WITH FREMEN WHEN ATREIDES
 #define AI_CPU1         1  // 1 = CPU (Atreides)

--- a/src/include/definitions.h
+++ b/src/include/definitions.h
@@ -1,9 +1,9 @@
 #ifndef DEFINITIONS_H_
 #define DEFINITIONS_H_
 
-#define MOUSECELL_TOPBAR  -1
-#define MOUSECELL_MINIMAP -2
-#define MOUSECELL_SIDEBAR -3
+// #define MOUSECELL_TOPBAR  -1
+// #define MOUSECELL_MINIMAP -2
+// #define MOUSECELL_SIDEBAR -3
 
 // MAP ID
 #define MAPID_UNITS  0

--- a/src/include/definitions.h
+++ b/src/include/definitions.h
@@ -249,10 +249,10 @@ const int D2TM_PARTICLE_SMOKE_WITH_SHADOW       = 35;
 // #define SMUDGE_WALL 2
 
 // Win/lose bit flags, borrowed from Dune Legacy's implementation
-#define WINLOSEFLAGS_AI_NO_BUILDINGS        0x01
-#define WINLOSEFLAGS_HUMAN_HAS_BUILDINGS    0x02
-#define WINLOSEFLAGS_QUOTA                  0x04
-#define WINLOSEFLAGS_TIMEOUT                0x08
+// #define WINLOSEFLAGS_AI_NO_BUILDINGS        0x01
+// #define WINLOSEFLAGS_HUMAN_HAS_BUILDINGS    0x02
+// #define WINLOSEFLAGS_QUOTA                  0x04
+// #define WINLOSEFLAGS_TIMEOUT                0x08
 
 
 /**

--- a/src/include/definitions.h
+++ b/src/include/definitions.h
@@ -12,7 +12,7 @@
 #define MAPID_WORMS  3
 #define MAPID_MAX	 4 // used for clearing all
 
-#define MAX_REGIONS		27			// not more then 27 regions as dune 2 has
+// #define MAX_REGIONS		27			// not more then 27 regions as dune 2 has
 
 // Max length of a path (per unit)
 #define MAX_PATH_SIZE    256

--- a/src/map/cPreviewMaps.cpp
+++ b/src/map/cPreviewMaps.cpp
@@ -22,7 +22,7 @@ cPreviewMaps::cPreviewMaps(SDLDrawer *renderDrawer, bool debugMode) : m_renderDr
 
 void cPreviewMaps::destroy()
 {
-    for (int i = 0; i < MAX_SKIRMISHMAPS; i++) {
+    for (int i = 0; i < MAX_SKIRMISHMAPS_CAPACITY; i++) {
         s_PreviewMap &previewMap = m_PreviewMap[i];
         if (previewMap.terrain) {
             SDL_FreeSurface(previewMap.terrain);
@@ -38,7 +38,7 @@ void cPreviewMaps::destroy()
 void cPreviewMaps::loadSkirmish(const std::string &filename)
 {
     int iNew = -1;
-    for (int i = 0; i < MAX_SKIRMISHMAPS; i++) {
+    for (int i = 0; i < MAX_SKIRMISHMAPS_CAPACITY; i++) {
         if (m_PreviewMap[i].name[0] == '\0') {
             iNew = i;
             break;
@@ -221,7 +221,7 @@ void cPreviewMaps::initPreviews()
 {
     //reset all ressources
     destroy();
-    for (int i = 0; i < MAX_SKIRMISHMAPS; i++) {
+    for (int i = 0; i < MAX_SKIRMISHMAPS_CAPACITY; i++) {
         s_PreviewMap &previewMap = m_PreviewMap[i];
         // clear out name
         previewMap.name.clear();
@@ -259,7 +259,7 @@ void cPreviewMaps::initRandomMap()
 }
 
 std::string cPreviewMaps::getMapSize(int i) const {
-    if (i > MAX_SKIRMISHMAPS) {
+    if (i > MAX_SKIRMISHMAPS_CAPACITY) {
         return "Invalid";
     }
     int playableCells = (m_PreviewMap[i].width-2) * (m_PreviewMap[i].height-2);

--- a/src/map/cPreviewMaps.h
+++ b/src/map/cPreviewMaps.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define MAX_SKIRMISHMAPS 100     // max of 100 skirmish maps
+// #define MAX_SKIRMISHMAPS 100     // max of 100 skirmish maps
 
 #include <SDL2/SDL.h>
 #include <vector>
@@ -34,7 +34,7 @@ public:
     void destroy();
 
     s_PreviewMap &getMap(int i) {
-        if (i > MAX_SKIRMISHMAPS) {
+        if (i > MAX_SKIRMISHMAPS_CAPACITY) {
             return m_PreviewMap[0];
         }
         return m_PreviewMap[i];
@@ -53,8 +53,9 @@ private:
     void initRandomMap();
     void initPreviews();
     int m_numberOfMaps = 0; // Review Stefan 25/10/2025 -> Replace with size of array m_PreviewMap?
+    static constexpr int MAX_SKIRMISHMAPS_CAPACITY = 300;
 
-    std::array<s_PreviewMap, MAX_SKIRMISHMAPS> m_PreviewMap;
+    std::array<s_PreviewMap, MAX_SKIRMISHMAPS_CAPACITY> m_PreviewMap;
     SDLDrawer * m_renderDrawer;
     bool m_debugMode;
 };


### PR DESCRIPTION
## **Goal**

Remove some old define  to class and improve code quality

### Changes
- Fix `ASTAR temp_map` as static to avoid recreate it on every call
- Remove define from `definitions.h` to right destination
- Transform define to constexpr as possible 