### PR TITLE
Technical / remove renderer from `cPlayer` class

### DIFF
--- a/src/drawers/cOrderDrawer.cpp
+++ b/src/drawers/cOrderDrawer.cpp
@@ -8,6 +8,7 @@
 #include "player/cPlayer.h"
 #include "sidebar/cSideBar.h"
 #include "utils/Graphics.hpp"
+#include "utils/texture_utils.h"
 #include "context/GameContext.hpp"
 #include "context/GraphicsContext.hpp"
 #include <SDL2/SDL.h>
@@ -21,7 +22,7 @@ cOrderDrawer::cOrderDrawer(GameContext *ctx, cPlayer *player) :
     assert(player != nullptr);
     assert(ctx != nullptr);
     auto *gfxinter = m_ctx->getGraphicsContext()->gfxinter.get();
-    m_buttonBitmap = player->createTextureFromIndexedSurfaceWithPalette(gfxinter->getSurface(BTN_ORDER), TransparentColorIndex);
+    m_buttonBitmap = createPlayerTextureFromIndexedSurfaceWithPalette(player, gfxinter->getSurface(BTN_ORDER), TransparentColorIndex);
     int halfOfButton = m_buttonBitmap->w / 2;
     int halfOfSidebar = cSideBar::SidebarWidthWithoutCandyBar / 2;
     int halfOfHeightLeftForButton = 50 / 2; // 50 = height of 1 row icons which is removed for Starport

--- a/src/drawers/cSideBarDrawer.cpp
+++ b/src/drawers/cSideBarDrawer.cpp
@@ -8,6 +8,7 @@
 #include "managers/cDrawManager.h"
 #include "player/cPlayer.h"
 #include "utils/Graphics.hpp"
+#include "utils/texture_utils.h"
 #include "context/GameContext.hpp"
 #include "context/GraphicsContext.hpp"
 #include "context/cInfoContext.h"
@@ -27,12 +28,12 @@ cSideBarDrawer::cSideBarDrawer(GameContext *ctx, cPlayer *player) :
     assert(player!= nullptr);
     assert(ctx != nullptr);
 
-    m_candyBarBall = m_player->createTextureFromIndexedSurfaceWithPalette(
-        m_gfxinter->getSurface(BMP_GERALD_CANDYBAR_BALL), TransparentColorIndex);
-    m_candyBarPiece = m_player->createTextureFromIndexedSurfaceWithPalette(
-        m_gfxinter->getSurface(BMP_GERALD_CANDYBAR_PIECE), TransparentColorIndex);
-    m_candyHorizonBar = m_player->createTextureFromIndexedSurfaceWithPalette(
-        m_gfxinter->getSurface(HORIZONTAL_CANDYBAR), TransparentColorIndex);
+    m_candyBarBall = createPlayerTextureFromIndexedSurfaceWithPalette(
+        m_player, m_gfxinter->getSurface(BMP_GERALD_CANDYBAR_BALL), TransparentColorIndex);
+    m_candyBarPiece = createPlayerTextureFromIndexedSurfaceWithPalette(
+        m_player, m_gfxinter->getSurface(BMP_GERALD_CANDYBAR_PIECE), TransparentColorIndex);
+    m_candyHorizonBar = createPlayerTextureFromIndexedSurfaceWithPalette(
+        m_player, m_gfxinter->getSurface(HORIZONTAL_CANDYBAR), TransparentColorIndex);
 
     m_candiBarRenderer = m_renderDrawer->createRenderTargetTexture(cSideBar::SidebarWidth, game.m_gameSettings->getScreenH()-40);
     m_renderDrawer->beginDrawingToTexture(m_candiBarRenderer);

--- a/src/gameobjects/particles/cParticle.cpp
+++ b/src/gameobjects/particles/cParticle.cpp
@@ -11,6 +11,7 @@
 
 #include "cParticle.h"
 #include "utils/RNG.hpp"
+#include "utils/texture_utils.h"
 #include "game/cGame.h"
 #include "include/d2tmc.h"
 #include "drawers/SDLDrawer.hpp"
@@ -848,7 +849,7 @@ void cParticle::recolorForHouseIfGiven() {
     
     cPlayer &player = game.m_gameObjectsContext->getPlayer(this->iHousePal);
     auto tex = gfxdata->getSurface(bmpIndex);
-    auto recoloredBmp = player.createTextureFromIndexedSurfaceWithPalette(tex, TransparentColorIndex);
+    auto recoloredBmp = createPlayerTextureFromIndexedSurfaceWithPalette(&player, tex, TransparentColorIndex);
     if (recoloredBmp != nullptr) {
         // but why did createTextureFromIndexedSurfaceWithPalette give an error ?
         bmp = recoloredBmp;

--- a/src/gamestates/cSelectYourNextConquestState.cpp
+++ b/src/gamestates/cSelectYourNextConquestState.cpp
@@ -9,6 +9,7 @@
 #include "drawers/SDLDrawer.hpp"
 #include "drawers/cMessageDrawer.h"
 #include "utils/ini.h"
+#include "utils/texture_utils.h"
 #include "include/sDataCampaign.h"
 #include "managers/cDrawManager.h"
 #include "player/cPlayer.h"
@@ -485,7 +486,7 @@ void cSelectYourNextConquestState::regionDraw(cRegion &regionPiece) const
         cPlayer &temp = game.m_gameObjectsContext->getPlayer(regionPiece.iHouse);
         // select_palette(temp.pal);
         if (regionPiece.iHouse!=regionPiece.oldHouse) {
-            regionPiece.bmpColor = temp.createTextureFromIndexedSurfaceWithPalette(regionPiece.bmp, TransparentColorIndex);
+            regionPiece.bmpColor = createPlayerTextureFromIndexedSurfaceWithPalette(&temp, regionPiece.bmp, TransparentColorIndex);
             regionPiece.oldHouse=regionPiece.iHouse;
         }
         drawRegion(regionPiece);
@@ -496,7 +497,7 @@ void cSelectYourNextConquestState::regionDraw(cRegion &regionPiece) const
         int iHouse = game.m_gameObjectsContext->getPlayer(HUMAN).getHouse();
         cPlayer &temp = game.m_gameObjectsContext->getPlayer(iHouse);
         if (regionPiece.iHouse!=regionPiece.oldHouse) {
-            regionPiece.bmpColor = temp.createTextureFromIndexedSurfaceWithPalette(regionPiece.bmp, TransparentColorIndex);
+            regionPiece.bmpColor = createPlayerTextureFromIndexedSurfaceWithPalette(&temp, regionPiece.bmp, TransparentColorIndex);
         }
         drawRegion(regionPiece);
     }

--- a/src/managers/cDrawManager.cpp
+++ b/src/managers/cDrawManager.cpp
@@ -15,6 +15,7 @@
 #include "player/cPlayers.h"
 #include "gameobjects/units/cUnits.h"
 #include "utils/Graphics.hpp"
+#include "utils/texture_utils.h"
 #include "context/GameContext.hpp"
 #include "context/GraphicsContext.hpp"
 #include "context/cInfoContext.h"
@@ -45,8 +46,8 @@ cDrawManager::cDrawManager(GameContext *ctx, cPlayer *thePlayer) :
     m_messageDrawer = std::make_unique<cMessageDrawer>(ctx);
     m_placeitDrawer = std::make_unique<cPlaceItDrawer>(ctx,thePlayer);
     m_structureDrawer = std::make_unique<cStructureDrawer>(ctx);
-    m_btnOptions = thePlayer->createTextureFromIndexedSurfaceWithPalette(
-        m_gfxinter->getSurface(BTN_OPTIONS), TransparentColorIndex
+    m_btnOptions = createPlayerTextureFromIndexedSurfaceWithPalette(
+        thePlayer, m_gfxinter->getSurface(BTN_OPTIONS), TransparentColorIndex
     );
     m_mouseDrawer = new cMouseDrawer(thePlayer, ctx->getTextContext()->getSmallTextDrawer());
 }

--- a/src/player/cPlayer.cpp
+++ b/src/player/cPlayer.cpp
@@ -11,6 +11,7 @@
 #include "gameobjects/structures/cStructures.h"
 #include "utils/cStructureUtils.h"
 #include "utils/common.h"
+#include "utils/texture_utils.h"
 #include "utils/cSoundPlayer.h"
 #include "player/cHousesInfo.h"
 #include "drawers/SDLDrawer.hpp"
@@ -113,6 +114,11 @@ void cPlayer::clearStructureTypeBitmaps()
 void cPlayer::setFocusCell(int cll)
 {
     this->focusCell_ = cll;
+}
+
+int cPlayer::getSwapColor() const
+{
+    return m_HousesInfo->getSwapColor(this->house);
 }
 
 void cPlayer::clearUnitTypeBitmaps()
@@ -273,8 +279,8 @@ void cPlayer::setHouse(int iHouse)
         emblemBackgroundColor = getEmblemBackgroundColorForHouse(house);
 
         destroyAllegroBitmaps();
-        bmp_flag = createTextureFromIndexedSurfaceWithPalette(gfxdata->getSurface(BUILDING_FLAG_LARGE),TransparentColorIndex);
-        bmp_flag_small = createTextureFromIndexedSurfaceWithPalette(gfxdata->getSurface(BUILDING_FLAG_SMALL),TransparentColorIndex);
+        bmp_flag = createPlayerTextureFromIndexedSurfaceWithPalette(this, gfxdata->getSurface(BUILDING_FLAG_LARGE),TransparentColorIndex);
+        bmp_flag_small = createPlayerTextureFromIndexedSurfaceWithPalette(this, gfxdata->getSurface(BUILDING_FLAG_SMALL),TransparentColorIndex);
 
         // now copy / set all structures for this player, with the correct color
         for (int i = 0; i < MAX_STRUCTURETYPES; i++) {
@@ -282,7 +288,7 @@ void cPlayer::setHouse(int iHouse)
 
             if (!structureType.configured) continue;
 
-            bmp_structure[i] = createTextureFromIndexedSurfaceWithPalette(structureType.bmp, TransparentColorIndex);
+            bmp_structure[i] = createPlayerTextureFromIndexedSurfaceWithPalette(this, structureType.bmp, TransparentColorIndex);
             if (!bmp_structure[i]) {
                 std::cerr << "Could not create bmp structure bitmap!? - Imminent crash.\n";
             }
@@ -294,7 +300,7 @@ void cPlayer::setHouse(int iHouse)
                 if (!bitmap) {
                     std::cerr << "Could not create FLASH bmp structure bitmap!? - Imminent crash.\n";
                 }
-                bmp_structure[j] = createTextureFromIndexedSurfaceWithPalette(structureType.flash, TransparentColorIndex);
+                bmp_structure[j] = createPlayerTextureFromIndexedSurfaceWithPalette(this, structureType.flash, TransparentColorIndex);
             }
 
         }
@@ -304,13 +310,13 @@ void cPlayer::setHouse(int iHouse)
         for (int i = 0; i < MAX_UNITTYPES; i++) {
             s_UnitInfo &unitType = game.m_infoContext->getUnitInfo(i);
 
-            bmp_unit[i] = createTextureFromIndexedSurfaceWithPalette(unitType.bmp, TransparentColorIndex);
+            bmp_unit[i] = createPlayerTextureFromIndexedSurfaceWithPalette(this, unitType.bmp, TransparentColorIndex);
             if (!bmp_unit[i]) {
                 std::cerr << "Could not create bmp unit bitmap!? - Imminent crash.\n";
             }
             if (unitType.top) {
 
-                bmp_unit_top[i] = createTextureFromIndexedSurfaceWithPalette(unitType.top, TransparentColorIndex);
+                bmp_unit_top[i] = createPlayerTextureFromIndexedSurfaceWithPalette(this, unitType.top, TransparentColorIndex);
             }
         }
     }
@@ -2317,13 +2323,4 @@ void cPlayer::onMyStructureDestroyed(const s_GameEvent &event)
     if (event.entitySpecificType == REFINERY) {
         reinforceHarvesterIfNeeded(event.atCell);
     }
-}
-
-
-Texture *cPlayer::createTextureFromIndexedSurfaceWithPalette(SDL_Surface *referenceSurface, int paletteIndexForTransparency)
-{
-    assert(referenceSurface && "referenceSurface must be given");
-    int swapStart = m_HousesInfo->getSwapColor(house);
-    if (swapStart < 0) swapStart = -1;
-    return global_renderDrawer->createTextureFromIndexedSurfaceWithPalette(referenceSurface, paletteIndexForTransparency, swapStart);
 }

--- a/src/player/cPlayer.h
+++ b/src/player/cPlayer.h
@@ -492,7 +492,8 @@ public:
 
     void deselectUnit(const int &unitId);
 
-    Texture *createTextureFromIndexedSurfaceWithPalette(SDL_Surface *referenceSurface, int paletteIndexForTransparency);
+    int getSwapColor() const;
+
 private:
     cBuildingListItem *isUpgradeAvailableToGrant(eBuildType providesType, int providesTypeId) const;
 

--- a/src/utils/texture_utils.cpp
+++ b/src/utils/texture_utils.cpp
@@ -1,0 +1,13 @@
+#include "texture_utils.h"
+#include "player/cPlayer.h"
+#include "drawers/SDLDrawer.hpp"
+#include "game/cGame.h"
+#include "include/d2tmc.h"
+
+Texture* createPlayerTextureFromIndexedSurfaceWithPalette(cPlayer* player, SDL_Surface* referenceSurface, int paletteIndexForTransparency) {
+    assert(player && "player must be given");
+    assert(referenceSurface && "referenceSurface must be given");
+    int swapStart = player->getSwapColor();
+    if (swapStart < 0) swapStart = -1;
+    return global_renderDrawer->createTextureFromIndexedSurfaceWithPalette(referenceSurface, paletteIndexForTransparency, swapStart);
+}

--- a/src/utils/texture_utils.h
+++ b/src/utils/texture_utils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <SDL2/SDL.h>
+
+class Texture;
+class cPlayer;
+
+// function to create a texture from an indexed surface, applying the player-specific palette.
+Texture* createPlayerTextureFromIndexedSurfaceWithPalette(cPlayer* player, SDL_Surface* referenceSurface, int paletteIndexForTransparency);


### PR DESCRIPTION
## **Goal**

`cPlayer` didn't need access to renderer yet.

### Changes
- Create `texture_utils.h` 
- Move `createTextureFromIndexedSurfaceWithPalette` to `texture_utils.h` 

## Testing Steps
All units from houses have the correct color
