### PR TITLE
Fix compiler warnings (mismatched-tags, sign-compare, pessimizing-move)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ if (APPLE)
         "-Wpedantic"
         "-Wzero-as-null-pointer-constant"
         "-Wextra-semi"
+        "-Werror"
     )
 elseif (UNIX)
     target_compile_options(${PROJECT_NAME}
@@ -145,6 +146,7 @@ elseif (UNIX)
         "-Wredundant-tags"
         "-Wzero-as-null-pointer-constant"
         "-Wextra-semi"
+        "-Werror"
         #"-Wsuggest-override"
         #"-Wmismatched-tags"
         #"-Wdeprecated-declarations"
@@ -161,6 +163,7 @@ else()
         "-Wredundant-tags"
         "-Wzero-as-null-pointer-constant"
         "-Wextra-semi"
+        "-Werror"
     )
   	target_link_libraries(${PROJECT_NAME}
   	PRIVATE

--- a/src/context/cInfoContextCreator.cpp
+++ b/src/context/cInfoContextCreator.cpp
@@ -856,7 +856,7 @@ void cInfoContextCreator::initBullets(cBulletInfos& bulletInfos)
 {
     logbook("Installing:  BULLET TYPES");
 
-    for (int i = 0; i < bulletInfos.size(); i++) {
+    for (size_t i = 0; i < bulletInfos.size(); i++) {
         bulletInfos[i].bmp = nullptr; // in case an invalid bitmap; default is a small rocket
         bulletInfos[i].moveSpeed = 2;
         bulletInfos[i].deathParticle = -1; // this points to a bitmap (in data file, using index)

--- a/src/context/cInfoContextCreator.h
+++ b/src/context/cInfoContextCreator.h
@@ -9,7 +9,7 @@ class cSpecialInfos;
 class cUpgradeInfos;
 class cUnitInfos;
 class cInfoContext;
-class SDL_Renderer;
+struct SDL_Renderer;
 struct s_TerrainInfo;
 
 class cInfoContextCreator {

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -68,7 +68,7 @@ struct s_PreviewMap;
 // thinkSlow_....() --> for now used to distinguish certain speed of "thinking" / invocations
 // state_...() --> because elegible for moving away
 
-class sGameServices;
+struct sGameServices;
 
 class cGame : public cScenarioObserver, cInputObserver {
 

--- a/src/gamestates/cCreditsState.cpp
+++ b/src/gamestates/cCreditsState.cpp
@@ -46,7 +46,7 @@ cCreditsState::cCreditsState(cGame &theGame, sGameServices* services) :
     int backButtonY = m_settings->getScreenH() - 21;
     int backButtonX = 0;
     cRectangle backButtonRect(backButtonX, backButtonY, backButtonWidth, backButtonHeight);
-    backButton = std::move(GuiButtonBuilder()
+    backButton = GuiButtonBuilder()
             .withRect(backButtonRect)
             .withLabel("BACK")
             .withTextDrawer(m_textDrawer)
@@ -57,7 +57,7 @@ cCreditsState::cCreditsState(cGame &theGame, sGameServices* services) :
                 m_game.setNextStateToTransitionTo(GAME_MENU);
                 m_game.initiateFadingOut();
             })
-            .build());
+            .build();
 
     m_lines = std::vector<s_CreditLine>();
     prepareCrawlerLines();

--- a/src/gamestates/cMainMenuState.cpp
+++ b/src/gamestates/cMainMenuState.cpp
@@ -55,7 +55,7 @@ cMainMenuState::cMainMenuState(cGame &theGame, sGameServices* services) :
     int creditsX = (m_settings->getScreenW() / 2) - buttonWidth;
     const cRectangle &creditsRect = cRectangle(creditsX, 0, buttonWidth, buttonHeight);
 
-    gui_btn_credits = std::move(GuiButtonBuilder()
+    gui_btn_credits = GuiButtonBuilder()
             .withRect(creditsRect)        
             .withLabel("CREDITS")
             .withTextDrawer(m_textDrawer)
@@ -65,7 +65,7 @@ cMainMenuState::cMainMenuState(cGame &theGame, sGameServices* services) :
             .onClick([this]() {
                 m_game.setNextStateToTransitionTo(GAME_CREDITS);
                 m_game.initiateFadingOut();})
-            .build());
+            .build();
 
     /////////////////////////////////
     //// Main Menu

--- a/src/mentat/BeneMentat.cpp
+++ b/src/mentat/BeneMentat.cpp
@@ -25,23 +25,23 @@ BeneMentat::BeneMentat(GameContext* ctx, s_DataCampaign* dataCampaign) : Abstrac
     buildLeftButton(gfxmentat->getTexture(BTN_NO), 293, 423);
     buildRightButton(gfxmentat->getTexture(BTN_YES), 466, 423);
 
-    leftGuiButton = std::move(GuiButtonBuilder()
-            .withRect(*leftButton)        
+    leftGuiButton = GuiButtonBuilder()
+            .withRect(*leftButton)
             .withLabel("No")
             .withTexture(gfxmentat->getTexture(BTN_NO))
             .withRenderer(m_renderDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
             .onClick([this]() { this->onNoButtonPressed(); })
-            .build());
+            .build();
 
-    rightGuiButton = std::move(GuiButtonBuilder()
-            .withRect(*rightButton)        
+    rightGuiButton = GuiButtonBuilder()
+            .withRect(*rightButton)
             .withLabel("Yes")
             .withTexture(gfxmentat->getTexture(BTN_YES))
             .withRenderer(m_renderDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
             .onClick([this]() { this->onYesButtonPressed(); })
-            .build());
+            .build();
 }
 
 void BeneMentat::onYesButtonPressed()


### PR DESCRIPTION
N/A (no specific issue)

## **Goal**

Fix compiler warnings that were present in the codebase.

### Changes

- Change `class SDL_Renderer` to `struct SDL_Renderer` in `cInfoContextCreator.h` to match SDL2's definition and fix `-Wmismatched-tags`
- Change `class sGameServices` to `struct sGameServices` in `cGame.h` to match the actual definition and fix `-Wmismatched-tags`
- Use `size_t` instead of `int` for loop counter in `cInfoContextCreator.cpp` to fix `-Wsign-compare`
- Remove redundant `std::move()` on temporaries in `cCreditsState.cpp`, `cMainMenuState.cpp`, and `BeneMentat.cpp` to fix `-Wpessimizing-move`

## Testing Steps

Build the project and verify no warnings are emitted:
```sh
./rebuildmacos.sh
```

## Screenshots (optional)