### PR TITLE
Fix starport order bugs

### DIFF
--- a/src/drawers/cBuildingListDrawer.cpp
+++ b/src/drawers/cBuildingListDrawer.cpp
@@ -4,6 +4,7 @@
 #include "game/cGame.h"
 #include "include/d2tmc.h"
 #include "data/gfxinter.h"
+#include "gameobjects/structures/cOrderProcesser.h"
 #include "player/cPlayer.h"
 #include "utils/Graphics.hpp"
 #include "context/GameContext.hpp"
@@ -251,7 +252,9 @@ void cBuildingListDrawer::drawList(cBuildingList *list, bool shouldDrawStructure
             if (list->getType() == eListType::LIST_STARPORT) {
                 // only for starport show you can't pay it, as we allow building units when you cannot pay it (ie partial
                 // payment/progress)
-                if (cannotPayIt) {
+                cOrderProcesser *orderProcesser = m_player->getOrderProcesser();
+                bool orderIsAwaitingFrigate = orderProcesser->isOrderPlaced() || orderProcesser->isFrigateSent();
+                if (cannotPayIt || orderIsAwaitingFrigate) {
                     m_renderDrawer->renderSprite(m_gfxinter->getTexture(PROGRESSNA), iDrawX, iDrawY,64);
                     Color errorFadingColor = m_player->getErrorFadingColor();
                     m_renderDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, errorFadingColor);

--- a/src/drawers/cOrderDrawer.cpp
+++ b/src/drawers/cOrderDrawer.cpp
@@ -43,15 +43,14 @@ void cOrderDrawer::drawOrderButton(cPlayer *thePlayer)
     cOrderProcesser *orderProcesser = thePlayer->getOrderProcesser();
 
     assert(orderProcesser);
-    if (orderProcesser->isOrderPlaced()) { //grey
-        m_renderDrawer->renderSprite(m_buttonBitmap, m_buttonRect.getX(), m_buttonRect.getY());
+    m_renderDrawer->renderSprite(m_buttonBitmap, m_buttonRect.getX(), m_buttonRect.getY());
+
+    bool canOrder = orderProcesser->canPlaceOrder();
+    if (!canOrder) {
         m_renderDrawer->renderRectColor(m_buttonRect,0,0,0,128);
     }
-    else {
-        m_renderDrawer->renderSprite(m_buttonBitmap, m_buttonRect.getX(), m_buttonRect.getY());
-    }
 
-    if (m_isMouseOverOrderButton) {
+    if (m_isMouseOverOrderButton && canOrder) {
         drawRectangleOrderButton();
     }
 }

--- a/src/drawers/cOrderDrawer.cpp
+++ b/src/drawers/cOrderDrawer.cpp
@@ -47,7 +47,7 @@ void cOrderDrawer::drawOrderButton(cPlayer *thePlayer)
 
     bool canOrder = orderProcesser->canPlaceOrder();
     if (!canOrder) {
-        m_renderDrawer->renderRectColor(m_buttonRect,0,0,0,128);
+        m_renderDrawer->renderRectFillColor(m_buttonRect, Color::Black, 128);
     }
 
     if (m_isMouseOverOrderButton && canOrder) {

--- a/src/gameobjects/structures/cOrderProcesser.cpp
+++ b/src/gameobjects/structures/cOrderProcesser.cpp
@@ -71,6 +71,7 @@ bool cOrderProcesser::acceptsOrders()
 {
     int freeSlot = getFreeSlot();
     bool result = m_frigateSent == false && m_orderPlaced == false && freeSlot > -1;
+    result = result && m_player->hasAtleastOneStructure(STARPORT);
     return result;
 }
 

--- a/src/gameobjects/structures/cOrderProcesser.cpp
+++ b/src/gameobjects/structures/cOrderProcesser.cpp
@@ -279,6 +279,7 @@ void cOrderProcesser::setOrderHasBeenProcessed()
 {
     m_orderPlaced = false;
     m_frigateSent = false;
+    m_secondsUntilArrival = -1;
     removeAllItems();
     m_unitIdOfFrigateSent = -1;
 }

--- a/src/sidebar/cBuildingList.cpp
+++ b/src/sidebar/cBuildingList.cpp
@@ -403,6 +403,13 @@ void cBuildingList::removeAllSublistItems(int sublistId)
     }
 }
 
+void cBuildingList::clearList()
+{
+    while (m_maxItems > 0) {
+        removeItemFromList(m_maxItems - 1);
+    }
+}
+
 void cBuildingList::resetTimesOrderedForAllItems()
 {
     for (int i = 0; i < MAX_ITEMS; i++) {

--- a/src/sidebar/cBuildingList.h
+++ b/src/sidebar/cBuildingList.h
@@ -136,6 +136,8 @@ public:
 
     void removeAllSublistItems(int sublistId);
 
+    void clearList();
+
     void resetTimesOrderedForAllItems();
 
     void setItemBuilder(cItemBuilder *value);

--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -445,6 +445,9 @@ void cBuildingListUpdater::onStructureDestroyed(int structureType)
             pProcesser->clear();
             cBuildingList *listStarport = sideBar->getList(eListType::LIST_STARPORT);
             listStarport->resetTimesOrderedForAllItems();
+            if (sideBar->getSelectedListID() == eListTypeAsInt(eListType::LIST_STARPORT)) {
+                sideBar->findFirstActiveListAndSelectIt();
+            }
         }
     }
 

--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -444,7 +444,7 @@ void cBuildingListUpdater::onStructureDestroyed(int structureType)
             cOrderProcesser *pProcesser = m_player->getOrderProcesser();
             pProcesser->clear();
             cBuildingList *listStarport = sideBar->getList(eListType::LIST_STARPORT);
-            listStarport->resetTimesOrderedForAllItems();
+            listStarport->clearList();
             if (sideBar->getSelectedListID() == eListTypeAsInt(eListType::LIST_STARPORT)) {
                 sideBar->findFirstActiveListAndSelectIt();
             }


### PR DESCRIPTION
Closes #758

## Summary

Three related starport bugs fixed, each in its own commit:

- **Bug: countdown continues after starport destroyed** — `setOrderHasBeenProcessed()` now resets `m_secondsUntilArrival` to `-1`, so the T-minus timer stops immediately when all starports are destroyed.
- **Bug: icons not shown as unavailable while awaiting frigate** — `cBuildingListDrawer` now checks `isOrderPlaced() || isFrigateSent()` and applies the "not available" overlay when the player cannot place new orders.
- **Bug: build list remains interactive after destruction** — `acceptsOrders()` now guards against no-starport state, and the sidebar auto-switches away from the starport list when the last one is destroyed.

## Test plan

- [ ] Build compiles without errors (`./rebuildmacos.sh`)
- [ ] Order units from starport → all icons show "not available" overlay while awaiting frigate
- [ ] Destroy your starport while an order is pending → countdown stops, no frigate arrives
- [ ] Destroy starport → sidebar switches away from the starport list; clicking starport items does not deduct money