### PR TITLE
Fix Windows build: buffer overflow parsing GEN cell in INI structures

### DIFF
--- a/src/utils/ini.cpp
+++ b/src/utils/ini.cpp
@@ -1065,20 +1065,9 @@ bool cIni::INI_Scenario_Section_Structures(int iHumanID, bool bSetUpPlayers, con
                     }
                 }
                 else if (iPart == 1) {
-                    // Figure out the cell shit of this GEN
-                    char cCell[5];
-                    for (int cc = 0; cc < 5; cc++)
-                        cCell[cc] = '\0';
-
-                    int iCC = 0;
-                    for (int cc = 3; cc < iIS; cc++) {
-                        cCell[iCC] = linefeed[cc];
-                        iCC++;
-                    }
-
-                    int iGenCell = atoi(cCell);
-
-                    iCell = iGenCell;
+                    // Extract cell number from GEN key: format is GEN<cell>=<house>,<structureType>
+                    // iIS is the position of '=', so the cell number sits between position 3 and iIS
+                    iCell = std::stoi(slinefeed.substr(3, iIS - 3));
 
                     if (strcmp(chunk, "Wall") == 0) iType = WALL;
                     if (strcmp(chunk, "Concrete") == 0) iType = SLAB1;


### PR DESCRIPTION
Fixes #926

## Summary

- The Windows (MinGW/GCC) build was failing because `ini.cpp` had a fixed 5-byte `char cCell[5]` buffer for reading the cell number out of `GEN<cell>=<house>,<structureType>` lines — GCC's `-Werror=stringop-overflow=` correctly caught the potential overrun and turned it into a compile error
- Replaced the manual byte-by-byte copy with `std::stoi(slinefeed.substr(3, iIS - 3))`, which extracts everything between `GEN` and `=` with no size constraint
- Supports 4, 5, and 6-digit cell numbers (128×128 maps and larger)

## Test plan

- [ ] Windows CI build passes (no `stringop-overflow` error in `ini.cpp`)
- [ ] macOS/Ubuntu builds still pass
- [ ] Load a campaign mission that uses GEN lines (e.g. scena005) and verify structures are placed correctly