### PR TITLE
Fix crash loading missions with sandworm units

### DIFF
--- a/src/gameobjects/units/cUnits.cpp
+++ b/src/gameobjects/units/cUnits.cpp
@@ -158,11 +158,9 @@ int cUnits::unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool 
     newUnit.guardTimer.reset(20 + RNG::rnd(70));
     newUnit.recreateDimensions();
 
-    // set (Correct!?) player id, when type is SANDWORM (!?)
+    // Sandworm units are always owned by AI_WORM. INI files typically specify "Fremen"
+    // as the house (player 5), but sandworms must be owned by AI_WORM (player 6).
     if (unitType == SANDWORM) {
-        if (iPlayer != AI_WORM) {
-            newUnit.log("ERROR: Wanted to create sandworm for player other than AI_WORM!?");
-        }
         iPlayer = AI_WORM;
     }
 


### PR DESCRIPTION
## Summary

- `cUnits::unitCreate()` called `newUnit.log()` at line 164, before `newUnit.iPlayer` was assigned (line 169)
- `cUnit::log()` calls `getPlayer(this->iPlayer)` — with `iPlayer` still uninitialized (-1), this fired the `cPlayers::operator[]` out-of-bounds assertion
- Root cause: INI files use `Fremen` (player 5) as the sandworm owner house, but sandworms must be owned by `AI_WORM` (player 6); the correction happened after the log call

**Fix:** move `iPlayer = AI_WORM` and `newUnit.iPlayer = iPlayer` before any log calls, and remove the now-dead error log (the condition `iPlayer != AI_WORM` can never be true after the correction).

## Test plan

- [ ] Build passes
- [ ] Play campaign mission 6 (first mission with sandworm units) — no crash on load
- [ ] Sandworms behave correctly in-game