### PR TITLE
Introduce Catch2 Unit-Testing Framework

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -44,6 +44,10 @@ jobs:
         run: |
           cd "${{ github.workspace }}\build"
           cmake --build . --target all -- -j -l 3
+      - name: Test
+        run: |
+          cd "${{ github.workspace }}\build"
+          ctest --output-on-failure
       - name: Produce binary
         run: |
           cd "${{ github.workspace }}"
@@ -103,6 +107,10 @@ jobs:
         run: |
           cd "${{ github.workspace }}/build"
           make -j4
+      - name: Test
+        run: |
+          cd "${{ github.workspace }}/build"
+          ctest --output-on-failure
       - name: Produce binary
         run: |
           cd "${{ github.workspace }}"
@@ -154,6 +162,10 @@ jobs:
         run: |
           cd "${{ github.workspace }}/build"
           make -j4
+      - name: Test
+        run: |
+          cd "${{ github.workspace }}/build"
+          ctest --output-on-failure
       - name: Produce binary
         run: |
           cd "${{ github.workspace }}"

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -37,6 +37,10 @@ jobs:
         run: |
           cd "${{ github.workspace }}\build"
           cmake --build . --target all -- -j -l 3
+      - name: Test
+        run: |
+          cd "${{ github.workspace }}\build"
+          ctest --output-on-failure
   Ubuntu:
     name: Ubuntu (x86)
     runs-on: [ ubuntu-latest ]
@@ -66,6 +70,10 @@ jobs:
         run: |
           cd "${{ github.workspace }}/build"
           make -j4
+      - name: Test
+        run: |
+          cd "${{ github.workspace }}/build"
+          ctest --output-on-failure
   MACOSX:
     name: Mac OS X (Arm64)
     runs-on: [ macos-15 ]
@@ -87,6 +95,10 @@ jobs:
         run: |
           cd "${{ github.workspace }}/build"
           make -j4
+      - name: Test
+        run: |
+          cd "${{ github.workspace }}/build"
+          ctest --output-on-failure
   MACOSX_INTEL:
     name: Mac OS X (Intel)
     runs-on: [ macos-15-intel ]
@@ -108,3 +120,7 @@ jobs:
         run: |
           cd "${{ github.workspace }}/build"
           make -j4
+      - name: Test
+        run: |
+          cd "${{ github.workspace }}/build"
+          ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,9 @@ endif()
 
 add_subdirectory(src)
 
+enable_testing()
+add_subdirectory(tests)
+
 add_executable(${PROJECT_NAME} ${D2TM_SRC} Script.rc)
 
 target_include_directories(${PROJECT_NAME}

--- a/rebuildmacos.sh
+++ b/rebuildmacos.sh
@@ -3,5 +3,6 @@ mkdir build
 cd build
 cmake ..
 cmake --build . --target all -- -j 6
+ctest --output-on-failure
 cd ..
 

--- a/rebuildwin.bat
+++ b/rebuildwin.bat
@@ -3,5 +3,6 @@ mkdir build
 cd build
 cmake .. -G "MinGW Makefiles"
 cmake --build . --target all -- -j 6
+ctest --output-on-failure
 cd ..
 

--- a/rebuildwinrelease.bat
+++ b/rebuildwinrelease.bat
@@ -3,6 +3,7 @@ mkdir Release
 cd Release
 cmake -DCMAKE_BUILD_TYPE=Release .. -G "MinGW Makefiles"
 cmake --build . --target all -- -j 6
+ctest --output-on-failure
 cd ..
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,31 +1,41 @@
 include(FetchContent)
 
-# On Apple Intel macs, the root CMakeLists.txt sets CMAKE_CXX_COMPILER / CMAKE_C_COMPILER
-# to bare names (e.g. "clang++") after its own project() call.  When FetchContent brings
-# in Catch2, that sub-project calls project() which requires an absolute compiler path.
+# The root CMakeLists.txt sets CMAKE_CXX_COMPILER / CMAKE_C_COMPILER after its own
+# project() call. CMake's initial compiler detection writes the system default (e.g.
+# /usr/bin/c++) into the cache. The root then overwrites the variable (e.g. to
+# /opt/homebrew/bin/g++-15 on arm64, or "clang++" on Intel). When FetchContent brings
+# in Catch2, that sub-project calls project() which re-detects the compiler from the
+# cache and may restore the system default, causing CMake to detect a "variables changed"
+# mismatch and re-run configure indefinitely (infinite loop on Apple Silicon).
 #
-# Fix: resolve bare names to absolute paths in this scope so child scopes (FetchContent)
-# inherit the absolute path. IS_ABSOLUTE is a no-op when the path is already absolute
-# (arm64 uses /opt/homebrew/bin/g++-15; Linux/Windows are detected with absolute paths).
+# Fix: before FetchContent runs, resolve any bare names to absolute paths and then
+# unconditionally force-update the cache to match the current variable value. This
+# ensures Catch2's project() call sees the intended compiler and does not re-detect.
 foreach(_lang CXX C)
     set(_compiler_var "CMAKE_${_lang}_COMPILER")
+    if("${${_compiler_var}}" STREQUAL "")
+        continue()
+    endif()
+
+    # Resolve bare names to absolute paths (needed on Apple Intel where "clang++"
+    # is set instead of a full path).
     if(NOT IS_ABSOLUTE "${${_compiler_var}}")
         find_program(_compiler_abs "${${_compiler_var}}"
             PATHS /usr/bin /usr/local/bin /opt/homebrew/bin
             NO_DEFAULT_PATH)
         if(NOT _compiler_abs)
-            # Fallback: let find_program search PATH normally
             find_program(_compiler_abs "${${_compiler_var}}")
         endif()
         if(_compiler_abs)
-            # Set normal variable in this scope — this shadows the parent's bare name
-            # and is inherited by any add_subdirectory() called from here (FetchContent).
             set(${_compiler_var} "${_compiler_abs}")
-            # Also update the cache so subsequent cmake runs see the absolute path.
-            set(${_compiler_var} "${_compiler_abs}" CACHE FILEPATH "${_lang} compiler" FORCE)
         endif()
         unset(_compiler_abs CACHE)
     endif()
+
+    # Force the cache to match the current value. Without this, Catch2's project()
+    # call re-detects the compiler and may write a different value, which triggers
+    # an infinite configure loop (observed on Apple Silicon / arm64).
+    set(${_compiler_var} "${${_compiler_var}}" CACHE FILEPATH "${_lang} compiler" FORCE)
 endforeach()
 unset(_lang)
 unset(_compiler_var)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,69 @@
+include(FetchContent)
+
+# On Apple Intel macs, the root CMakeLists.txt sets CMAKE_CXX_COMPILER / CMAKE_C_COMPILER
+# to bare names (e.g. "clang++") after its own project() call.  When FetchContent brings
+# in Catch2, that sub-project calls project() which requires an absolute compiler path.
+#
+# Fix: resolve bare names to absolute paths in this scope so child scopes (FetchContent)
+# inherit the absolute path. IS_ABSOLUTE is a no-op when the path is already absolute
+# (arm64 uses /opt/homebrew/bin/g++-15; Linux/Windows are detected with absolute paths).
+foreach(_lang CXX C)
+    set(_compiler_var "CMAKE_${_lang}_COMPILER")
+    if(NOT IS_ABSOLUTE "${${_compiler_var}}")
+        find_program(_compiler_abs "${${_compiler_var}}"
+            PATHS /usr/bin /usr/local/bin /opt/homebrew/bin
+            NO_DEFAULT_PATH)
+        if(NOT _compiler_abs)
+            # Fallback: let find_program search PATH normally
+            find_program(_compiler_abs "${${_compiler_var}}")
+        endif()
+        if(_compiler_abs)
+            # Set normal variable in this scope — this shadows the parent's bare name
+            # and is inherited by any add_subdirectory() called from here (FetchContent).
+            set(${_compiler_var} "${_compiler_abs}")
+            # Also update the cache so subsequent cmake runs see the absolute path.
+            set(${_compiler_var} "${_compiler_abs}" CACHE FILEPATH "${_lang} compiler" FORCE)
+        endif()
+        unset(_compiler_abs CACHE)
+    endif()
+endforeach()
+unset(_lang)
+unset(_compiler_var)
+
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG        v3.8.1
+)
+FetchContent_MakeAvailable(Catch2)
+
+# Only the source files that MapGeometry directly or transitively depends on.
+# No SDL runtime linkage required — SDL2 headers are needed only to compile
+# cRectangle.h (which declares an inline toSDL() helper using SDL_Rect).
+set(TEST_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/map/MapGeometry.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/RNG.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/d2tm_math.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/cPoint.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/cRectangle.cpp
+)
+
+add_executable(d2tm_tests
+    map/test_MapGeometry.cpp
+    ${TEST_SOURCES}
+)
+
+# SDL2_INCLUDE_DIRS is populated by the root CMakeLists.txt for all platforms
+# (pkg-config on macOS, find_package on Linux/Windows).
+target_include_directories(d2tm_tests
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_SOURCE_DIR}/src/include
+        ${SDL2_INCLUDE_DIRS}
+)
+
+target_link_libraries(d2tm_tests PRIVATE Catch2::Catch2WithMain)
+
+include(CTest)
+include(Catch)
+catch_discover_tests(d2tm_tests)

--- a/tests/map/test_MapGeometry.cpp
+++ b/tests/map/test_MapGeometry.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "map/MapGeometry.hpp"
+#include <cmath>
 
 // All tests use a standard 64x64 map (the size used by the game)
 static constexpr int MAP_W = 64;

--- a/tests/map/test_MapGeometry.cpp
+++ b/tests/map/test_MapGeometry.cpp
@@ -1,0 +1,128 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "map/MapGeometry.hpp"
+
+// All tests use a standard 64x64 map (the size used by the game)
+static constexpr int MAP_W = 64;
+static constexpr int MAP_H = 64;
+
+TEST_CASE("MapGeometry - getCellX", "[map][geometry]")
+{
+    MapGeometry geo(MAP_W, MAP_H);
+
+    REQUIRE(geo.getCellX(0)    == 0);
+    REQUIRE(geo.getCellX(1)    == 1);
+    REQUIRE(geo.getCellX(63)   == 63); // last cell of first row
+    REQUIRE(geo.getCellX(64)   == 0);  // first cell of second row
+    REQUIRE(geo.getCellX(65)   == 1);
+    REQUIRE(geo.getCellX(4095) == 63); // last cell of the map
+}
+
+TEST_CASE("MapGeometry - getCellY", "[map][geometry]")
+{
+    MapGeometry geo(MAP_W, MAP_H);
+
+    REQUIRE(geo.getCellY(0)    == 0);
+    REQUIRE(geo.getCellY(63)   == 0);  // still first row
+    REQUIRE(geo.getCellY(64)   == 1);  // second row
+    REQUIRE(geo.getCellY(128)  == 2);
+    REQUIRE(geo.getCellY(4095) == 63); // last row
+}
+
+TEST_CASE("MapGeometry - makeCell", "[map][geometry]")
+{
+    MapGeometry geo(MAP_W, MAP_H);
+
+    REQUIRE(geo.makeCell(0,  0)  == 0);
+    REQUIRE(geo.makeCell(1,  0)  == 1);
+    REQUIRE(geo.makeCell(0,  1)  == 64);
+    REQUIRE(geo.makeCell(63, 63) == 4095);
+
+    // round-trip: makeCell -> getCellX/Y
+    REQUIRE(geo.getCellX(geo.makeCell(5, 7)) == 5);
+    REQUIRE(geo.getCellY(geo.makeCell(5, 7)) == 7);
+}
+
+TEST_CASE("MapGeometry - getCellWithMapDimensions", "[map][geometry]")
+{
+    MapGeometry geo(MAP_W, MAP_H);
+
+    REQUIRE(geo.getCellWithMapDimensions(0,  0)  == 0);
+    REQUIRE(geo.getCellWithMapDimensions(1,  0)  == 1);
+    REQUIRE(geo.getCellWithMapDimensions(63, 63) == 4095);
+
+    // out-of-bounds returns -1
+    REQUIRE(geo.getCellWithMapDimensions(-1,  0) == -1);
+    REQUIRE(geo.getCellWithMapDimensions(0,  -1) == -1);
+    REQUIRE(geo.getCellWithMapDimensions(64,  0) == -1);
+    REQUIRE(geo.getCellWithMapDimensions(0,  64) == -1);
+}
+
+TEST_CASE("MapGeometry - getCellWithMapBorders", "[map][geometry]")
+{
+    MapGeometry geo(MAP_W, MAP_H);
+
+    // Playable area is cells (1,1) to (62,62); the outer ring is invisible border
+    REQUIRE(geo.getCellWithMapBorders(1,  1)  == 65);   // (1 * 64) + 1
+    REQUIRE(geo.getCellWithMapBorders(62, 62) == geo.makeCell(62, 62));
+
+    // Invisible border cells return -1
+    REQUIRE(geo.getCellWithMapBorders(0,  1)  == -1);
+    REQUIRE(geo.getCellWithMapBorders(1,  0)  == -1);
+    REQUIRE(geo.getCellWithMapBorders(63, 1)  == -1);
+    REQUIRE(geo.getCellWithMapBorders(1,  63) == -1);
+}
+
+TEST_CASE("MapGeometry - isValidCell", "[map][geometry]")
+{
+    MapGeometry geo(MAP_W, MAP_H);
+
+    REQUIRE(geo.isValidCell(0)    == true);
+    REQUIRE(geo.isValidCell(4095) == true);
+    REQUIRE(geo.isValidCell(-1)   == false);
+    REQUIRE(geo.isValidCell(4096) == false);
+}
+
+TEST_CASE("MapGeometry - getAbsoluteXPositionFromCell", "[map][geometry]")
+{
+    MapGeometry geo(MAP_W, MAP_H);
+
+    // Each tile is 32 pixels wide
+    REQUIRE(geo.getAbsoluteXPositionFromCell(0)  == 0);
+    REQUIRE(geo.getAbsoluteXPositionFromCell(1)  == 32);
+    REQUIRE(geo.getAbsoluteXPositionFromCell(64) == 0);  // x wraps back to 0 on new row
+    REQUIRE(geo.getAbsoluteXPositionFromCell(65) == 32);
+}
+
+TEST_CASE("MapGeometry - getAbsoluteYPositionFromCell", "[map][geometry]")
+{
+    MapGeometry geo(MAP_W, MAP_H);
+
+    // Each tile is 32 pixels tall
+    REQUIRE(geo.getAbsoluteYPositionFromCell(0)  == 0);
+    REQUIRE(geo.getAbsoluteYPositionFromCell(1)  == 0);   // still row 0
+    REQUIRE(geo.getAbsoluteYPositionFromCell(64) == 32);  // row 1
+    REQUIRE(geo.getAbsoluteYPositionFromCell(65) == 32);
+}
+
+TEST_CASE("MapGeometry - getAbsolutePositionFromCell (centered)", "[map][geometry]")
+{
+    MapGeometry geo(MAP_W, MAP_H);
+
+    // Centered adds half a tile (16px) to each axis
+    REQUIRE(geo.getAbsoluteXPositionFromCellCentered(0)  == 16);
+    REQUIRE(geo.getAbsoluteYPositionFromCellCentered(0)  == 16);
+    REQUIRE(geo.getAbsoluteXPositionFromCellCentered(65) == 48);
+    REQUIRE(geo.getAbsoluteYPositionFromCellCentered(65) == 48);
+}
+
+TEST_CASE("MapGeometry - distance", "[map][geometry]")
+{
+    MapGeometry geo(MAP_W, MAP_H);
+
+    // ABS_length() returns 1 when both inputs are the same cell (by design)
+    REQUIRE_THAT(geo.distance(0, 0),   Catch::Matchers::WithinAbs(1.0,        1e-9));
+    REQUIRE_THAT(geo.distance(0, 1),   Catch::Matchers::WithinAbs(1.0,        1e-9)); // horizontal
+    REQUIRE_THAT(geo.distance(0, 64),  Catch::Matchers::WithinAbs(1.0,        1e-9)); // vertical
+    REQUIRE_THAT(geo.distance(0, 65),  Catch::Matchers::WithinAbs(std::sqrt(2.0), 1e-9)); // diagonal
+}


### PR DESCRIPTION
## Summary

- Adds a `tests/` directory wired into CMake via `add_subdirectory(tests)` + `enable_testing()`
- Catch2 v3 is fetched automatically at configure time via `FetchContent` — no manual install needed
- First test file (`tests/map/test_MapGeometry.cpp`) covers `MapGeometry` (pure-computation class, no SDL dependency): cell coordinate conversions, boundary lookups, pixel positions, and distance calculation
- Includes a cross-platform workaround: Apple Intel macs set `CMAKE_CXX_COMPILER` to a bare name (`clang++`) after `project()`, which would break Catch2's own `project()` call; the tests CMakeLists resolves it to an absolute path before `FetchContent_MakeAvailable`
- `ctest --output-on-failure` is added to all rebuild scripts (`rebuildmacos.sh`, `rebuildwin.bat`, `rebuildwinrelease.bat`) so tests run automatically after every build
- `ctest --output-on-failure` is also added to the CI workflows for master and PRs (before release packaging on master)

## Running tests

```sh
./rebuildmacos.sh          # builds everything and immediately runs tests
```

Or manually after a build:

```sh
cd build && ctest --output-on-failure
```

## Test plan

- [x] `./rebuildmacos.sh` builds cleanly and all 10 tests pass
- [x] `ctest --output-on-failure` — 10/10 tests pass
- [x] Verified `ABS_length()` quirk: returns `1` for same-cell distance (by design, per existing comment in source)