### PR TITLE
Switch all Apple builds to system Clang, drop GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,26 +53,7 @@ if(APPLE)
             # the root prefix by default (to avoid clashes).
             "${HOMEBREW_PREFIX}/opt/lapack"
             "${HOMEBREW_PREFIX}/opt/openblas"
-            "${HOMEBREW_PREFIX}/opt/gcc/lib/gcc/15"
     )
-
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-        message(STATUS "Apple Silicon (arm64)")
-        set(CMAKE_C_COMPILER "${HOMEBREW_PREFIX}/bin/gcc-15")
-        set(CMAKE_CXX_COMPILER "${HOMEBREW_PREFIX}/bin/g++-15")
-    elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-        message(STATUS "Apple Intel X64")
-        set(CMAKE_C_COMPILER "clang")
-        set(CMAKE_CXX_COMPILER "clang++")
-    endif()
-
-    message(STATUS "Mac GCC C compiler: ${CMAKE_C_COMPILER}")
-    message(STATUS "Mac GCC C++ compiler: ${CMAKE_CXX_COMPILER}")
-
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        add_compile_options(-stdlib=libstdc++)
-        add_link_options(-stdlib=libstdc++)
-    endif()
 
     include_directories(
       ${SDL2_INCLUDE_DIRS}
@@ -116,10 +97,7 @@ target_include_directories(${PROJECT_NAME}
 
 if (APPLE)
 
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-    elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-        target_compile_definitions(${PROJECT_NAME} PRIVATE D2TM_CLANG=1)
-    endif()
+    target_compile_definitions(${PROJECT_NAME} PRIVATE D2TM_CLANG=1)
 
     set(ALL_SDL_LIBS ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES} ${SDL2_TTF_LIBRARIES} ${SDL2_MIXER_LIBRARIES})
     list(REMOVE_DUPLICATES ALL_SDL_LIBS)

--- a/install_dependencies_macosx.sh
+++ b/install_dependencies_macosx.sh
@@ -9,7 +9,6 @@ echo  ---  Installing dependencies  ---
 echo  ---                           ---
 echo  ---------------------------------
 
-brew install gcc
 brew install cmake
 brew install ninja
 brew install pkg-config


### PR DESCRIPTION
## Summary

- GCC 15 was introduced in Oct 2025 as a workaround because AppleClang at the time lacked C++23 support (`std::chrono::zoned_time`, `std::from_chars` for float)
- Intel Mac was later switched back to Clang with `D2TM_CLANG=1` workaround code paths; ARM stayed on GCC
- The GCC setup was causing an infinite CMake configure loop once FetchContent (Catch2) was introduced (GCC being set after `project()` confuses sub-project compiler detection)
- AppleClang 17 on `macos-15` (the current CI runner) supports what we need

**Changes:**
- Remove explicit compiler overrides for arm64/x86_64 — CMake auto-detects system Clang on both
- Remove GCC lib path (`opt/gcc/lib/gcc/15`) from `CMAKE_PREFIX_PATH`
- Remove GCC-specific `-stdlib=libstdc++` flags
- Set `D2TM_CLANG=1` for **all** Apple (ARM + Intel), using the same proven workaround code paths Intel has been using successfully
- Remove `brew install gcc` from `install_dependencies_macosx.sh`

## Test plan

- [x] Local build (`./rebuildmacos.sh`) passes — builds with system Clang, 10/10 tests green
- [x] CI: ARM Mac (`macos-15`) build passes without the configure loop
- [x] CI: Intel Mac (`macos-15-intel`) build continues to pass