### PR TITLE
Fix Fremen units spawning on out-of playable map bounds

### DIFF
--- a/src/building/cItemBuilder.cpp
+++ b/src/building/cItemBuilder.cpp
@@ -325,7 +325,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                                     break;
                             }
                             // change cell
-                            cPoint::split(x, y) = game.m_gameObjectsContext->getMap().fixCoordinatesToBeWithinMap(x, y);
+                            cPoint::split(x, y) = game.m_gameObjectsContext->getMap().fixCoordinatesToBeWithinPlayableMap(x, y);
 
                             iCll = game.m_gameObjectsContext->getMap().getGeometry().makeCell(x, y);
                         }


### PR DESCRIPTION
Fixes #912

## Root cause

When the Fremen special weapon deploys 6 unit groups, each one spawns by shifting 1–2 cells from the previous spawn position. The shift was clamped with `fixCoordinatesToBeWithinMap`, which clamps to `[0, mapWidth-1]` — valid cell indices but **including the map border row/column** that is outside the playable area.

With 6 units spawning in sequence, a few consecutive shifts toward the same edge easily reach x=0 or y=0 (border cells), placing units out of bounds.

## Fix

One-line change: use `fixCoordinatesToBeWithinPlayableMap` instead, which clamps to `[1, mapWidth-2] × [1, mapHeight-2]` and keeps all spawns within the playable area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)