### PR TITLE
Prevent MCV from executing attack commands

### DIFF
--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -880,6 +880,10 @@ void cUnit::attack(int goalCell, int unitId, int structureId, int attackCell, bo
 
 void cUnit::attackAt(int cell)
 {
+    if (!isAttackingUnit()) {
+        return;
+    }
+
     log(std::format("attackAt() : cell target is [{}]", cell));
 
     if (!game.m_gameObjectsContext->getMap().isWithinBoundaries(cell)) {


### PR DESCRIPTION
Fixes #934

## Root cause

`attackAt()` had no check for whether the unit is capable of attacking. MCV has `canAttackUnits = false` by default, but the attack command was carried out anyway, causing the MCV to chase enemies and attempt to fire.

## Fix

Added an early return in `attackAt()` when `isAttackingUnit()` is false. This covers all callers in one place:
- Player right-click on an enemy unit/structure
- AI skirmish brain ordering an attack
- Threat-response action (counter-attack)
- Fremen super-weapon brain

Any other non-attacking unit (e.g. harvester) also benefits from this guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)