### PR TITLE
Fix force-attack on out-of-range structures and cells

### DIFF
--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -2916,6 +2916,10 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
                     }
                 }
             }
+            else if (combat.iAttackStructure > -1 || combat.iAttackCell > -1) {
+                // structure/cell targets also need to resume attack mode after each chase step
+                setAction(eActionType::ATTACK_CHASE);
+            }
         }
 
         // movement to cell complete


### PR DESCRIPTION
Fixes #932

## Root cause

When a unit is out of range and starts chasing a target, the action cycles:
`ATTACK_CHASE` → (out of range) → `CHASE` → (step complete) → back to `ATTACK_CHASE`

The step-complete transition back to `ATTACK_CHASE` only existed for **unit** targets (`iAttackUnit > -1`). Structure targets and cell targets (force-attack on empty ground / spice blooms) were missing — so the unit arrived at the destination still in `CHASE` mode and `think_attack()` was never called again, meaning it never fired.

## Fix

Added the missing `ATTACK_CHASE` transition for `iAttackStructure > -1` and `iAttackCell > -1` in the movement-completion handler, matching the symmetry already present in `startChasingTarget()`.

Covers both:
- Force-attacking a spice bloom from outside firing range
- Force-attacking a structure from outside firing range

🤖 Generated with [Claude Code](https://claude.com/claude-code)