### PR TITLE
Replace gh-pages with GitHub Releases for bleeding edge builds

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -56,25 +56,23 @@ jobs:
         run: |
           cd "${{ github.workspace }}/bin"
           zip -vr d2tm.zip . -x "*.DS_Store"
-      - name: Produce release name
+      - name: Create bleeding edge release and upload Windows binary
+        shell: bash
         run: |
-          cd "${{ github.workspace }}"
-          mkdir -p out/nightly
-          FILE_NAME=D2TM-$(date -u +'%Y-%m-%dT%H-%M').windows.$(git rev-parse --short HEAD).zip
-          cp bin/d2tm.zip "out/nightly/$FILE_NAME"
-          echo "RELEASE_NAME=$FILE_NAME" >> $GITHUB_ENV
-      - name: Upload ZIP as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.RELEASE_NAME }}
-          path: bin/d2tm.zip
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
-          keep_files: true
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          TAG="bleeding-edge-${SHORT_SHA}"
+          DATE=$(date -u +'%Y-%m-%d %H:%M UTC')
+          gh release create "$TAG" \
+            --prerelease \
+            --title "Bleeding Edge - ${DATE} - ${SHORT_SHA}" \
+            --notes "Automated bleeding edge build from master branch.
+
+Commit: ${{ github.sha }}
+Date: ${DATE}" \
+            2>/dev/null || true
+          gh release upload "$TAG" bin/d2tm.zip --clobber --display-name d2tm-windows.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   Ubuntu:
     name: Ubuntu (x86)
@@ -119,25 +117,12 @@ jobs:
         run: |
           cd "${{ github.workspace }}/bin"
           zip -vr d2tm.zip . -x "*.DS_Store"
-      - name: Produce release name
+      - name: Upload Linux binary to bleeding edge release
         run: |
-          cd "${{ github.workspace }}"
-          mkdir -p out/nightly
-          FILE_NAME=D2TM-$(date -u +'%Y-%m-%dT%H-%M').linux.$(git rev-parse --short HEAD).zip
-          cp bin/d2tm.zip "out/nightly/$FILE_NAME"
-          echo "RELEASE_NAME=$FILE_NAME" >> $GITHUB_ENV
-      - name: Upload ZIP as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.RELEASE_NAME }}
-          path: bin/d2tm.zip
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
-          keep_files: true
+          TAG="bleeding-edge-$(git rev-parse --short HEAD)"
+          gh release upload "$TAG" bin/d2tm.zip --clobber --display-name d2tm-linux.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   MACOSX:
     name: Mac OS X
@@ -174,123 +159,29 @@ jobs:
         run: |
           cd "${{ github.workspace }}/bin"
           zip -vr d2tm.zip . -x "*.DS_Store"
-      - name: Produce release name
+      - name: Upload macOS binary to bleeding edge release
         run: |
-          cd "${{ github.workspace }}"
-          mkdir -p out/nightly
-          FILE_NAME=D2TM-$(date -u +'%Y-%m-%dT%H-%M').macosx.$(git rev-parse --short HEAD).zip
-          cp bin/d2tm.zip "out/nightly/$FILE_NAME"
-          echo "RELEASE_NAME=$FILE_NAME" >> $GITHUB_ENV
-      - name: Upload ZIP as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.RELEASE_NAME }}
-          path: bin/d2tm.zip
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
-          keep_files: true
-
-  Cleanup-GH-Pages:
-    needs: [MSYS2, Ubuntu, MACOSX]  # all builds must be completed successfully
-    name: Cleanup old GH Pages builds
-    runs-on: [ macos-15 ]
-    steps:
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          fetch-depth: 0   # fetch full history to see all files
-
-      - name: Remove builds older than 3 months
-        run: |
-          set -euo pipefail
-          threshold=$(date -v-90d +%s)
-          
-          find nightly -type f -regex '.*/D2TM-[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}T[0-9]\{2\}-[0-9]\{2\}\..*\.zip$' \
-          -print | while read -r f; do
-            name=$(basename "$f")
-            datepart=$(echo "$name" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}' || true)
-            if [ -z "$datepart" ]; then
-              echo "Skipping $name (no date found)"
-              continue
-            fi
-            iso=$(echo "$datepart" | sed 's/T\([0-9][0-9]\)-\([0-9][0-9]\)/T\1:\2/')
-          
-            # macOS date conversion
-            file_epoch=$(date -j -u -f "%Y-%m-%dT%H:%M" "$iso" +%s 2>/dev/null || echo 0)
-          
-            if [ "$file_epoch" -lt "$threshold" ]; then
-              echo "Deleting $f (older than 90 days)"
-              rm -f "$f"
-            fi
-          done
-
-      - name: Commit cleanup
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          if ! git diff --cached --quiet; then
-            git commit -m "Cleanup old nightly builds (>90 days)"
-            git push origin gh-pages
-          else
-            echo "No changes to commit."
-          fi
-
-      - name: Push cleanup
-        run: git push origin gh-pages
+          TAG="bleeding-edge-$(git rev-parse --short HEAD)"
+          gh release upload "$TAG" bin/d2tm.zip --clobber --display-name d2tm-macos.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  Update-Github-Pages:
-    if: always()
-    needs: [Cleanup-GH-Pages]
-    runs-on: [ macos-15 ]
+  Cleanup-Old-Releases:
+    needs: [MSYS2, Ubuntu, MACOSX]  # all builds must complete successfully
+    name: Cleanup old bleeding edge releases
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: gh-pages
-          submodules: recursive
-          fetch-depth: 0   # fetch full history to see all files
-      - name: Generate index.html
+      - name: Delete bleeding edge releases older than 90 days
         run: |
-          cd "${{ github.workspace }}"
-          mkdir -p out
-
-          echo '<!DOCTYPE html>' > out/index.html
-          echo '<html><head><meta charset="UTF-8"><title>D2TM Nightly Builds</title></head><body>' >> out/index.html
-          echo '<h1>Dune 2 - The Maker: Bleeding Edge Builds</h1>' >> out/index.html
-
-          echo '<h2>Windows</h1><ul>' >> out/index.html
-          for zip in $(ls nightly/*windows*.zip | sort -r); do
-            file=$(basename "$zip")
-            echo "<li><a href=\"nightly/$file\">$file</a></li>" >> out/index.html
-          done
-          echo '</ul>' >> out/index.html
-
-          echo '<h2>MacOS</h1><ul>' >> out/index.html
-          for zip in $(ls nightly/*macosx*.zip | sort -r); do
-            file=$(basename "$zip")
-            echo "<li><a href=\"nightly/$file\">$file</a></li>" >> out/index.html
-          done
-          echo '</ul>' >> out/index.html
-
-          echo '<h2>Linux</h1><ul>' >> out/index.html
-          for zip in $(ls nightly/*linux*.zip | sort -r); do
-            file=$(basename "$zip")
-            echo "<li><a href=\"nightly/$file\">$file</a></li>" >> out/index.html
-          done
-
-          echo '</ul></body></html>' >> out/index.html
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
-          keep_files: true
+          cutoff=$(date -u -d '90 days ago' +%s)
+          gh release list --repo ${{ github.repository }} --limit 200 --json tagName,publishedAt \
+            | jq -r '.[] | select(.tagName | startswith("bleeding-edge-")) | [.tagName, .publishedAt] | @tsv' \
+            | while IFS=$'\t' read -r tag published; do
+                epoch=$(date -u -d "$published" +%s)
+                if [ "$epoch" -lt "$cutoff" ]; then
+                  echo "Deleting old release: $tag"
+                  gh release delete "$tag" --cleanup-tag --yes
+                fi
+              done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Each successful master build creates a GitHub **pre-release** tagged `bleeding-edge-<short-sha>` with three platform assets: `d2tm-windows.zip`, `d2tm-linux.zip`, `d2tm-macos.zip`
- Because the jobs are sequential (`Windows → Ubuntu → macOS` via `needs`), Windows creates the release and the other two jobs upload to it using the deterministic SHA-based tag — no race conditions
- A `Cleanup-Old-Releases` job (runs after all three builds succeed) deletes any `bleeding-edge-*` release older than 90 days, including its tag — no accumulation, no repo bloat
- Removes all gh-pages deployment steps, and the `Cleanup-GH-Pages` and `Update-Github-Pages` jobs entirely

## After merging

Two manual steps needed:
1. Delete the `gh-pages` branch: `git push origin --delete gh-pages`
2. Disable GitHub Pages in **Settings → Pages → Source → None**

## Test plan
- [ ] Merge to master and verify a `bleeding-edge-<sha>` release appears under Releases with all three platform zips
- [ ] Verify the cleanup job runs without error (nothing to delete on first run)
- [ ] Delete gh-pages branch and disable Pages in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)