### PR TITLE
Add GPL v2 license with asset usage clarification

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,43 @@
+## MIT License
+
+Copyright (C) 2002-2026 Stefan Hendriks and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## Source Code Only
+
+This license applies to the **source code** of Dune II - The Maker only.
+
+---
+
+## Assets
+
+The game assets (graphics, sounds, music, and data files) found in the `bin/data/`
+directory are **not covered by this license**.
+
+These assets are inspired by the original Dune II game (© Westwood Studios / Electronic Arts),
+but have been largely modified, enhanced, and reworked by the Dune II - The Maker contributors
+over the years. They are not original Dune II graphics and are not the property of
+Westwood Studios or Electronic Arts. They are the result of the creative work of this
+project's community, built upon the spirit of the original game.
+
+Nevertheless, these assets may **not** be redistributed, reused in other projects,
+or used in any form without explicit permission from the Dune II - The Maker project.


### PR DESCRIPTION
## Summary

- Adds `LICENSE.md` with GNU GPL v2 for the source code
- Includes an asset section clarifying that graphics/sounds are inspired by Dune II but have been largely modified and enhanced by D2TM contributors — they are not original EA/Westwood assets, but may not be redistributed without permission

## Test plan

- [ ] Review license text and asset disclaimer wording
- [ ] Confirm GPL v2 is the intended license