### PR TITLE
Fix mentat repeat bug (#969)

### DIFF
--- a/src/mentat/AbstractMentat.cpp
+++ b/src/mentat/AbstractMentat.cpp
@@ -374,8 +374,22 @@ void AbstractMentat::resetSpeak()
 
 void AbstractMentat::onNotifyMouseEvent(const s_MouseEvent &event)
 {
+    // Always keep button hover state current so focus is correct when buttons re-appear
+    if (event.eventType == MOUSE_MOVED_TO) {
+        if (m_guiBtnToMissionSelect) {
+            m_guiBtnToMissionSelect->onNotifyMouseEvent(event);
+        }
+        if (leftGuiButton) {
+            leftGuiButton->onNotifyMouseEvent(event);
+        }
+        if (rightGuiButton) {
+            rightGuiButton->onNotifyMouseEvent(event);
+        }
+        return;
+    }
+
     if (state == SPEAKING) {
-        if (event.eventType==MOUSE_LEFT_BUTTON_CLICKED) {
+        if (event.eventType == MOUSE_LEFT_BUTTON_CLICKED) {
             if (TIMER_Speaking > 0) {
                 TIMER_Speaking = 1;
             }


### PR DESCRIPTION
## Summary

- During `SPEAKING` state, `MOUSE_MOVED_TO` events were not forwarded to buttons, leaving `m_focus` frozen from the previous `AWAITING_RESPONSE` phase
- After clicking Repeat, the button's `m_focus` stayed `true` throughout the speech, causing the very next click to fire Repeat again when `AWAITING_RESPONSE` was re-entered
- Fix: always forward `MOUSE_MOVED_TO` to buttons regardless of mentat state, so focus accurately reflects the actual mouse position when buttons re-appear

## Test plan

- [ ] Play a briefing, let mentat finish speaking, click Repeat
- [ ] Rapidly click through the speech — Repeat should not fire again unintentionally
- [ ] Deliberately hover over Repeat and click — should still work correctly
- [ ] Same for Proceed button

Fixes #969