### PR TITLE
Fix build_manual.yml workflow

### DIFF
--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -67,6 +67,7 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --notes "Release $TAG" \
+            --latest=false \
             2>/dev/null || true
           cp bin/d2tm.zip bin/d2tm-windows-${{ inputs.tag }}.zip
           gh release upload "$TAG" bin/d2tm-windows-${{ inputs.tag }}.zip --clobber

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -25,9 +25,9 @@ jobs:
         with:
           msystem: MINGW64 # D2TM is built within a MinGW64 bit environment
           update: true
-          install: git gzip zip unzip mingw-w64-x86_64-toolchain mingw64/mingw-w64-x86_64-SDL2 mingw64/mingw-w64-x86_64-SDL2_mixer mingw64/mingw-w64-x86_64-SDL2_image mingw64/mingw-w64-x86_64-SDL2_ttf mingw64/mingw-w64-x86_64-cmake
+          install: git gzip zip unzip mingw-w64-x86_64-toolchain mingw64/mingw-w64-x86_64-SDL2 mingw64/mingw-w64-x86_64-SDL2_mixer mingw64/mingw-w64-x86_64-SDL2_image mingw64/mingw-w64-x86_64-SDL2_ttf mingw64/mingw-w64-x86_64-cmake mingw-w64-x86_64-catch
       - name: configure Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.2
+        uses: al-cheb/configure-pagefile-action@v1.3
         with:
           minimum-size: 16GB
           maximum-size: 16GB
@@ -43,11 +43,15 @@ jobs:
           cd "${{ github.workspace }}"
           mkdir build
           cd build
-          cmake .. -DENV_D2TM_VERSION=${{inputs.tag}} -DCMAKE_BUILD_TYPE=Release -G "MinGW Makefiles"
+          cmake .. -DENV_D2TM_VERSION=${{ inputs.tag }} -DCMAKE_BUILD_TYPE=Release -G "MinGW Makefiles"
       - name: Build
         run: |
           cd "${{ github.workspace }}\build"
           cmake --build . --target all -- -j -l 3
+      - name: Test
+        run: |
+          cd "${{ github.workspace }}\build"
+          ctest --output-on-failure
       - name: Produce binary
         run: |
           cd "${{ github.workspace }}"
@@ -56,25 +60,18 @@ jobs:
         run: |
           cd "${{ github.workspace }}/bin"
           zip -vr d2tm.zip . -x "*.DS_Store"
-      - name: Produce release name
+      - name: Create release and upload Windows binary
+        shell: bash
         run: |
-          cd "${{ github.workspace }}"
-          mkdir -p out/nightly
-          FILE_NAME=D2TM-$(date -u +'%Y-%m-%dT%H-%M').windows.${{ inputs.tag }}.zip
-          cp bin/d2tm.zip "out/nightly/$FILE_NAME"
-          echo "RELEASE_NAME=$FILE_NAME" >> $GITHUB_ENV
-      - name: Upload ZIP as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.RELEASE_NAME }}
-          path: bin/d2tm.zip
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
-          keep_files: true
+          TAG="${{ inputs.tag }}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "Release $TAG" \
+            2>/dev/null || true
+          cp bin/d2tm.zip bin/d2tm-windows-${{ inputs.tag }}.zip
+          gh release upload "$TAG" bin/d2tm-windows-${{ inputs.tag }}.zip --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   Ubuntu:
     name: Ubuntu (x86)
@@ -86,7 +83,6 @@ jobs:
         with:
           version: 14
           platform: x86
-      #          platform: x64
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -103,11 +99,15 @@ jobs:
           cd "${{ github.workspace }}"
           mkdir build
           cd build
-          cmake .. -DENV_D2TM_VERSION=${{inputs.tag}} -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DENV_D2TM_VERSION=${{ inputs.tag }} -DCMAKE_BUILD_TYPE=Release
       - name: Build
         run: |
           cd "${{ github.workspace }}/build"
           make -j4
+      - name: Test
+        run: |
+          cd "${{ github.workspace }}/build"
+          ctest --output-on-failure
       - name: Produce binary
         run: |
           cd "${{ github.workspace }}"
@@ -116,78 +116,16 @@ jobs:
         run: |
           cd "${{ github.workspace }}/bin"
           zip -vr d2tm.zip . -x "*.DS_Store"
-      - name: Produce release name
+      - name: Upload Linux binary to release
         run: |
-          cd "${{ github.workspace }}"
-          mkdir -p out/nightly
-          FILE_NAME=D2TM-$(date -u +'%Y-%m-%dT%H-%M').linux.${{ inputs.tag }}.zip
-          cp bin/d2tm.zip "out/nightly/$FILE_NAME"
-          echo "RELEASE_NAME=$FILE_NAME" >> $GITHUB_ENV
-      - name: Upload ZIP as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.RELEASE_NAME }}
-          path: bin/d2tm.zip
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
-          keep_files: true
-  MACOSX_INTEL:
-    name: Mac OS X (Intel)
-    needs: Ubuntu
-    runs-on: [ macos-15-intel ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Install dependencies
-        run: |
-          ./install_dependencies_macosx.sh
-      - name: Configure
-        run: |
-          cd "${{ github.workspace }}"
-          mkdir build
-          cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release
-      - name: Build
-        run: |
-          cd "${{ github.workspace }}/build"
-          make -j4
-      - name: Produce binary
-        run: |
-          cd "${{ github.workspace }}"
-          ./create_release.sh
-      - name: Zip binary
-        run: |
-          cd "${{ github.workspace }}/bin"
-          zip -vr d2tm.zip . -x "*.DS_Store"
-      - name: Produce release name
-        run: |
-          cd "${{ github.workspace }}"
-          mkdir -p out/nightly
-          FILE_NAME=D2TM-$(date -u +'%Y-%m-%dT%H-%M').macosx.intel.${{ inputs.tag }}.zip
-          cp bin/d2tm.zip "out/nightly/$FILE_NAME"
-          echo "RELEASE_NAME=$FILE_NAME" >> $GITHUB_ENV
-      - name: Upload ZIP as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.RELEASE_NAME }}
-          path: bin/d2tm.zip
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
-          keep_files: true
+          cp bin/d2tm.zip bin/d2tm-linux-${{ inputs.tag }}.zip
+          gh release upload "${{ inputs.tag }}" bin/d2tm-linux-${{ inputs.tag }}.zip --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   MACOSX:
-    name: Mac OS X
-    needs: MACOSX_INTEL
+    name: Mac OS X (Arm64)
+    needs: Ubuntu
     runs-on: [ macos-15 ]
     steps:
       - name: Checkout
@@ -204,11 +142,15 @@ jobs:
           cd "${{ github.workspace }}"
           mkdir build
           cd build
-          cmake .. -DENV_D2TM_VERSION=${{inputs.tag}} -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DENV_D2TM_VERSION=${{ inputs.tag }} -DCMAKE_BUILD_TYPE=Release
       - name: Build
         run: |
           cd "${{ github.workspace }}/build"
           make -j4
+      - name: Test
+        run: |
+          cd "${{ github.workspace }}/build"
+          ctest --output-on-failure
       - name: Produce binary
         run: |
           cd "${{ github.workspace }}"
@@ -217,123 +159,52 @@ jobs:
         run: |
           cd "${{ github.workspace }}/bin"
           zip -vr d2tm.zip . -x "*.DS_Store"
-      - name: Produce release name
+      - name: Upload macOS ARM binary to release
         run: |
-          cd "${{ github.workspace }}"
-          mkdir -p out/nightly
-          FILE_NAME=D2TM-$(date -u +'%Y-%m-%dT%H-%M').macosx.arm.${{ inputs.tag }}.zip
-          cp bin/d2tm.zip "out/nightly/$FILE_NAME"
-          echo "RELEASE_NAME=$FILE_NAME" >> $GITHUB_ENV
-      - name: Upload ZIP as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.RELEASE_NAME }}
-          path: bin/d2tm.zip
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
-          keep_files: true
-
-  Cleanup-GH-Pages:
-    needs: [MSYS2, Ubuntu, MACOSX, MACOSX_INTEL]  # all builds must be completed successfully
-    name: Cleanup old GH Pages builds
-    runs-on: [ macos-15 ]
-    steps:
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          fetch-depth: 0   # fetch full history to see all files
-
-      - name: Remove builds older than 3 months
-        run: |
-          set -euo pipefail
-          threshold=$(date -v-90d +%s)
-          
-          find nightly -type f -regex '.*/D2TM-[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}T[0-9]\{2\}-[0-9]\{2\}\..*\.zip$' \
-          -print | while read -r f; do
-            name=$(basename "$f")
-            datepart=$(echo "$name" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}' || true)
-            if [ -z "$datepart" ]; then
-              echo "Skipping $name (no date found)"
-              continue
-            fi
-            iso=$(echo "$datepart" | sed 's/T\([0-9][0-9]\)-\([0-9][0-9]\)/T\1:\2/')
-          
-            # macOS date conversion
-            file_epoch=$(date -j -u -f "%Y-%m-%dT%H:%M" "$iso" +%s 2>/dev/null || echo 0)
-          
-            if [ "$file_epoch" -lt "$threshold" ]; then
-              echo "Deleting $f (older than 90 days)"
-              rm -f "$f"
-            fi
-          done
-
-      - name: Commit cleanup
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          if ! git diff --cached --quiet; then
-            git commit -m "Cleanup old nightly builds (>90 days)"
-            git push origin gh-pages
-          else
-            echo "No changes to commit."
-          fi
-
-      - name: Push cleanup
-        run: git push origin gh-pages
+          cp bin/d2tm.zip bin/d2tm-macos-arm-${{ inputs.tag }}.zip
+          gh release upload "${{ inputs.tag }}" bin/d2tm-macos-arm-${{ inputs.tag }}.zip --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  Update-Github-Pages:
-    if: always()
-    needs: [Cleanup-GH-Pages]
-    runs-on: [ macos-15 ]
+  MACOSX_INTEL:
+    name: Mac OS X (Intel)
+    needs: MACOSX
+    runs-on: [ macos-15-intel ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: gh-pages
+          ref: ${{ inputs.tag }}
           submodules: recursive
           fetch-depth: 0   # fetch full history to see all files
-      - name: Generate index.html
+      - name: Install dependencies
+        run: |
+          ./install_dependencies_macosx.sh
+      - name: Configure
         run: |
           cd "${{ github.workspace }}"
-          mkdir -p out
-
-          echo '<!DOCTYPE html>' > out/index.html
-          echo '<html><head><meta charset="UTF-8"><title>D2TM Nightly Builds</title></head><body>' >> out/index.html
-          echo '<h1>Dune 2 - The Maker: Bleeding Edge Builds</h1>' >> out/index.html
-
-          echo '<h2>Windows</h1><ul>' >> out/index.html
-          for zip in $(ls nightly/*windows*.zip | sort -r); do
-            file=$(basename "$zip")
-            echo "<li><a href=\"nightly/$file\">$file</a></li>" >> out/index.html
-          done
-          echo '</ul>' >> out/index.html
-
-          echo '<h2>MacOS</h1><ul>' >> out/index.html
-          for zip in $(ls nightly/*macosx*.zip | sort -r); do
-            file=$(basename "$zip")
-            echo "<li><a href=\"nightly/$file\">$file</a></li>" >> out/index.html
-          done
-          echo '</ul>' >> out/index.html
-
-          echo '<h2>Linux</h1><ul>' >> out/index.html
-          for zip in $(ls nightly/*linux*.zip | sort -r); do
-            file=$(basename "$zip")
-            echo "<li><a href=\"nightly/$file\">$file</a></li>" >> out/index.html
-          done
-
-          echo '</ul></body></html>' >> out/index.html
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
-          keep_files: true
+          mkdir build
+          cd build
+          cmake .. -DENV_D2TM_VERSION=${{ inputs.tag }} -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: |
+          cd "${{ github.workspace }}/build"
+          make -j4
+      - name: Test
+        run: |
+          cd "${{ github.workspace }}/build"
+          ctest --output-on-failure
+      - name: Produce binary
+        run: |
+          cd "${{ github.workspace }}"
+          ./create_release.sh
+      - name: Zip binary
+        run: |
+          cd "${{ github.workspace }}/bin"
+          zip -vr d2tm.zip . -x "*.DS_Store"
+      - name: Upload macOS Intel binary to release
+        run: |
+          cp bin/d2tm.zip bin/d2tm-macos-intel-${{ inputs.tag }}.zip
+          gh release upload "${{ inputs.tag }}" bin/d2tm-macos-intel-${{ inputs.tag }}.zip --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -64,9 +64,9 @@ jobs:
           DATE=$(date -u +'%Y-%m-%d %H:%M')
           NOTES=$(printf 'Automated bleeding edge build from master branch.\n\nCommit: %s\nDate: %s' "${SHORT_SHA}" "${DATE}")
           gh release create "$TAG" \
-            --prerelease \
             --title "Bleeding Edge - ${DATE}" \
             --notes "$NOTES" \
+            --latest=false \
             2>/dev/null || true
           cp bin/d2tm.zip bin/d2tm-windows-${SHORT_SHA}.zip
           gh release upload "$TAG" bin/d2tm-windows-${SHORT_SHA}.zip --clobber


### PR DESCRIPTION
## Summary

- Add `mingw-w64-x86_64-catch` to Windows MSYS2 install — was missing, causing build failure since Catch2 was introduced
- Upgrade pagefile action to `v1.3` (v1.2 is broken on Windows Server 2025)
- Add `ctest` Test step to all four platforms (Windows, Ubuntu, macOS ARM, macOS Intel)
- Replace gh-pages deployment with GitHub Releases upload — assets named `d2tm-windows/linux/macos-arm/macos-intel-<tag>.zip`
- Fix MACOSX_INTEL job: was missing `ref`, `fetch-depth`, and `-DENV_D2TM_VERSION`
- Remove obsolete `Cleanup-GH-Pages` and `Update-Github-Pages` jobs

## Test plan

- [ ] Trigger workflow manually with a tag (e.g. `v0.8.0`) and verify all four platform builds succeed
- [ ] Verify release assets appear on the GitHub Release for that tag