### PR TITLE
Upgrade actions/checkout v2 to v4

### DIFF
--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -33,7 +33,7 @@ jobs:
           maximum-size: 16GB
           disk-root: "C:"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
           submodules: recursive
@@ -85,7 +85,7 @@ jobs:
           version: 14
           platform: x86
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
           submodules: recursive
@@ -130,7 +130,7 @@ jobs:
     runs-on: [ macos-15 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
           submodules: recursive
@@ -173,7 +173,7 @@ jobs:
     runs-on: [ macos-15-intel ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
           submodules: recursive

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -30,7 +30,7 @@ jobs:
           maximum-size: 16GB
           disk-root: "C:"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0   # fetch full history to see all files
@@ -85,7 +85,7 @@ jobs:
           platform: x86
       #          platform: x64
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0   # fetch full history to see all files
@@ -131,7 +131,7 @@ jobs:
     runs-on: [ macos-15 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0   # fetch full history to see all files

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -24,7 +24,7 @@ jobs:
           maximum-size: 16GB
           disk-root: "C:"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Configure
@@ -52,7 +52,7 @@ jobs:
           platform: x86
 #          platform: x64
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install dependencies
@@ -79,7 +79,7 @@ jobs:
     runs-on: [ macos-15 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install dependencies
@@ -104,7 +104,7 @@ jobs:
     runs-on: [ macos-15-intel ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout@v2` to `@v4` across all three build workflows (`build_master.yml`, `build_pr.yml`, `build_manual.yml`)

`v2` runs on Node 16 which GitHub has deprecated, causing warnings in CI. `v4` runs on Node 20.

## Test plan

- [ ] PR build passes without Node deprecation warnings