### PR TITLE
Upgrade actions to Node 24: actions/checkout v6, configure-pagefile v1.5, brew --quiet

### DIFF
--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -33,7 +33,7 @@ jobs:
           maximum-size: 16GB
           disk-root: "C:"
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
           submodules: recursive
@@ -85,7 +85,7 @@ jobs:
           version: 14
           platform: x86
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
           submodules: recursive
@@ -130,7 +130,7 @@ jobs:
     runs-on: [ macos-15 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
           submodules: recursive
@@ -173,7 +173,7 @@ jobs:
     runs-on: [ macos-15-intel ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
           submodules: recursive

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -27,7 +27,7 @@ jobs:
           update: true
           install: git gzip zip unzip mingw-w64-x86_64-toolchain mingw64/mingw-w64-x86_64-SDL2 mingw64/mingw-w64-x86_64-SDL2_mixer mingw64/mingw-w64-x86_64-SDL2_image mingw64/mingw-w64-x86_64-SDL2_ttf mingw64/mingw-w64-x86_64-cmake mingw-w64-x86_64-catch
       - name: configure Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.3
+        uses: al-cheb/configure-pagefile-action@v1.5
         with:
           minimum-size: 16GB
           maximum-size: 16GB

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -24,7 +24,7 @@ jobs:
           update: true
           install: git gzip zip unzip mingw-w64-x86_64-toolchain mingw64/mingw-w64-x86_64-SDL2 mingw64/mingw-w64-x86_64-SDL2_mixer mingw64/mingw-w64-x86_64-SDL2_image mingw64/mingw-w64-x86_64-SDL2_ttf mingw64/mingw-w64-x86_64-cmake mingw-w64-x86_64-catch
       - name: configure Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.3
+        uses: al-cheb/configure-pagefile-action@v1.5
         with:
           minimum-size: 16GB
           maximum-size: 16GB

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -30,7 +30,7 @@ jobs:
           maximum-size: 16GB
           disk-root: "C:"
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0   # fetch full history to see all files
@@ -85,7 +85,7 @@ jobs:
           platform: x86
       #          platform: x64
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0   # fetch full history to see all files
@@ -131,7 +131,7 @@ jobs:
     runs-on: [ macos-15 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0   # fetch full history to see all files

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -18,7 +18,7 @@ jobs:
           update: true
           install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc mingw64/mingw-w64-x86_64-SDL2 mingw64/mingw-w64-x86_64-SDL2_mixer mingw64/mingw-w64-x86_64-SDL2_image mingw64/mingw-w64-x86_64-SDL2_ttf mingw64/mingw-w64-x86_64-cmake mingw-w64-x86_64-catch
       - name: configure Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.3
+        uses: al-cheb/configure-pagefile-action@v1.5
         with:
           minimum-size: 16GB
           maximum-size: 16GB

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -24,7 +24,7 @@ jobs:
           maximum-size: 16GB
           disk-root: "C:"
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Configure
@@ -52,7 +52,7 @@ jobs:
           platform: x86
 #          platform: x64
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install dependencies
@@ -79,7 +79,7 @@ jobs:
     runs-on: [ macos-15 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install dependencies
@@ -104,7 +104,7 @@ jobs:
     runs-on: [ macos-15-intel ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install dependencies

--- a/install_dependencies_macosx.sh
+++ b/install_dependencies_macosx.sh
@@ -9,11 +9,4 @@ echo  ---  Installing dependencies  ---
 echo  ---                           ---
 echo  ---------------------------------
 
-brew install cmake
-brew install ninja
-brew install pkg-config
-brew install sdl2
-brew install sdl2_ttf
-brew install sdl2_image
-brew install sdl2_mixer
-brew install catch2
+brew install --quiet cmake ninja pkg-config sdl2 sdl2_ttf sdl2_image sdl2_mixer catch2


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout` from v4 to v6 (Node 20 deprecated, v6 uses Node 24) across all three build workflows
- Upgrades `al-cheb/configure-pagefile-action` from v1.3 to v1.5 (Node 24 support) across all three build workflows
- Adds `--quiet` flag to `brew install` in `install_dependencies_macosx.sh` to suppress "already installed" warnings on macOS runners

## Test plan
- [ ] Verify no more Node.js 20 deprecation warnings in Windows build
- [ ] Verify macOS build no longer shows brew warnings
- [ ] Verify all build workflows complete successfully after merge