### PR TITLE
Units will respond to move order even if mouse is outside map boundary

### DIFF
--- a/src/controls/cGameControlsContext.cpp
+++ b/src/controls/cGameControlsContext.cpp
@@ -25,6 +25,7 @@ cGameControlsContext::cGameControlsContext(cPlayer *player, cMouse *mouse) :
     m_mouseHoveringOverUnitId(-1),
     m_mouseOnBattleField(false),
     m_mouseCell(-99),
+    m_mouseCellClamped(0),
     m_player(player),
     m_state(MOUSESTATE_SELECT),
     m_prevState(MOUSESTATE_SELECT),
@@ -70,14 +71,20 @@ void cGameControlsContext::updateMouseCell(const cPoint &coords)
         return;
     }
     m_mouseOnBattleField = true;
-    m_mouseCell = getMouseCellFromScreen(coords.x, coords.y);
+    m_mouseCell = getMouseCellFromScreen(coords.x, coords.y, false);
+    if (m_mouseCell<0) { // clampe mouse cell to map
+        m_mouseCellClamped = getMouseCellFromScreen(coords.x, coords.y, true);
+    }
 }
 
-int cGameControlsContext::getMouseCellFromScreen(int mouseX, int mouseY) const
+int cGameControlsContext::getMouseCellFromScreen(int mouseX, int mouseY, bool clamped) const
 {
     int absMapX = game.m_mapCamera->getAbsMapMouseX(mouseX);
     int absMapY = game.m_mapCamera->getAbsMapMouseY(mouseY);
-    return game.m_mapCamera->getCellFromAbsolutePosition(absMapX, absMapY);
+    if (clamped)
+        return game.m_mapCamera->getCellClampedFromAbsolutePosition(absMapX, absMapY);
+    else
+        return game.m_mapCamera->getCellFromAbsolutePosition(absMapX, absMapY);
 }
 
 void cGameControlsContext::determineHoveringOverStructureId()

--- a/src/controls/cGameControlsContext.cpp
+++ b/src/controls/cGameControlsContext.cpp
@@ -71,21 +71,24 @@ void cGameControlsContext::updateMouseCell(const cPoint &coords)
         return;
     }
     m_mouseOnBattleField = true;
-    m_mouseCell = getMouseCellFromScreen(coords.x, coords.y, false);
-    if (m_mouseCell<0) { // clampe mouse cell to map
-        m_mouseCellClamped = getMouseCellFromScreen(coords.x, coords.y, true);
+    m_mouseCell = getMouseCellFromScreen(coords.x, coords.y);
+    if (m_mouseCell < 0) { // clamp mouse cell to map
+        m_mouseCellClamped = getMouseCellFromScreenClamped(coords.x, coords.y);
     }
 }
 
-int cGameControlsContext::getMouseCellFromScreen(int mouseX, int mouseY, bool clamped) const
+int cGameControlsContext::getMouseCellFromScreen(int mouseX, int mouseY) const
 {
     int absMapX = game.m_mapCamera->getAbsMapMouseX(mouseX);
     int absMapY = game.m_mapCamera->getAbsMapMouseY(mouseY);
-    if (clamped) {
-        return game.m_mapCamera->getCellClampedFromAbsolutePosition(absMapX, absMapY);
-    } else {
-        return game.m_mapCamera->getCellFromAbsolutePosition(absMapX, absMapY);
-    }
+    return game.m_mapCamera->getCellFromAbsolutePosition(absMapX, absMapY);
+}
+
+int cGameControlsContext::getMouseCellFromScreenClamped(int mouseX, int mouseY) const
+{
+    int absMapX = game.m_mapCamera->getAbsMapMouseX(mouseX);
+    int absMapY = game.m_mapCamera->getAbsMapMouseY(mouseY);
+    return game.m_mapCamera->getCellFromAbsolutePositionClamped(absMapX, absMapY);
 }
 
 void cGameControlsContext::determineHoveringOverStructureId()

--- a/src/controls/cGameControlsContext.cpp
+++ b/src/controls/cGameControlsContext.cpp
@@ -81,10 +81,11 @@ int cGameControlsContext::getMouseCellFromScreen(int mouseX, int mouseY, bool cl
 {
     int absMapX = game.m_mapCamera->getAbsMapMouseX(mouseX);
     int absMapY = game.m_mapCamera->getAbsMapMouseY(mouseY);
-    if (clamped)
+    if (clamped) {
         return game.m_mapCamera->getCellClampedFromAbsolutePosition(absMapX, absMapY);
-    else
+    } else {
         return game.m_mapCamera->getCellFromAbsolutePosition(absMapX, absMapY);
+    }
 }
 
 void cGameControlsContext::determineHoveringOverStructureId()

--- a/src/controls/cGameControlsContext.h
+++ b/src/controls/cGameControlsContext.h
@@ -45,6 +45,9 @@ public:
     int getMouseCell() const {
         return m_mouseCell;
     }
+    int getMouseCellClamped() const {
+        return m_mouseCellClamped;
+    }
 
     bool isMouseOverStructure() const {
         return m_mouseHoveringOverStructureId > -1;
@@ -74,7 +77,7 @@ public:
 
     cAbstractStructure *getStructurePointerWhereMouseHovers() const;
 
-    int getMouseCellFromScreen(int mouseX, int mouseY) const;
+    int getMouseCellFromScreen(int mouseX, int mouseY, bool clamped) const;
 
     void onNotifyMouseEvent(const s_MouseEvent &event) override;
     void onNotifyKeyboardEvent(const cKeyboardEvent &event) override;
@@ -99,6 +102,7 @@ private:
 
     // on what cell is the mouse hovering
     int m_mouseCell;
+    int m_mouseCellClamped;
 
     // context belongs to specific player
     cPlayer *m_player;

--- a/src/controls/cGameControlsContext.h
+++ b/src/controls/cGameControlsContext.h
@@ -77,7 +77,8 @@ public:
 
     cAbstractStructure *getStructurePointerWhereMouseHovers() const;
 
-    int getMouseCellFromScreen(int mouseX, int mouseY, bool clamped) const;
+    int getMouseCellFromScreen(int mouseX, int mouseY) const;
+    int getMouseCellFromScreenClamped(int mouseX, int mouseY) const;
 
     void onNotifyMouseEvent(const s_MouseEvent &event) override;
     void onNotifyKeyboardEvent(const cKeyboardEvent &event) override;

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -114,7 +114,10 @@ void cMouseUnitsSelectedState::onMouseLeftButtonClicked()
         evaluateSelectedUnits();
 
         int mouseCell = m_context->getMouseCell();
-
+        // if mouse cell is invalid, try to get mouse cell in map (Manathan distance)
+        if (mouseCell < 0) {
+            mouseCell = m_context->getMouseCellClamped();
+        }
         bool infantryAcknowledged = false;
         bool unitAcknowledged = false;
 

--- a/src/map/MapGeometry.cpp
+++ b/src/map/MapGeometry.cpp
@@ -137,6 +137,15 @@ int MapGeometry::getCellWithMapDimensions(int x, int y) const
     return (y * mapWidth) + x;
 }
 
+int MapGeometry::getCellClampedWithMapDimensions(int x, int y) const
+{
+    if (x < 1) x= 1;
+    if (x >= mapWidth) x = mapWidth -2;
+    if (y < 0) y=1;
+    if (y >= mapHeight) y = mapHeight -2;
+    return (y * mapWidth) + x;
+}
+
 int MapGeometry::makeCell(int x, int y) const
 {
     assert(x > -1 && "makeCell x must be > -1");

--- a/src/map/MapGeometry.cpp
+++ b/src/map/MapGeometry.cpp
@@ -137,15 +137,6 @@ int MapGeometry::getCellWithMapDimensions(int x, int y) const
     return (y * mapWidth) + x;
 }
 
-int MapGeometry::getCellClampedWithMapDimensions(int x, int y) const
-{
-    if (x < 1) x= 1;
-    if (x >= mapWidth) x = mapWidth -2;
-    if (y < 0) y=1;
-    if (y >= mapHeight) y = mapHeight -2;
-    return (y * mapWidth) + x;
-}
-
 int MapGeometry::makeCell(int x, int y) const
 {
     assert(x > -1 && "makeCell x must be > -1");

--- a/src/map/MapGeometry.hpp
+++ b/src/map/MapGeometry.hpp
@@ -25,6 +25,7 @@ public:
         If you want to take the invisible border into account use getCellWithMapBorders instead.
     **/
     int getCellWithMapDimensions(int x, int y) const;
+    int getCellClampedWithMapDimensions(int x, int y) const;
     /**
         Return map cell; taking the map borders into account. If x or y falls out of bounds, this function will return -1
         If you want to include the invisible map borders, use getCellWithMapDimensions instead.

--- a/src/map/MapGeometry.hpp
+++ b/src/map/MapGeometry.hpp
@@ -25,7 +25,7 @@ public:
         If you want to take the invisible border into account use getCellWithMapBorders instead.
     **/
     int getCellWithMapDimensions(int x, int y) const;
-    int getCellClampedWithMapDimensions(int x, int y) const;
+    int getCellWithMapDimensionsClamped(int x, int y) const;
     /**
         Return map cell; taking the map borders into account. If x or y falls out of bounds, this function will return -1
         If you want to include the invisible map borders, use getCellWithMapDimensions instead.

--- a/src/map/cMapCamera.cpp
+++ b/src/map/cMapCamera.cpp
@@ -179,6 +179,11 @@ int cMapCamera::getCellFromAbsolutePosition(int x, int y)
     return m_mapGeometry->getCellWithMapDimensions((x / 32), (y / 32));
 }
 
+int cMapCamera::getCellClampedFromAbsolutePosition(int x, int y)
+{
+    return m_mapGeometry->getCellClampedWithMapDimensions((x / 32), (y / 32));
+}
+
 void cMapCamera::onNotifyMouseEvent(const s_MouseEvent &event)
 {
     // MOUSE WHEEL scrolling causes zooming in/out

--- a/src/map/cMapCamera.cpp
+++ b/src/map/cMapCamera.cpp
@@ -179,9 +179,11 @@ int cMapCamera::getCellFromAbsolutePosition(int x, int y)
     return m_mapGeometry->getCellWithMapDimensions((x / 32), (y / 32));
 }
 
-int cMapCamera::getCellClampedFromAbsolutePosition(int x, int y)
+int cMapCamera::getCellFromAbsolutePositionClamped(int x, int y)
 {
-    return m_mapGeometry->getCellClampedWithMapDimensions((x / 32), (y / 32));
+    int cx, cy;
+    cPoint::split(cx, cy) = m_mapGeometry->fixCoordinatesToBeWithinPlayableMap((x / 32), (y / 32));
+    return m_mapGeometry->makeCell(cx, cy);
 }
 
 void cMapCamera::onNotifyMouseEvent(const s_MouseEvent &event)

--- a/src/map/cMapCamera.h
+++ b/src/map/cMapCamera.h
@@ -170,7 +170,7 @@ public:
     }
 
     int getCellFromAbsolutePosition(int x, int y);
-    int getCellClampedFromAbsolutePosition(int x, int y);
+    int getCellFromAbsolutePositionClamped(int x, int y);
 
     void setViewportPosition(int x, int y);
 

--- a/src/map/cMapCamera.h
+++ b/src/map/cMapCamera.h
@@ -170,6 +170,7 @@ public:
     }
 
     int getCellFromAbsolutePosition(int x, int y);
+    int getCellClampedFromAbsolutePosition(int x, int y);
 
     void setViewportPosition(int x, int y);
 


### PR DESCRIPTION
## **Goal**

A unit moves around the battlefield regardless of where you click on the camera view, even if that click is outside the map. The unit will move to the nearest cell to the click, using Manhattan distance.

## Screenshots (optional)

https://github.com/user-attachments/assets/82084a92-0d64-47f0-97f0-bfc38bd997bb

