### PR TITLE
Allow sending units via minimap

### DIFF
--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -213,6 +213,9 @@ void cMiniMapDrawer::onNotifyMouseEvent(const s_MouseEvent &event)
         case eMouseEventType::MOUSE_LEFT_BUTTON_PRESSED:
             onMousePressedLeft(event);
             return;
+        case eMouseEventType::MOUSE_RIGHT_BUTTON_PRESSED:
+            onMousePressedRight(event);
+            return;
         default:
             return;
     }
@@ -395,6 +398,7 @@ void cMiniMapDrawer::onMouseClickedLeft(const s_MouseEvent &event) {
         !game.getMouse()->isBoxSelecting() && // pressed the mouse and not boxing anything..
         this->m_status != NOTAVAILABLE // only allow action when not drawing logo
     ) {
+        // left mouse *click* will move any units if selected
         if (m_player->hasAnyUnitSelected()) {
             auto m_mouse = game.getMouse();
             int mouseCellOnMinimap = getMouseCell(m_mouse->getX(), m_mouse->getY());
@@ -413,11 +417,25 @@ void cMiniMapDrawer::onMousePressedLeft(const s_MouseEvent &event)
         !game.getMouse()->isBoxSelecting() && // pressed the mouse and not boxing anything..
         this->m_status != NOTAVAILABLE // only allow action when not drawing logo
     ) {
-        auto m_mouse = game.getMouse();
-        int mouseCellOnMinimap = getMouseCell(m_mouse->getX(), m_mouse->getY());
+        // left-mouse button press only moves viewport if no units are selected
         if (!m_player->hasAnyUnitSelected()) {
+            auto m_mouse = game.getMouse();
+            int mouseCellOnMinimap = getMouseCell(m_mouse->getX(), m_mouse->getY());
             m_mapCamera->centerAndJumpViewPortToCell(mouseCellOnMinimap);
         }
+    }
+}
+
+void cMiniMapDrawer::onMousePressedRight(const s_MouseEvent &event)
+{
+    if (m_RectFullMinimap.isPointWithin(event.coords.x, event.coords.y) && // on minimap space
+        !game.getMouse()->isBoxSelecting() && // pressed the mouse and not boxing anything..
+        this->m_status != NOTAVAILABLE // only allow action when not drawing logo
+    ) {
+        // right-mouse button press will always move viewport
+        auto m_mouse = game.getMouse();
+        int mouseCellOnMinimap = getMouseCell(m_mouse->getX(), m_mouse->getY());
+        m_mapCamera->centerAndJumpViewPortToCell(mouseCellOnMinimap);
     }
 }
 

--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -394,15 +394,26 @@ void cMiniMapDrawer::onMousePressedLeft(const s_MouseEvent &event)
     if (m_RectFullMinimap.isPointWithin(event.coords.x, event.coords.y) && // on minimap space
         !game.getMouse()->isBoxSelecting() // pressed the mouse and not boxing anything..
     ) {
-        if (game.m_gameObjectsContext->getUnits()->areUnitsSelected() == true) {
+        if (m_player->hasAnyUnitSelected()) {
             //std::cout << "Mouse cursor is on pos:" << event.coords.x << "," << event.coords.y << " on minimap, moving selected units there." << std::endl;
             //std::cout << "RectMiniMap size: " << m_RectMinimap.getWidth() << "," << m_RectMinimap.getHeight() << std::endl;
-            int posX = (event.coords.x-m_RectMinimap.getX())/m_factorZoom;
-            if (posX<0) posX=1;
-            if (posX>m_RectMinimap.getWidth()) posX=m_RectMinimap.getWidth()-1;
-            int posY = (event.coords.y-m_RectMinimap.getY())/m_factorZoom;
-            if (posY<0) posY=1;
-            if (posY>m_RectMinimap.getHeight()) posY=m_RectMinimap.getHeight()-1;
+
+            int posX = (event.coords.x - m_RectMinimap.getX()) / m_factorZoom;
+            if (posX < 0) {
+                posX = 1;
+            }
+
+            if (posX > m_RectMinimap.getWidth()) {
+                posX = m_RectMinimap.getWidth() - 1;
+            }
+
+            int posY = (event.coords.y - m_RectMinimap.getY()) / m_factorZoom;
+            if (posY < 0) {
+                posY = 1;
+            }
+            if (posY > m_RectMinimap.getHeight()) {
+                posY = m_RectMinimap.getHeight() - 1;
+            }
             //std::cout << "Calculated pos on map: " << posX << "," << posY << ":"<< (posY * m_RectMinimap.getWidth()/m_factorZoom) + posX << std::endl;
             cUnits *units = game.m_gameObjectsContext->getUnits();
             units->move_to((posY * m_RectMinimap.getWidth()/m_factorZoom) + posX);

--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -21,7 +21,7 @@
 #include "context/cGameObjectContext.h"
 #include "map/cMap.h"
 #include <cassert>
-#include <iostream>
+//#include <iostream>
 
 #include "data/gfxaudio.h"
 
@@ -59,8 +59,8 @@ cMiniMapDrawer::cMiniMapDrawer(GameContext *ctx, cMap *map, cPlayer *player, cMa
 
     m_RectMinimap = cRectangle(m_drawX, m_drawY, m_factorZoom*getMapWidthInPixels(), m_factorZoom * getMapHeightInPixels());
     m_RectFullMinimap = cRectangle(topLeftX, topLeftY, cSideBar::WidthOfMinimap, cSideBar::HeightOfMinimap);
-    std::cout << "Minimap top left corner: (" << m_RectMinimap.getX() << ", " << m_RectMinimap.getY() << ", " << m_RectMinimap.getWidth() << ", " << m_RectMinimap.getHeight() << ")" << std::endl;
-    std::cout << "RectFullMinimap: (" << m_RectFullMinimap.getX() << ", " << m_RectFullMinimap.getY() << ", " << m_RectFullMinimap.getWidth() << ", " << m_RectFullMinimap.getHeight() << ")" << std::endl;
+    //std::cout << "Minimap top left corner: (" << m_RectMinimap.getX() << ", " << m_RectMinimap.getY() << ", " << m_RectMinimap.getWidth() << ", " << m_RectMinimap.getHeight() << ")" << std::endl;
+    //std::cout << "RectFullMinimap: (" << m_RectFullMinimap.getX() << ", " << m_RectFullMinimap.getY() << ", " << m_RectFullMinimap.getWidth() << ", " << m_RectFullMinimap.getHeight() << ")" << std::endl;
     m_mipMapTex = m_renderDrawer->createRenderTargetTexture(getMapWidthInPixels(), getMapHeightInPixels());
 }
 
@@ -395,15 +395,15 @@ void cMiniMapDrawer::onMousePressedLeft(const s_MouseEvent &event)
         !game.getMouse()->isBoxSelecting() // pressed the mouse and not boxing anything..
     ) {
         if (game.m_gameObjectsContext->getUnits()->areUnitsSelected() == true) {
-            std::cout << "Mouse cursor is on pos:" << event.coords.x << "," << event.coords.y << " on minimap, moving selected units there." << std::endl;
-            std::cout << "RectMiniMap size: " << m_RectMinimap.getWidth() << "," << m_RectMinimap.getHeight() << std::endl;
+            //std::cout << "Mouse cursor is on pos:" << event.coords.x << "," << event.coords.y << " on minimap, moving selected units there." << std::endl;
+            //std::cout << "RectMiniMap size: " << m_RectMinimap.getWidth() << "," << m_RectMinimap.getHeight() << std::endl;
             int posX = (event.coords.x-m_RectMinimap.getX())/m_factorZoom;
             if (posX<0) posX=1;
             if (posX>m_RectMinimap.getWidth()) posX=m_RectMinimap.getWidth()-1;
             int posY = (event.coords.y-m_RectMinimap.getY())/m_factorZoom;
             if (posY<0) posY=1;
             if (posY>m_RectMinimap.getHeight()) posY=m_RectMinimap.getHeight()-1;
-            std::cout << "Calculated pos on map: " << posX << "," << posY << ":"<< (posY * m_RectMinimap.getWidth()/m_factorZoom) + posX << std::endl;
+            //std::cout << "Calculated pos on map: " << posX << "," << posY << ":"<< (posY * m_RectMinimap.getWidth()/m_factorZoom) + posX << std::endl;
             cUnits *units = game.m_gameObjectsContext->getUnits();
             units->move_to((posY * m_RectMinimap.getWidth()/m_factorZoom) + posX);
             return;

--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -398,24 +398,12 @@ void cMiniMapDrawer::onMousePressedLeft(const s_MouseEvent &event)
         if (m_player->hasAnyUnitSelected()) {
             // Translate map coordinates to cell
             int posX = (event.coords.x - m_RectMinimap.getX()) / m_factorZoom;
-            if (posX < 0) {
-                posX = 1;
-            }
-
-            if (posX > m_RectMinimap.getWidth()) {
-                posX = m_RectMinimap.getWidth() - 1;
-            }
-
             int posY = (event.coords.y - m_RectMinimap.getY()) / m_factorZoom;
-            if (posY < 0) {
-                posY = 1;
-            }
-            if (posY > m_RectMinimap.getHeight()) {
-                posY = m_RectMinimap.getHeight() - 1;
-            }
+
+            auto point = m_map->getGeometry().fixCoordinatesToBeWithinPlayableMap(posX, posY);
 
             cUnits *units = game.m_gameObjectsContext->getUnits();
-            units->move_to((posY * m_RectMinimap.getWidth()/m_factorZoom) + posX);
+            units->move_to(m_map->getGeometry().makeCell(point));
             return;
         }
         if (m_player->hasAtleastOneStructure(RADAR)) {

--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -392,12 +392,11 @@ void cMiniMapDrawer::onMouseAt(const s_MouseEvent &event)
 void cMiniMapDrawer::onMousePressedLeft(const s_MouseEvent &event)
 {
     if (m_RectFullMinimap.isPointWithin(event.coords.x, event.coords.y) && // on minimap space
-        !game.getMouse()->isBoxSelecting() // pressed the mouse and not boxing anything..
+        !game.getMouse()->isBoxSelecting() && // pressed the mouse and not boxing anything..
+        this->m_status != NOTAVAILABLE // only allow action when not drawing logo
     ) {
         if (m_player->hasAnyUnitSelected()) {
-            //std::cout << "Mouse cursor is on pos:" << event.coords.x << "," << event.coords.y << " on minimap, moving selected units there." << std::endl;
-            //std::cout << "RectMiniMap size: " << m_RectMinimap.getWidth() << "," << m_RectMinimap.getHeight() << std::endl;
-
+            // Translate map coordinates to cell
             int posX = (event.coords.x - m_RectMinimap.getX()) / m_factorZoom;
             if (posX < 0) {
                 posX = 1;
@@ -414,7 +413,7 @@ void cMiniMapDrawer::onMousePressedLeft(const s_MouseEvent &event)
             if (posY > m_RectMinimap.getHeight()) {
                 posY = m_RectMinimap.getHeight() - 1;
             }
-            //std::cout << "Calculated pos on map: " << posX << "," << posY << ":"<< (posY * m_RectMinimap.getWidth()/m_factorZoom) + posX << std::endl;
+
             cUnits *units = game.m_gameObjectsContext->getUnits();
             units->move_to((posY * m_RectMinimap.getWidth()/m_factorZoom) + posX);
             return;

--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -24,6 +24,7 @@
 //#include <iostream>
 
 #include "data/gfxaudio.h"
+#include "gameobjects/particles/cParticle.h"
 
 cMiniMapDrawer::cMiniMapDrawer(GameContext *ctx, cMap *map, cPlayer *player, cMapCamera *mapCamera) :
     m_isMouseOver(false),
@@ -207,7 +208,7 @@ void cMiniMapDrawer::onNotifyMouseEvent(const s_MouseEvent &event)
             onMouseAt(event);
             return;
         case eMouseEventType::MOUSE_LEFT_BUTTON_CLICKED:
-            onMousePressedLeft(event); // click has same behavior as 'press'
+            onMouseClickedLeft(event);
             return;
         case eMouseEventType::MOUSE_LEFT_BUTTON_PRESSED:
             onMousePressedLeft(event);
@@ -389,26 +390,32 @@ void cMiniMapDrawer::onMouseAt(const s_MouseEvent &event)
     m_isMouseOver = m_RectMinimap.isPointWithin(event.coords.x, event.coords.y);
 }
 
+void cMiniMapDrawer::onMouseClickedLeft(const s_MouseEvent &event) {
+    if (m_RectFullMinimap.isPointWithin(event.coords.x, event.coords.y) && // on minimap space
+        !game.getMouse()->isBoxSelecting() && // pressed the mouse and not boxing anything..
+        this->m_status != NOTAVAILABLE // only allow action when not drawing logo
+    ) {
+        if (m_player->hasAnyUnitSelected()) {
+            auto m_mouse = game.getMouse();
+            int mouseCellOnMinimap = getMouseCell(m_mouse->getX(), m_mouse->getY());
+            cUnits *units = game.m_gameObjectsContext->getUnits();
+            units->move_to(mouseCellOnMinimap);
+
+            auto absPoint = m_map->getGeometry().getAbsolutePositionFromCell(mouseCellOnMinimap);
+            cParticle::create(absPoint.x, absPoint.y, D2TM_PARTICLE_MOVE, -1, -1);
+        }
+    }
+}
+
 void cMiniMapDrawer::onMousePressedLeft(const s_MouseEvent &event)
 {
     if (m_RectFullMinimap.isPointWithin(event.coords.x, event.coords.y) && // on minimap space
         !game.getMouse()->isBoxSelecting() && // pressed the mouse and not boxing anything..
         this->m_status != NOTAVAILABLE // only allow action when not drawing logo
     ) {
-        if (m_player->hasAnyUnitSelected()) {
-            // Translate map coordinates to cell
-            int posX = (event.coords.x - m_RectMinimap.getX()) / m_factorZoom;
-            int posY = (event.coords.y - m_RectMinimap.getY()) / m_factorZoom;
-
-            auto point = m_map->getGeometry().fixCoordinatesToBeWithinPlayableMap(posX, posY);
-
-            cUnits *units = game.m_gameObjectsContext->getUnits();
-            units->move_to(m_map->getGeometry().makeCell(point));
-            return;
-        }
-        if (m_player->hasAtleastOneStructure(RADAR)) {
-            auto m_mouse = game.getMouse();
-            int mouseCellOnMinimap = getMouseCell(m_mouse->getX(), m_mouse->getY());
+        auto m_mouse = game.getMouse();
+        int mouseCellOnMinimap = getMouseCell(m_mouse->getX(), m_mouse->getY());
+        if (!m_player->hasAnyUnitSelected()) {
             m_mapCamera->centerAndJumpViewPortToCell(mouseCellOnMinimap);
         }
     }

--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -59,6 +59,8 @@ cMiniMapDrawer::cMiniMapDrawer(GameContext *ctx, cMap *map, cPlayer *player, cMa
 
     m_RectMinimap = cRectangle(m_drawX, m_drawY, m_factorZoom*getMapWidthInPixels(), m_factorZoom * getMapHeightInPixels());
     m_RectFullMinimap = cRectangle(topLeftX, topLeftY, cSideBar::WidthOfMinimap, cSideBar::HeightOfMinimap);
+    std::cout << "Minimap top left corner: (" << m_RectMinimap.getX() << ", " << m_RectMinimap.getY() << ", " << m_RectMinimap.getWidth() << ", " << m_RectMinimap.getHeight() << ")" << std::endl;
+    std::cout << "RectFullMinimap: (" << m_RectFullMinimap.getX() << ", " << m_RectFullMinimap.getY() << ", " << m_RectFullMinimap.getWidth() << ", " << m_RectFullMinimap.getHeight() << ")" << std::endl;
     m_mipMapTex = m_renderDrawer->createRenderTargetTexture(getMapWidthInPixels(), getMapHeightInPixels());
 }
 
@@ -392,7 +394,20 @@ void cMiniMapDrawer::onMousePressedLeft(const s_MouseEvent &event)
     if (m_RectFullMinimap.isPointWithin(event.coords.x, event.coords.y) && // on minimap space
         !game.getMouse()->isBoxSelecting() // pressed the mouse and not boxing anything..
     ) {
-
+        if (game.m_gameObjectsContext->getUnits()->areUnitsSelected() == true) {
+            std::cout << "Mouse cursor is on pos:" << event.coords.x << "," << event.coords.y << " on minimap, moving selected units there." << std::endl;
+            std::cout << "RectMiniMap size: " << m_RectMinimap.getWidth() << "," << m_RectMinimap.getHeight() << std::endl;
+            int posX = (event.coords.x-m_RectMinimap.getX())/m_factorZoom;
+            if (posX<0) posX=1;
+            if (posX>m_RectMinimap.getWidth()) posX=m_RectMinimap.getWidth()-1;
+            int posY = (event.coords.y-m_RectMinimap.getY())/m_factorZoom;
+            if (posY<0) posY=1;
+            if (posY>m_RectMinimap.getHeight()) posY=m_RectMinimap.getHeight()-1;
+            std::cout << "Calculated pos on map: " << posX << "," << posY << ":"<< (posY * m_RectMinimap.getWidth()/m_factorZoom) + posX << std::endl;
+            cUnits *units = game.m_gameObjectsContext->getUnits();
+            units->move_to((posY * m_RectMinimap.getWidth()/m_factorZoom) + posX);
+            return;
+        }
         if (m_player->hasAtleastOneStructure(RADAR)) {
             auto m_mouse = game.getMouse();
             int mouseCellOnMinimap = getMouseCell(m_mouse->getX(), m_mouse->getY());

--- a/src/drawers/cMiniMapDrawer.h
+++ b/src/drawers/cMiniMapDrawer.h
@@ -66,6 +66,7 @@ protected:
 private:
     void onMouseAt(const s_MouseEvent &event);
     void onMousePressedLeft(const s_MouseEvent &event);
+    void onMouseClickedLeft(const s_MouseEvent &event);
     void cleanDrawTerrain() const;
     int getMouseCell(int mouseX, int mouseY);
 

--- a/src/drawers/cMiniMapDrawer.h
+++ b/src/drawers/cMiniMapDrawer.h
@@ -66,6 +66,7 @@ protected:
 private:
     void onMouseAt(const s_MouseEvent &event);
     void onMousePressedLeft(const s_MouseEvent &event);
+    void onMousePressedRight(const s_MouseEvent &event);
     void onMouseClickedLeft(const s_MouseEvent &event);
     void cleanDrawTerrain() const;
     int getMouseCell(int mouseX, int mouseY);

--- a/src/gameobjects/units/cUnits.cpp
+++ b/src/gameobjects/units/cUnits.cpp
@@ -214,16 +214,6 @@ int cUnits::unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool 
 //     return unitCreate(iCll, unitType, iPlayer, bOnStart, isReinforcement, 1.0f);
 // }
 
-bool cUnits::areUnitsSelected() const
-{
-    for (const auto& unit : m_units) {
-        if (unit.isValid() && unit.isSelected()) {
-            return true;
-        }
-    }
-    return false;
-}
-
 void cUnits::move_to(int icell)
 {
     // Implementation for moving units to a specific cell

--- a/src/gameobjects/units/cUnits.cpp
+++ b/src/gameobjects/units/cUnits.cpp
@@ -213,3 +213,23 @@ int cUnits::unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool 
 // {
 //     return unitCreate(iCll, unitType, iPlayer, bOnStart, isReinforcement, 1.0f);
 // }
+
+bool cUnits::areUnitsSelected() const
+{
+    for (const auto& unit : m_units) {
+        if (unit.isValid() && unit.isSelected()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void cUnits::move_to(int icell)
+{
+    // Implementation for moving units to a specific cell
+    for (auto& unit : m_units) {
+        if (unit.isValid() && unit.isSelected()) {
+            unit.move_to(icell);
+        }
+    }
+}

--- a/src/gameobjects/units/cUnits.h
+++ b/src/gameobjects/units/cUnits.h
@@ -85,6 +85,10 @@ public:
     auto end() { return m_units.end(); }
     auto end() const { return m_units.end(); }
 
+    bool areUnitsSelected() const;
+
+    void move_to(int icell);
+
     /**
      * Creates a new unit, when bOnStart is true, it will prevent AI players from moving a unit immediately a bit.
      * Assumes the creation of a unit is NOT a reinforcement.

--- a/src/gameobjects/units/cUnits.h
+++ b/src/gameobjects/units/cUnits.h
@@ -85,8 +85,6 @@ public:
     auto end() { return m_units.end(); }
     auto end() const { return m_units.end(); }
 
-    bool areUnitsSelected() const;
-
     void move_to(int icell);
 
     /**

--- a/src/map/MapGeometry.cpp
+++ b/src/map/MapGeometry.cpp
@@ -137,6 +137,10 @@ int MapGeometry::getCellWithMapDimensions(int x, int y) const
     return (y * mapWidth) + x;
 }
 
+int MapGeometry::makeCell(cPoint point) const {
+    return makeCell(point.x, point.y);
+}
+
 int MapGeometry::makeCell(int x, int y) const
 {
     assert(x > -1 && "makeCell x must be > -1");

--- a/src/map/MapGeometry.hpp
+++ b/src/map/MapGeometry.hpp
@@ -46,6 +46,7 @@ public:
         Use <b>getCellWithMapDimensions</b> if you want a safe way to get a cell within the <i>maximum</i> map boundaries.
     **/
     int makeCell(int x, int y) const;
+    int makeCell(cPoint point) const;
 
     bool isValidCell(int c) const;
     bool isWithinBoundaries(int x, int y) const;

--- a/src/map/cMap.cpp
+++ b/src/map/cMap.cpp
@@ -57,7 +57,7 @@ cMap::cMap()
 
     m_settings = nullptr;
     m_infos = nullptr;
-    m_objects = nullptr;
+    m_gameObjectContext = nullptr;
     m_interface = nullptr;
     m_log = nullptr;
 }
@@ -90,8 +90,8 @@ void cMap::serviceInit(sGameServices* services)
     assert(m_settings != nullptr);
     m_infos = services->info;
     assert(m_infos != nullptr);
-    m_objects = services->objects;
-    assert(m_objects != nullptr);
+    m_gameObjectContext = services->objects;
+    assert(m_gameObjectContext != nullptr);
     m_interface = m_ctx->getGameInterface();
     assert(m_interface != nullptr);
 }
@@ -128,8 +128,8 @@ void cMap::init(int width, int height)
     // clear out all cells
     clearAllCells();
 
-    if (m_objects) {
-        m_objects->getStructureFactory()->deleteAllExistingStructures();
+    if (m_gameObjectContext) {
+        m_gameObjectContext->getStructureFactory()->deleteAllExistingStructures();
     }
 
     m_TIMER_scroll = 0;
@@ -253,7 +253,7 @@ bool cMap::canDeployUnitAtCell(int iCell, int iUnitID)
     if (iCell < 0 || iUnitID < 0)
         return false;
 
-    cUnit *pUnit = m_objects->getUnit(iUnitID);
+    cUnit *pUnit = m_gameObjectContext->getUnit(iUnitID);
     if (!pUnit) return false;
     if (!pUnit->isAirbornUnit()) return false; // weird unit passed in
     if (pUnit->iNewUnitType < 0) return false; // safe-guard when this unit has no new unit to spawn
@@ -311,7 +311,7 @@ bool cMap::occupied(int iCll, int iUnitID)
     if (iCll < 0 || iUnitID < 0)
         return true;
 
-    cUnit *pUnit = m_objects->getUnit(iUnitID);
+    cUnit *pUnit = m_gameObjectContext->getUnit(iUnitID);
     if (!pUnit) return true;
 
     int structureIdOnMap = getCellIdStructuresLayer(iCll);
@@ -373,7 +373,7 @@ void cMap::thinkAboutRespawningWorms()
     // timer hit exactly '1'
     m_iTIMER_respawnSandworms--;
 
-    int currentAmountOfWorms = m_objects->getPlayer(AI_WORM)->getAmountOfUnitsForType(SANDWORM);
+    int currentAmountOfWorms = m_gameObjectContext->getPlayer(AI_WORM)->getAmountOfUnitsForType(SANDWORM);
     if (currentAmountOfWorms < m_iDesiredAmountOfWorms) {
         // spawn one worm, set timer again
         int failures = 0;
@@ -459,7 +459,7 @@ void cMap::thinkAutoDetonateSpiceBlooms()  // let spice bloom detonate after X a
 void cMap::draw_bullets()
 {
     // Loop through all units, check if they should be drawn, and if so, draw them
-    for (auto& bullet : m_objects->getBullets()) {
+    for (auto& bullet : m_gameObjectContext->getBullets()) {
         if (bullet.bAlive) {
             bullet.draw();
         }
@@ -512,13 +512,13 @@ void cMap::clearShroud(int c, int size, int playerId)
 
                 int structureId = getCellIdStructuresLayer(cl);
                 if (structureId > -1) {
-                    cAbstractStructure *pStructure = m_objects->getStructure(structureId);
+                    cAbstractStructure *pStructure = m_gameObjectContext->getStructure(structureId);
                     if (!pStructure) continue;
                     s_GameEvent event {
                         .eventType = eGameEventType::GAME_EVENT_DISCOVERED,
                         .entityType = eBuildType::STRUCTURE,
                         .entityID = structureId,
-                        .player = m_objects->getPlayer(playerId),
+                        .player = m_gameObjectContext->getPlayer(playerId),
                         .entitySpecificType = pStructure->getType(),
                         .atCell = cl
                     };
@@ -528,13 +528,13 @@ void cMap::clearShroud(int c, int size, int playerId)
 
                 int unitId = getCellIdUnitLayer(cl);
                 if (unitId > -1) {
-                    cUnit *cUnit = m_objects->getUnit(unitId);
+                    cUnit *cUnit = m_gameObjectContext->getUnit(unitId);
                     if (cUnit && cUnit->isValid()) {
                         s_GameEvent event {
                             .eventType = eGameEventType::GAME_EVENT_DISCOVERED,
                             .entityType = eBuildType::UNIT,
                             .entityID = unitId,
-                            .player = m_objects->getPlayer(playerId),
+                            .player = m_gameObjectContext->getPlayer(playerId),
                             .entitySpecificType = cUnit->getType(),
                             .atCell = cl
                         };
@@ -568,8 +568,8 @@ void cMap::draw_units()
     //// @Mira fix trasnparency set_trans_blender(0, 0, 0, 160);
 
     // draw all worms first
-    for (size_t i = 0; i < m_objects->getUnitsSize(); i++) {
-        cUnit *pUnit = m_objects->getUnit(i);
+    for (size_t i = 0; i < m_gameObjectContext->getUnitsSize(); i++) {
+        cUnit *pUnit = m_gameObjectContext->getUnit(i);
         if (!pUnit || !pUnit->isValid()) continue;
 
         // DEBUG MODE: DRAW PATHS
@@ -588,8 +588,8 @@ void cMap::draw_units()
     }
 
     // then: draw infantry units
-    for (size_t i = 0; i < m_objects->getUnitsSize(); i++) {
-        cUnit *pUnit = m_objects->getUnit(i);
+    for (size_t i = 0; i < m_gameObjectContext->getUnitsSize(); i++) {
+        cUnit *pUnit = m_gameObjectContext->getUnit(i);
         if (!pUnit || !pUnit->isValid()) continue;
 
         if (!pUnit->isInfantryUnit())
@@ -604,8 +604,8 @@ void cMap::draw_units()
     }
 
     // then: draw ground units
-    for (size_t i = 0; i < m_objects->getUnitsSize(); i++) {
-        cUnit *pUnit = m_objects->getUnit(i);
+    for (size_t i = 0; i < m_gameObjectContext->getUnitsSize(); i++) {
+        cUnit *pUnit = m_gameObjectContext->getUnit(i);
         if (!pUnit || !pUnit->isValid()) continue;
 
         if (pUnit->isAirbornUnit() ||
@@ -636,8 +636,8 @@ void cMap::draw_units_2nd()
     auto *mapViewport = m_interface->getMapViewport();
 
     // draw health of units
-    for (size_t i = 0; i < m_objects->getUnitsSize(); i++) {
-        cUnit *pUnit = m_objects->getUnit(i);
+    for (size_t i = 0; i < m_gameObjectContext->getUnitsSize(); i++) {
+        cUnit *pUnit = m_gameObjectContext->getUnit(i);
         if (!pUnit || !pUnit->isValid()) continue;
         if (!pUnit->rendering.bHovered && !pUnit->isSelected()) continue;
         if (!pUnit->isWithinViewport(mapViewport)) continue;
@@ -652,8 +652,8 @@ void cMap::draw_units_2nd()
     }
 
     // draw airborn units
-    for (size_t i = 0; i < m_objects->getUnitsSize(); i++) {
-        cUnit *pUnit = m_objects->getUnit(i);
+    for (size_t i = 0; i < m_gameObjectContext->getUnitsSize(); i++) {
+        cUnit *pUnit = m_gameObjectContext->getUnit(i);
         if (!pUnit || !pUnit->isValid()) continue;
         if (!pUnit->isAirbornUnit()) continue;
 
@@ -671,7 +671,7 @@ void cMap::draw_units_2nd()
 
 int cMap::mouse_draw_x()
 {
-    cPlayer *humanPlayer = m_objects->getPlayer(HUMAN);
+    cPlayer *humanPlayer = m_gameObjectContext->getPlayer(HUMAN);
     if (humanPlayer->getGameControlsContext()->getMouseCell() > -1) {
         int mouseCell = humanPlayer->getGameControlsContext()->getMouseCell();
         int absX = m_mapGeometry->getAbsoluteXPositionFromCell(mouseCell);
@@ -683,7 +683,7 @@ int cMap::mouse_draw_x()
 int cMap::mouse_draw_y()
 {
     //@mira rewrite
-    cPlayer *humanPlayer = m_objects->getPlayer(HUMAN);
+    cPlayer *humanPlayer = m_gameObjectContext->getPlayer(HUMAN);
     if (humanPlayer->getGameControlsContext()->getMouseCell() > -1) {
         int mouseCell = humanPlayer->getGameControlsContext()->getMouseCell();
         int absY = m_mapGeometry->getAbsoluteYPositionFromCell(mouseCell);
@@ -1108,7 +1108,7 @@ cAbstractStructure *cMap::findClosestStructureType(int cell, int structureType, 
 
     const std::vector<int> &myStructuresAsId = player->getAllMyStructuresAsId();
     for (auto &i: myStructuresAsId) {
-        cAbstractStructure *pStructure = m_objects->getStructure(i);
+        cAbstractStructure *pStructure = m_gameObjectContext->getStructure(i);
         if (pStructure == nullptr) continue;
         if (pStructure->getType() != structureType) continue;
 
@@ -1122,7 +1122,7 @@ cAbstractStructure *cMap::findClosestStructureType(int cell, int structureType, 
     }
 
     if (foundStructureId > -1) {
-        return m_objects->getStructure(foundStructureId);
+        return m_gameObjectContext->getStructure(foundStructureId);
     }
 
     return nullptr;
@@ -1198,7 +1198,7 @@ cAbstractStructure *cMap::findClosestAvailableStructureType(int cell, int struct
 
     const std::vector<int> &myStructuresAsId = pPlayer->getAllMyStructuresAsId();
     for (auto &i: myStructuresAsId) {
-        cAbstractStructure *pStructure = m_objects->getStructure(i);
+        cAbstractStructure *pStructure = m_gameObjectContext->getStructure(i);
         if (pStructure == nullptr) continue;
         if (pStructure->getType() != structureType) continue;
         if (pStructure->hasUnitWithin()) continue; // already occupied
@@ -1213,7 +1213,7 @@ cAbstractStructure *cMap::findClosestAvailableStructureType(int cell, int struct
     }
 
     if (foundStructureId > -1) {
-        return m_objects->getStructure(foundStructureId);
+        return m_gameObjectContext->getStructure(foundStructureId);
     }
 
     return nullptr;
@@ -1233,7 +1233,7 @@ cMap::findClosestAvailableStructureTypeWhereNoUnitIsHeadingTo(int cell, int stru
 
     const std::vector<int> &myStructuresAsId = pPlayer->getAllMyStructuresAsId();
     for (auto &i: myStructuresAsId) {
-        cAbstractStructure *pStructure = m_objects->getStructure(i);
+        cAbstractStructure *pStructure = m_gameObjectContext->getStructure(i);
         if (pStructure == nullptr) continue;
         if (pStructure->getOwner() != playerId) continue;
         if (pStructure->getType() != structureType) continue;
@@ -1251,7 +1251,7 @@ cMap::findClosestAvailableStructureTypeWhereNoUnitIsHeadingTo(int cell, int stru
     }
 
     if (foundStructureId > -1) {
-        return m_objects->getStructure(foundStructureId);
+        return m_gameObjectContext->getStructure(foundStructureId);
     }
 
     return nullptr;
@@ -1361,7 +1361,7 @@ void cMap::onEntityCreated(const s_GameEvent &event)
 
 void cMap::evaluateIfWeShouldSetTimerToRespawnWorm()
 {
-    int currentAmountOfWorms = m_objects->getPlayer(AI_WORM)->getAmountOfUnitsForType(SANDWORM);
+    int currentAmountOfWorms = m_gameObjectContext->getPlayer(AI_WORM)->getAmountOfUnitsForType(SANDWORM);
 
     // as long as we don't have the desired amount, set respawn timer
     if (currentAmountOfWorms < m_iDesiredAmountOfWorms) {

--- a/src/map/cMap.cpp
+++ b/src/map/cMap.cpp
@@ -128,6 +128,11 @@ void cMap::init(int width, int height)
     // clear out all cells
     clearAllCells();
 
+    // moved in cGameObjectContext
+    if (game->m_gameObjectsContext) {
+        game->m_gameObjectsContext->getStructureFactory()->deleteAllExistingStructures();
+    }
+
     m_TIMER_scroll = 0;
     m_iScrollSpeed = 1;
 

--- a/src/map/cMap.cpp
+++ b/src/map/cMap.cpp
@@ -128,9 +128,8 @@ void cMap::init(int width, int height)
     // clear out all cells
     clearAllCells();
 
-    // moved in cGameObjectContext
-    if (game->m_gameObjectsContext) {
-        game->m_gameObjectsContext->getStructureFactory()->deleteAllExistingStructures();
+    if (m_objects) {
+        m_objects->getStructureFactory()->deleteAllExistingStructures();
     }
 
     m_TIMER_scroll = 0;

--- a/src/map/cMap.h
+++ b/src/map/cMap.h
@@ -446,9 +446,9 @@ private:
     GameContext *m_ctx = nullptr;
     cGameSettings *m_settings = nullptr;
     cInfoContext *m_infos = nullptr;
-    cGameObjectContext *m_objects = nullptr;
+    cGameObjectContext *m_gameObjectContext = nullptr;
     cGameInterface *m_interface = nullptr;
-    cLog *m_log = nullptr;    
+    cLog *m_log = nullptr;
     cTextDrawer *m_textDrawer = nullptr;
 
     std::unique_ptr<MapGeometry> m_mapGeometry;

--- a/src/player/cPlayer.cpp
+++ b/src/player/cPlayer.cpp
@@ -1661,6 +1661,20 @@ int cPlayer::getSpecialUnitType()
     return TRIKE;
 }
 
+bool cPlayer::hasAnyUnitSelected() {
+    for (size_t i = 0; i < m_objects->getUnitsSize(); i++) {
+        cUnit *pUnit = m_objects->getUnit(i);
+        if (!pUnit->isValid()) continue;
+        if (pUnit->isDead() && !pUnit->isHidden()) continue; // hidden units play "dead" :/
+        if (!pUnit->belongsTo(this)) continue;
+        if (pUnit->isMarkedForRemoval()) continue; // do not count marked for removal units
+        if (pUnit->isSelected()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool cPlayer::hasEnoughPowerFor(int structureType) const
 {
     assert(structureType > -1 && "hasEnoughPowerFor called with structureType < 0!");

--- a/src/player/cPlayer.h
+++ b/src/player/cPlayer.h
@@ -443,6 +443,8 @@ public:
     int getScoutingUnitType();
     int getSpecialUnitType();
 
+    bool hasAnyUnitSelected();
+
     static std::string getHouseNameForId(int house);
 
     void logStructures();


### PR DESCRIPTION
From #291 

## **Goal**

Send units to destination via minimap is now possible with this patch

### Changes
- `cUnits` can move units
- `cMinimapDrawer` change behavior if units are selected

## Testing Steps
I created maps with markers to check the PR

## Screenshots

https://github.com/user-attachments/assets/53cee2fd-bbf8-4006-af5d-1ef303e88e4e


close #291 
