### PR TITLE
Introduce `BuildEvent` and `DamagedEvent` for `sGameEvent`

### DIFF
--- a/src/building/cItemBuilder.cpp
+++ b/src/building/cItemBuilder.cpp
@@ -216,14 +216,15 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
             }
             item->setPlaceIt(true);
 
-            s_GameEvent event {
+            const s_GameEvent event {
                 .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_PLACE_IT,
-                .entityType = item->getBuildType(),
-                .player = m_player,
-                .entitySpecificType = item->getBuildId(),
-                .buildingListItem = item // mandatory for this event!
+                .data = BuildingEvent {
+                    .entityType = item->getBuildType(),
+                    .player = m_player,
+                    .entitySpecificType = item->getBuildId(),
+                    .buildingListItem = item // mandatory for this event!
+                }
             };
-
             game.onNotifyGameEvent(event);
         }
     }
@@ -350,14 +351,15 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                     if (!item->shouldDeployIt()) {
                         item->setDeployIt(true);
 
-                        s_GameEvent event {
+                        const s_GameEvent event {
                             .eventType = eGameEventType::GAME_EVENT_SPECIAL_SELECT_TARGET,
-                            .entityType = item->getBuildType(),
-                            .player = m_player,
-                            .entitySpecificType = item->getBuildId(),
-                            .buildingListItem = item // mandatory for this event!
+                            .data = BuildingEvent {
+                                .entityType = item->getBuildType(),
+                                .player = m_player,
+                                .entitySpecificType = item->getBuildId(),
+                                .buildingListItem = item
+                            }
                         };
-
                         game.onNotifyGameEvent(event);
                     }
                 }
@@ -371,17 +373,16 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
         }
         else if (eBuildType == UPGRADE) {
             // notify game that the item just has been finished
-            s_GameEvent event {
-                .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_FINISHED,
-                .entityType = eBuildType,
-                .entityID = -1,
-                .player = m_player,
-                .entitySpecificType = buildId,
-                .atCell = -1,
-                .isReinforce = false,
-                .buildingListItem = item
-            };
 
+            const s_GameEvent event {
+                .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_FINISHED,
+                .data = BuildingEvent {
+                    .entityType = eBuildType,
+                    .player = m_player,
+                    .entitySpecificType = buildId,
+                    .buildingListItem = item
+                }
+            };
             game.onNotifyGameEvent(event);
 
             // these destroy the data..

--- a/src/building/cItemBuilder.cpp
+++ b/src/building/cItemBuilder.cpp
@@ -219,11 +219,8 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
             s_GameEvent event {
                 .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_PLACE_IT,
                 .entityType = item->getBuildType(),
-                .entityID = -1,
                 .player = m_player,
                 .entitySpecificType = item->getBuildId(),
-                .atCell = -1,
-                .isReinforce = false,
                 .buildingListItem = item // mandatory for this event!
             };
 
@@ -270,7 +267,6 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                 .entitySpecificType = buildId,
                 .atCell = -1,
                 .isReinforce = false,
-                .buildingListItem = nullptr
             };
 
             game.onNotifyGameEvent(event);
@@ -343,7 +339,6 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                     .entitySpecificType = buildId,
                     .atCell = -1,
                     .isReinforce = false,
-                    .buildingListItem = nullptr
                 };
 
                 game.onNotifyGameEvent(event);
@@ -358,11 +353,8 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                         s_GameEvent event {
                             .eventType = eGameEventType::GAME_EVENT_SPECIAL_SELECT_TARGET,
                             .entityType = item->getBuildType(),
-                            .entityID = -1,
                             .player = m_player,
                             .entitySpecificType = item->getBuildId(),
-                            .atCell = -1,
-                            .isReinforce = false,
                             .buildingListItem = item // mandatory for this event!
                         };
 

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1113,7 +1113,8 @@ void cGame::onNotifyGameEvent(const s_GameEvent &event)
     m_players->onNotifyGameEvent(event);
 }
 
-void cGame::onEventEntityDestroyed(const s_GameEvent &event) {
+void cGame::onEventEntityDestroyed(const s_GameEvent &event)
+{
     if (event.entityType != eBuildType::STRUCTURE) {
         return;
     }

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1215,14 +1215,15 @@ void cGame::onEventSpecialLaunch(const LaunchDeathHandEvent &event) const
                     createBullet(special.providesTypeId, pStructure->getCell(), deployCell, -1, structureId);
 
                     // notify game that the item just has been finished!
-                    s_GameEvent event {
+                    const s_GameEvent event {
                         .eventType = eGameEventType::GAME_EVENT_SPECIAL_LAUNCHED,
-                        .entityType = itemToDeploy->getBuildType(),
-                        .player = pStructure->getPlayer(),
-                        .entitySpecificType = itemToDeploy->getBuildId(),
-                        .buildingListItem = itemToDeploy
+                        .data = BuildingEvent {
+                            .entityType = itemToDeploy->getBuildType(),
+                            .player = pStructure->getPlayer(),
+                            .entitySpecificType = itemToDeploy->getBuildId(),
+                            .buildingListItem = itemToDeploy
+                        }
                     };
-
                     game.onNotifyGameEvent(event);
                 }
             }

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1218,11 +1218,8 @@ void cGame::onEventSpecialLaunch(const LaunchDeathHandEvent &event) const
                     s_GameEvent event {
                         .eventType = eGameEventType::GAME_EVENT_SPECIAL_LAUNCHED,
                         .entityType = itemToDeploy->getBuildType(),
-                        .entityID = -1,
                         .player = pStructure->getPlayer(),
                         .entitySpecificType = itemToDeploy->getBuildId(),
-                        .atCell = -1,
-                        .isReinforce = false,
                         .buildingListItem = itemToDeploy
                     };
 
@@ -1253,7 +1250,6 @@ void cGame::onEventSpecialLaunch(const LaunchDeathHandEvent &event) const
         .entitySpecificType = itemToDeploy->getBuildId(),
         .atCell = -1,
         .isReinforce = false,
-        .buildingListItem = nullptr
     };
 
     game.onNotifyGameEvent(eventT);

--- a/src/gameobjects/structures/cAbstractStructure.cpp
+++ b/src/gameobjects/structures/cAbstractStructure.cpp
@@ -515,16 +515,17 @@ void cAbstractStructure::damage(int hp, int originId)
             }
         }
 
-        s_GameEvent event {
+        const s_GameEvent event {
             .eventType = eGameEventType::GAME_EVENT_DAMAGED,
-            .entityType = eBuildType::STRUCTURE,
-            .entityID = getStructureId(),
-            .player = getPlayer(),
-            .entitySpecificType = getType(),
-            .originId = originId,
-            .originType = eBuildType::UNIT // TODO: What if another structure damaged me!?
+            .data = DamagedEvent {
+                .entityType = eBuildType::STRUCTURE,
+                .entityID = getStructureId(),
+                .player = getPlayer(),
+                .entitySpecificType = getType(),
+                .originId = originId,
+                .originType = eBuildType::UNIT // TODO: What if another structure damaged me!?
+            }
         };
-
         game.onNotifyGameEvent(event);
     }
 }

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -3506,17 +3506,18 @@ void cUnit::takeDamage(int damage, int unitWhoDealsDamage, int structureWhoDeals
                     originCell = pStructure->getCell();
                 }
             }
-            s_GameEvent event {
+            const s_GameEvent event {
                 .eventType = eGameEventType::GAME_EVENT_DAMAGED,
-                .entityType = eBuildType::UNIT,
-                .entityID = iID,
-                .player = getPlayer(),
-                .entitySpecificType = getType(),
-                .atCell = originCell,
-                .originId = originId,
-                .originType = originType,
+                .data = DamagedEvent {
+                    .entityType = eBuildType::UNIT,
+                    .entityID = iID,
+                    .player = getPlayer(),
+                    .entitySpecificType = getType(),
+                    .atCell = originCell,
+                    .originId = originId,
+                    .originType = originType
+                }
             };
-
             m_interface->onNotifyGameEvent(event);
         }
     }

--- a/src/include/sGameEvent.cpp
+++ b/src/include/sGameEvent.cpp
@@ -97,14 +97,24 @@ const std::string s_GameEvent::toString(const s_GameEvent &event)
         );
     }
 
-    return std::format("cGameEvent [type={}], [entityType={}], [entityId={}], [entitySpecificType={} ={}], [isReinforce={}], [atCell={}], [buildingListItem={}]",
+    if (const auto *buildingEvent = std::get_if<BuildingEvent>(&event.data)) {
+        return std::format(
+            "BuildingEvent[entityType={}, player={}, entitySpecificType={}, buildingListItem={}, buildingList={}]",
+            eBuildTypeString(buildingEvent->entityType),
+            buildingEvent->player ? "present" : "nullptr",
+            buildingEvent->entitySpecificType,
+            buildingEvent->buildingListItem ? "present" : "nullptr",
+            buildingEvent->buildingList ? "present" : "nullptr"
+        );
+    }
+
+    return std::format("cGameEvent [type={}], [entityType={}], [entityId={}], [entitySpecificType={} ={}], [isReinforce={}], [atCell={}]",
                            toString(event.eventType),
                            eBuildTypeString(event.entityType),
                            event.entityID,
                            event.entitySpecificType,
                            toStringBuildTypeSpecificType(event.entityType, event.entitySpecificType),
                            event.isReinforce ? "true" : "false",
-                           event.atCell,
-                           event.buildingListItem ? "present" : "nullptr"
+                           event.atCell
                           );
 }

--- a/src/include/sGameEvent.cpp
+++ b/src/include/sGameEvent.cpp
@@ -84,7 +84,20 @@ const std::string s_GameEvent::toString(const s_GameEvent &event)
         );
     }
 
-    return std::format("cGameEvent [type={}], [entityType={}], [entityId={}], [entitySpecificType={} ={}], [isReinforce={}], [atCell={}], [buildingListItem={}] [originId={}]",
+    if (const auto *damagedEvent = std::get_if<DamagedEvent>(&event.data)) {
+        return std::format(
+            "DamagedEvent[entityType={}, entityId={}, player={}, entitySpecificType={}, atCell={}, originId={}, originType={}]",
+            eBuildTypeString(damagedEvent->entityType),
+            damagedEvent->entityID,
+            damagedEvent->player ? "present" : "nullptr",
+            damagedEvent->entitySpecificType,
+            damagedEvent->atCell,
+            damagedEvent->originId,
+            eBuildTypeString(damagedEvent->originType)
+        );
+    }
+
+    return std::format("cGameEvent [type={}], [entityType={}], [entityId={}], [entitySpecificType={} ={}], [isReinforce={}], [atCell={}], [buildingListItem={}]",
                            toString(event.eventType),
                            eBuildTypeString(event.entityType),
                            event.entityID,
@@ -92,7 +105,6 @@ const std::string s_GameEvent::toString(const s_GameEvent &event)
                            toStringBuildTypeSpecificType(event.entityType, event.entitySpecificType),
                            event.isReinforce ? "true" : "false",
                            event.atCell,
-                           event.buildingListItem ? "present" : "nullptr",
-                           event.originId
+                           event.buildingListItem ? "present" : "nullptr"
                           );
 }

--- a/src/include/sGameEvent.h
+++ b/src/include/sGameEvent.h
@@ -32,10 +32,20 @@ struct LaunchDeathHandEvent {
     int playerID = -1; // for looging purposes, as player pointer might not always be available
 };
 
+// GAME_EVENT_DAMAGED
+struct DamagedEvent {
+    eBuildType entityType = eBuildType::UNKNOWN; //kind of entity this applies to.
+    int entityID = -1;
+    cPlayer *player = nullptr;
+    int entitySpecificType = -1; // type of <entityType>, ie, if entityType is STRUCTURE. This value can be CONSTYARD
+    int atCell = -1;
+    int originId = -1; // in case GAME_EVENT_DAMAGED, this is the id that inflicted damage
+    eBuildType originType = eBuildType::UNKNOWN; // in case GAME_EVENT_DAMAGED, this is the kind of entity that inflicted damage
+};
 
 struct s_GameEvent {
     eGameEventType eventType = eGameEventType::GAME_EVENT_NONE;
-    using GameEventData = std::variant<std::monostate, DeployUnitEvent, LaunchDeathHandEvent>;
+    using GameEventData = std::variant<std::monostate, DeployUnitEvent, LaunchDeathHandEvent, DamagedEvent>;
     GameEventData data = std::monostate{};
     
     /**
@@ -62,8 +72,6 @@ struct s_GameEvent {
     cBuildingListItem *buildingListItem = nullptr; // if buildingListItem is ready (special, or not)
     cBuildingList *buildingList = nullptr; // in case buildingList is available (or not)
 
-    int originId = -1; // in case GAME_EVENT_DAMAGED, this is the id that inflicted damage
-    eBuildType originType = eBuildType::UNKNOWN; // in case GAME_EVENT_DAMAGED, this is the kind of entity that inflicted damage
 
     static const char *toString(const eGameEventType &eventType);
 

--- a/src/include/sGameEvent.h
+++ b/src/include/sGameEvent.h
@@ -43,9 +43,18 @@ struct DamagedEvent {
     eBuildType originType = eBuildType::UNKNOWN; // in case GAME_EVENT_DAMAGED, this is the kind of entity that inflicted damage
 };
 
+// BUILDING_EVENT
+struct BuildingEvent {
+    eBuildType entityType;  //kind of entity this applies to.
+    cPlayer *player = nullptr;
+    int entitySpecificType = -1; // type of <entityType>, ie, if entityType is STRUCTURE. This value can be CONSTYARD
+    cBuildingListItem *buildingListItem = nullptr; // if buildingListItem is ready (special, or not)
+    cBuildingList *buildingList = nullptr; // in case buildingList is available (or not)
+};
+
 struct s_GameEvent {
     eGameEventType eventType = eGameEventType::GAME_EVENT_NONE;
-    using GameEventData = std::variant<std::monostate, DeployUnitEvent, LaunchDeathHandEvent, DamagedEvent>;
+    using GameEventData = std::variant<std::monostate, DeployUnitEvent, LaunchDeathHandEvent, DamagedEvent, BuildingEvent>;
     GameEventData data = std::monostate{};
     
     /**
@@ -69,9 +78,6 @@ struct s_GameEvent {
     int entitySpecificType = -1; // type of <entityType>, ie, if entityType is STRUCTURE. This value can be CONSTYARD
     int atCell = -1;        // if applicable (== > -1) where on the map did this event happen?
     bool isReinforce = false;       // only applicable for UNIT and CREATED events. So we can distinguish between 'normal' CREATED units and reinforced units.
-    cBuildingListItem *buildingListItem = nullptr; // if buildingListItem is ready (special, or not)
-    cBuildingList *buildingList = nullptr; // in case buildingList is available (or not)
-
 
     static const char *toString(const eGameEventType &eventType);
 

--- a/src/map/cMap.cpp
+++ b/src/map/cMap.cpp
@@ -875,9 +875,7 @@ void cMap::createCell(int cell, int terrainType, int tile)
             .player = nullptr,
             .entitySpecificType = -1,
             .atCell = cell,
-            .isReinforce = false,
-            .buildingListItem = nullptr,
-            .buildingList = nullptr
+            .isReinforce = false
         };
 
         m_interface->onNotifyGameEvent(event);
@@ -1325,9 +1323,7 @@ void cMap::detonateSpiceBloom(int cell)
         .player = nullptr,
         .entitySpecificType = -1,
         .atCell = cell,
-        .isReinforce = false,
-        .buildingListItem = nullptr,
-        .buildingList = nullptr
+        .isReinforce = false
     };
     m_interface->onNotifyGameEvent(event);
 

--- a/src/player/brains/cPlayerBrainCampaign.cpp
+++ b/src/player/brains/cPlayerBrainCampaign.cpp
@@ -139,7 +139,10 @@ void cPlayerBrainCampaign::onNotifyGameEvent(const s_GameEvent &event)
                     onMyStructureCreated(event);
                     break;
                 case eGameEventType::GAME_EVENT_DAMAGED:
-                    onMyStructureAttacked(event);
+                    if (const auto *damagedEvent = std::get_if<DamagedEvent>(&event.data)) {
+                        onMyStructureAttacked(*damagedEvent);
+                    }
+                    break;
                     // help I'm under attack.. do something smart
                     break;
                 case eGameEventType::GAME_EVENT_DECAY:
@@ -153,7 +156,9 @@ void cPlayerBrainCampaign::onNotifyGameEvent(const s_GameEvent &event)
         else if (event.entityType == eBuildType::UNIT) {
             switch (event.eventType) {
                 case eGameEventType::GAME_EVENT_DAMAGED:
-                    onMyUnitAttacked(event);
+                    if (const auto *damagedEvent = std::get_if<DamagedEvent>(&event.data)) {
+                        onMyUnitAttacked(*damagedEvent);
+                    }
                     break;
                 default:
                     break;
@@ -228,7 +233,7 @@ void cPlayerBrainCampaign::onMyStructureDestroyed(const s_GameEvent &event)
     }
 }
 
-void cPlayerBrainCampaign::onMyUnitAttacked(const s_GameEvent &event)
+void cPlayerBrainCampaign::onMyUnitAttacked(const DamagedEvent &event)
 {
     if (event.originType == eBuildType::UNKNOWN) {
         // don't know who attacked us; ignore
@@ -247,7 +252,7 @@ void cPlayerBrainCampaign::onMyUnitAttacked(const s_GameEvent &event)
     }
 }
 
-void cPlayerBrainCampaign::onMyStructureAttacked(const s_GameEvent &event)
+void cPlayerBrainCampaign::onMyStructureAttacked(const DamagedEvent &event)
 {
     if (player->hasEnoughCreditsFor(50)) {
         cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];

--- a/src/player/brains/cPlayerBrainCampaign.h
+++ b/src/player/brains/cPlayerBrainCampaign.h
@@ -55,11 +55,11 @@ private:
 
     void onMyStructureCreated(const s_GameEvent &event);
 
-    void onMyStructureAttacked(const s_GameEvent &event);
+    void onMyStructureAttacked(const DamagedEvent &event);
 
     void onMyStructureDecayed(const s_GameEvent &event);
 
-    void onMyUnitAttacked(const s_GameEvent &event);
+    void onMyUnitAttacked(const DamagedEvent &event);
 
     void thinkState_ScanBase();
 

--- a/src/player/brains/cPlayerBrainSkirmish.cpp
+++ b/src/player/brains/cPlayerBrainSkirmish.cpp
@@ -159,7 +159,10 @@ void cPlayerBrainSkirmish::onNotifyGameEvent(const s_GameEvent &event)
                     onMyStructureCreated(event);
                     break;
                 case eGameEventType::GAME_EVENT_DAMAGED:
-                    onMyStructureAttacked(event);
+                    if (const auto *damagedEvent = std::get_if<DamagedEvent>(&event.data)) {
+                        onMyStructureAttacked(*damagedEvent);
+                    }
+                    break;
                     // help I'm under attack.. do something smart
                     break;
                 case eGameEventType::GAME_EVENT_DECAY:
@@ -173,7 +176,9 @@ void cPlayerBrainSkirmish::onNotifyGameEvent(const s_GameEvent &event)
         else if (event.entityType == eBuildType::UNIT) {
             switch (event.eventType) {
                 case eGameEventType::GAME_EVENT_DAMAGED:
-                    onMyUnitAttacked(event);
+                    if (const auto *damagedEvent = std::get_if<DamagedEvent>(&event.data)) {
+                        onMyUnitAttacked(*damagedEvent);
+                    }
                     break;
                 default:
                     break;
@@ -261,7 +266,7 @@ void cPlayerBrainSkirmish::onMyStructureDestroyed(const s_GameEvent &event)
     }
 }
 
-void cPlayerBrainSkirmish::onMyStructureAttacked(const s_GameEvent &event)
+void cPlayerBrainSkirmish::onMyStructureAttacked(const DamagedEvent &event)
 {
     if (player->hasEnoughCreditsFor(50)) {
         cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
@@ -1608,7 +1613,7 @@ void cPlayerBrainSkirmish::log(const std::string &txt)
                );
 }
 
-void cPlayerBrainSkirmish::onMyUnitAttacked(const s_GameEvent &event)
+void cPlayerBrainSkirmish::onMyUnitAttacked(const DamagedEvent &event)
 {
     if (event.originType == eBuildType::UNKNOWN) {
         // don't know who attacked us; ignore

--- a/src/player/brains/cPlayerBrainSkirmish.cpp
+++ b/src/player/brains/cPlayerBrainSkirmish.cpp
@@ -1091,7 +1091,6 @@ void cPlayerBrainSkirmish::thinkState_ProcessBuildOrders()
                     .entitySpecificType = buildOrder.buildId,
                     .atCell = -1,
                     .isReinforce = false,
-                    .buildingListItem = nullptr
                 };
 
                 game.onNotifyGameEvent(event);

--- a/src/player/brains/cPlayerBrainSkirmish.h
+++ b/src/player/brains/cPlayerBrainSkirmish.h
@@ -104,11 +104,11 @@ private:
 
     void onMyStructureCreated(const s_GameEvent &event);
 
-    void onMyStructureAttacked(const s_GameEvent &event);
+    void onMyStructureAttacked(const DamagedEvent &event);
 
     void onMyStructureDecayed(const s_GameEvent &event);
 
-    void onMyUnitAttacked(const s_GameEvent &event);
+    void onMyUnitAttacked(const DamagedEvent &event);
 
     void thinkState_Base();
 

--- a/src/player/brains/missions/cPlayerBrainMission.cpp
+++ b/src/player/brains/missions/cPlayerBrainMission.cpp
@@ -421,11 +421,8 @@ void cPlayerBrainMission::thinkState_PrepareGatherResources()
             s_GameEvent event {
                 .eventType = eGameEventType::GAME_EVENT_SPECIAL_SELECT_TARGET,
                 .entityType = item->getBuildType(),
-                .entityID = -1,
                 .player = player,
                 .entitySpecificType = item->getBuildId(),
-                .atCell = -1,
-                .isReinforce = false,
                 .buildingListItem = item // mandatory for this event!
             };
             // fake notification for missionKind so that its state gets updated...

--- a/src/player/brains/missions/cPlayerBrainMission.cpp
+++ b/src/player/brains/missions/cPlayerBrainMission.cpp
@@ -418,14 +418,15 @@ void cPlayerBrainMission::thinkState_PrepareGatherResources()
         else {
             // in reality this event already has been sent, but this mission did not exist yet
             cBuildingListItem *item = player->getSpecialAwaitingPlacement();
-            s_GameEvent event {
+            const s_GameEvent event {
                 .eventType = eGameEventType::GAME_EVENT_SPECIAL_SELECT_TARGET,
-                .entityType = item->getBuildType(),
-                .player = player,
-                .entitySpecificType = item->getBuildId(),
-                .buildingListItem = item // mandatory for this event!
+                .data = BuildingEvent {
+                    .entityType = item->getBuildType(),
+                    .player = player,
+                    .entitySpecificType = item->getBuildId(),
+                    .buildingListItem = item
+                }
             };
-            // fake notification for missionKind so that its state gets updated...
             missionKind->onNotifyGameEvent(event);
         }
         return; // bail, mission without units will wait for events

--- a/src/player/brains/missions/cPlayerBrainMissionKind.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKind.cpp
@@ -113,8 +113,9 @@ void cPlayerBrainMissionKind::onExecuteSpecificStateSwitch(const s_GameEvent &ev
 
     // just before we set select-target state, we call this method. So our child-implementations
     // can change state accordingly
-    onNotify_SpecificStateSwitch(event);
-
+    if (const auto *buildEvent = std::get_if<BuildingEvent>(&event.data)) {
+        onNotify_SpecificStateSwitch(*buildEvent);
+    }
     mission->changeState(PLAYERBRAINMISSION_STATE_SELECT_TARGET);
 }
 

--- a/src/player/brains/missions/cPlayerBrainMissionKind.h
+++ b/src/player/brains/missions/cPlayerBrainMissionKind.h
@@ -77,7 +77,7 @@ public:
 
     virtual cPlayerBrainMissionKind *clone(cPlayer *player, cPlayerBrainMission *mission) = 0;
 
-    virtual void onNotify_SpecificStateSwitch(const s_GameEvent &event) = 0;
+    virtual void onNotify_SpecificStateSwitch(const BuildingEvent &event) = 0;
 
     void onNotifyGameEvent(const s_GameEvent &event);
 

--- a/src/player/brains/missions/cPlayerBrainMissionKindAttack.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKindAttack.cpp
@@ -191,7 +191,7 @@ cPlayerBrainMissionKind *cPlayerBrainMissionKindAttack::clone(cPlayer *player, c
     return copy;
 }
 
-void cPlayerBrainMissionKindAttack::onNotify_SpecificStateSwitch(const s_GameEvent &)
+void cPlayerBrainMissionKindAttack::onNotify_SpecificStateSwitch(const BuildingEvent &)
 {
     // NOOP
 }

--- a/src/player/brains/missions/cPlayerBrainMissionKindAttack.h
+++ b/src/player/brains/missions/cPlayerBrainMissionKindAttack.h
@@ -22,7 +22,7 @@ public:
 
     void onNotifyGameEvent(const s_GameEvent &event) override;
 
-    void onNotify_SpecificStateSwitch(const s_GameEvent &event) override;
+    void onNotify_SpecificStateSwitch(const BuildingEvent &event) override;
 
     const char *toString() override {
         return "cPlayerBrainMissionKindAttack";

--- a/src/player/brains/missions/cPlayerBrainMissionKindDeathHand.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKindDeathHand.cpp
@@ -103,7 +103,9 @@ void cPlayerBrainMissionKindDeathHand::onNotifyGameEvent(const s_GameEvent &even
     log(std::format("cPlayerBrainMissionKindDeathHand::onNotifyGameEvent() -> {}", event.toString(event.eventType)).c_str());
 
     if (event.eventType == eGameEventType::GAME_EVENT_LIST_ITEM_CANCELLED) {
-        onBuildItemCancelled(event);
+        if (const auto *buildingEvent = std::get_if<BuildingEvent>(&event.data)) {
+            onBuildItemCancelled(*buildingEvent);
+        }
     }
 }
 
@@ -119,7 +121,7 @@ cPlayerBrainMissionKind *cPlayerBrainMissionKindDeathHand::clone(cPlayer *player
     return copy;
 }
 
-void cPlayerBrainMissionKindDeathHand::onBuildItemCancelled(const s_GameEvent &event)
+void cPlayerBrainMissionKindDeathHand::onBuildItemCancelled(const BuildingEvent &event)
 {
     if (event.player == player) {
         // looks like the thing we had stored is being cancelled, so forget about it
@@ -131,7 +133,7 @@ void cPlayerBrainMissionKindDeathHand::onBuildItemCancelled(const s_GameEvent &e
     }
 }
 
-void cPlayerBrainMissionKindDeathHand::onNotify_SpecificStateSwitch(const s_GameEvent &event)
+void cPlayerBrainMissionKindDeathHand::onNotify_SpecificStateSwitch(const BuildingEvent &event)
 {
     // here we know it is the specific thing we are interested in (hence the "SpecificStateSwitch" name)
     if (event.player == player) {

--- a/src/player/brains/missions/cPlayerBrainMissionKindDeathHand.h
+++ b/src/player/brains/missions/cPlayerBrainMissionKindDeathHand.h
@@ -28,7 +28,7 @@ public:
         return "cPlayerBrainMissionKindDeathHand";
     }
 
-    void onNotify_SpecificStateSwitch(const s_GameEvent &event) override;
+    void onNotify_SpecificStateSwitch(const BuildingEvent &event) override;
 
 private:
     int target;
@@ -40,7 +40,7 @@ private:
 
     void onMySpecialSelectTarget(const s_GameEvent &event);
 
-    void onBuildItemCancelled(const s_GameEvent &event);
+    void onBuildItemCancelled(const BuildingEvent &event);
 };
 
 }

--- a/src/player/brains/missions/cPlayerBrainMissionKindExplore.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKindExplore.cpp
@@ -73,7 +73,7 @@ cPlayerBrainMissionKind *cPlayerBrainMissionKindExplore::clone(cPlayer *player, 
     return copy;
 }
 
-void cPlayerBrainMissionKindExplore::onNotify_SpecificStateSwitch(const s_GameEvent &)
+void cPlayerBrainMissionKindExplore::onNotify_SpecificStateSwitch(const BuildingEvent &)
 {
     // NOOP
 }

--- a/src/player/brains/missions/cPlayerBrainMissionKindExplore.h
+++ b/src/player/brains/missions/cPlayerBrainMissionKindExplore.h
@@ -26,7 +26,7 @@ public:
         return "cPlayerBrainMissionKindExplore";
     }
 
-    void onNotify_SpecificStateSwitch(const s_GameEvent &event) override;
+    void onNotify_SpecificStateSwitch(const BuildingEvent &event) override;
 
 private:
     int targetCell;

--- a/src/player/brains/missions/cPlayerBrainMissionKindFremen.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKindFremen.cpp
@@ -51,7 +51,7 @@ cPlayerBrainMissionKind *cPlayerBrainMissionKindFremen::clone(cPlayer *player, c
     return copy;
 }
 
-void cPlayerBrainMissionKindFremen::onNotify_SpecificStateSwitch(const s_GameEvent &)
+void cPlayerBrainMissionKindFremen::onNotify_SpecificStateSwitch(const BuildingEvent &)
 {
     // NOOP
 }

--- a/src/player/brains/missions/cPlayerBrainMissionKindFremen.h
+++ b/src/player/brains/missions/cPlayerBrainMissionKindFremen.h
@@ -26,7 +26,7 @@ public:
         return "cPlayerBrainMissionKindFremen";
     }
 
-    void onNotify_SpecificStateSwitch(const s_GameEvent &event) override;
+    void onNotify_SpecificStateSwitch(const BuildingEvent &event) override;
 private:
 };
 

--- a/src/player/brains/missions/cPlayerBrainMissionKindSaboteur.cpp
+++ b/src/player/brains/missions/cPlayerBrainMissionKindSaboteur.cpp
@@ -112,7 +112,7 @@ cPlayerBrainMissionKind *cPlayerBrainMissionKindSaboteur::clone(cPlayer *player,
     return copy;
 }
 
-void cPlayerBrainMissionKindSaboteur::onNotify_SpecificStateSwitch(const s_GameEvent &)
+void cPlayerBrainMissionKindSaboteur::onNotify_SpecificStateSwitch(const BuildingEvent &)
 {
     // NOOP
 }

--- a/src/player/brains/missions/cPlayerBrainMissionKindSaboteur.h
+++ b/src/player/brains/missions/cPlayerBrainMissionKindSaboteur.h
@@ -27,7 +27,7 @@ public:
         return "cPlayerBrainMissionKindSaboteur";
     }
 
-    void onNotify_SpecificStateSwitch(const s_GameEvent &event) override;
+    void onNotify_SpecificStateSwitch(const BuildingEvent &event) override;
 
 private:
     int targetStructureID;

--- a/src/player/cPlayer.cpp
+++ b/src/player/cPlayer.cpp
@@ -1632,14 +1632,18 @@ void cPlayer::onNotifyGameEvent(const s_GameEvent &event)
     }
 
     if (event.eventType == eGameEventType::GAME_EVENT_SPECIAL_LAUNCHED) {
-        auto msg = std::format("{} launched!", event.buildingListItem->getNameString());
-        addNotification(msg, eNotificationType::BAD);
+        if (const auto *buildEvent = std::get_if<BuildingEvent>(&event.data)) {
+                auto msg = std::format("{} launched!", buildEvent->buildingListItem->getNameString());
+                addNotification(msg, eNotificationType::BAD);
+        }
     }
 
     if (event.player == this) {
         if (event.eventType == eGameEventType::GAME_EVENT_SPECIAL_SELECT_TARGET) {
-            auto msg = std::format("{} is ready for deployment.", event.buildingListItem->getNameString());
-            addNotification(msg, eNotificationType::PRIORITY);
+            if (const auto *buildEvent = std::get_if<BuildingEvent>(&event.data)) {
+                auto msg = std::format("{} is ready for deployment.", buildEvent->buildingListItem->getNameString());
+                addNotification(msg, eNotificationType::PRIORITY);
+            }
         }
 
         if (event.eventType == eGameEventType::GAME_EVENT_CREATED) {
@@ -1666,8 +1670,10 @@ void cPlayer::onNotifyGameEvent(const s_GameEvent &event)
 
         if (event.eventType == eGameEventType::GAME_EVENT_LIST_ITEM_FINISHED) {
             if (event.entityType == eBuildType::UPGRADE) {
-                auto msg = std::format("Upgrade: {} completed.", event.buildingListItem->getNameString());
-                addNotification(msg, eNotificationType::PRIORITY);
+                if (const auto *buildEvent = std::get_if<BuildingEvent>(&event.data)) {
+                    auto msg = std::format("Upgrade: {} completed.", buildEvent->buildingListItem->getNameString());
+                    addNotification(msg, eNotificationType::PRIORITY);
+                }
             }
         }
 

--- a/src/sidebar/cBuildingList.cpp
+++ b/src/sidebar/cBuildingList.cpp
@@ -144,11 +144,8 @@ bool cBuildingList::addItemToList(cBuildingListItem *item)
     s_GameEvent event {
         .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_ADDED,
         .entityType = buildType,
-        .entityID = -1,
         .player = pPlayer,
         .entitySpecificType = buildId,
-        .atCell = -1,
-        .isReinforce = false,
         .buildingListItem = item
     };
 
@@ -159,15 +156,11 @@ bool cBuildingList::addItemToList(cBuildingListItem *item)
         s_GameEvent event {
             .eventType = eGameEventType::GAME_EVENT_LIST_BECAME_AVAILABLE,
             .entityType = buildType,
-            .entityID = -1,
             .player = pPlayer,
             .entitySpecificType = buildId,
-            .atCell = -1,
-            .isReinforce = false,
             .buildingListItem = item,
             .buildingList = this
         };
-
         game.onNotifyGameEvent(event);
     }
 
@@ -236,7 +229,6 @@ bool cBuildingList::removeItemFromList(int position)
             .entitySpecificType = -1, // BOGUS
             .atCell = -1,
             .isReinforce = false,
-            .buildingListItem = nullptr,
             .buildingList = this
         };
 

--- a/src/sidebar/cBuildingList.cpp
+++ b/src/sidebar/cBuildingList.cpp
@@ -140,26 +140,28 @@ bool cBuildingList::addItemToList(cBuildingListItem *item)
     cPlayer *pPlayer = m_itemBuilder->getPlayer();
     int buildId = item->getBuildId();
     eBuildType buildType = item->getBuildType();
-
-    s_GameEvent event {
+    const s_GameEvent event {
         .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_ADDED,
-        .entityType = buildType,
-        .player = pPlayer,
-        .entitySpecificType = buildId,
-        .buildingListItem = item
+        .data = BuildingEvent {
+            .entityType = buildType,
+            .player = pPlayer,
+            .entitySpecificType = buildId,
+            .buildingListItem = item
+        }
     };
-
     game.onNotifyGameEvent(event);
 
     if (isAvailable() != beforeAddingAvailable) {
         // emit another event that this list became available! (so that sidebar can animate things)
-        s_GameEvent event {
+        const s_GameEvent event {
             .eventType = eGameEventType::GAME_EVENT_LIST_BECAME_AVAILABLE,
-            .entityType = buildType,
-            .player = pPlayer,
-            .entitySpecificType = buildId,
-            .buildingListItem = item,
-            .buildingList = this
+            .data = BuildingEvent {
+                .entityType = buildType,
+                .player = pPlayer,
+                .entitySpecificType = buildId,
+                .buildingListItem = item,
+                .buildingList = this
+            }
         };
         game.onNotifyGameEvent(event);
     }
@@ -221,17 +223,15 @@ bool cBuildingList::removeItemFromList(int position)
 
     if (isAvailable() != beforeRemovingAvailable) {
         // emit another event that this list became un-available!
-        s_GameEvent event {
+        const s_GameEvent event {
             .eventType = eGameEventType::GAME_EVENT_LIST_BECAME_UNAVAILABLE,
-            .entityType = eBuildType::UNIT, // BOGUS
-            .entityID = -1,
-            .player = this->m_itemBuilder->getPlayer(),
-            .entitySpecificType = -1, // BOGUS
-            .atCell = -1,
-            .isReinforce = false,
-            .buildingList = this
+            .data = BuildingEvent {
+                .entityType = eBuildType::UNIT,
+                .player = this->m_itemBuilder->getPlayer(),
+                .entitySpecificType = -1,
+                .buildingList = this
+            }
         };
-
         game.onNotifyGameEvent(event);
     }
     return true;

--- a/src/sidebar/cSideBar.cpp
+++ b/src/sidebar/cSideBar.cpp
@@ -273,14 +273,15 @@ void cSideBar::cancelBuildingListItem(cBuildingListItem *item)
             item->resetProgress();
 
             // notify game that the item just has been cancelled, just before the actual removal
-            s_GameEvent event {
+            const s_GameEvent event {
                 .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_CANCELLED,
-                .entityType = item->getBuildType(),
-                .player = m_player,
-                .entitySpecificType = item->getBuildId(),
-                .buildingListItem = item
+                .data = BuildingEvent {
+                    .entityType = item->getBuildType(),
+                    .player = m_player,
+                    .entitySpecificType = item->getBuildId(),
+                    .buildingListItem = item
+                }
             };
-
             game.onNotifyGameEvent(event);
             // else, only the number is decreased (used for queueing)
 
@@ -323,48 +324,49 @@ void cSideBar::onNotify(const s_GameEvent &event)
     if (event.player != nullptr && event.player != m_player) {
         return;
     }
-
-    // for us, or for no player in particular
-    switch(event.eventType) {
-        case eGameEventType::GAME_EVENT_SPECIAL_SELECT_TARGET:
-            onSpecialReadyToDeployEvent(event);
-            break;
-        case eGameEventType::GAME_EVENT_LIST_ITEM_PLACE_IT:
-            onListItemReadyToPlaceEvent(event);
-            break;
-        case eGameEventType::GAME_EVENT_LIST_BECAME_AVAILABLE:
-            onListBecameAvailableEvent(event);
-            break;
-        case eGameEventType::GAME_EVENT_LIST_BECAME_UNAVAILABLE:
-            onListBecameUnavailableEvent(event);
-            break;
-        case eGameEventType::GAME_EVENT_ABOUT_TO_BEGIN:
-            findFirstActiveListAndSelectIt();
-            break;
-        default:
-            break;
+    if (const auto *buildEvent = std::get_if<BuildingEvent>(&event.data)) {
+        // for us, or for no player in particular
+        switch(event.eventType) {
+            case eGameEventType::GAME_EVENT_SPECIAL_SELECT_TARGET:
+                onSpecialReadyToDeployEvent(buildEvent);
+                break;
+            case eGameEventType::GAME_EVENT_LIST_ITEM_PLACE_IT:
+                onListItemReadyToPlaceEvent(buildEvent);
+                break;
+            case eGameEventType::GAME_EVENT_LIST_BECAME_AVAILABLE:
+                onListBecameAvailableEvent(buildEvent);
+                break;
+            case eGameEventType::GAME_EVENT_LIST_BECAME_UNAVAILABLE:
+                onListBecameUnavailableEvent(buildEvent);
+                break;
+            case eGameEventType::GAME_EVENT_ABOUT_TO_BEGIN:
+                findFirstActiveListAndSelectIt();
+                break;
+            default:
+                break;
+        }
     }
 }
 
-void cSideBar::onListItemReadyToPlaceEvent(const s_GameEvent &event) const
+void cSideBar::onListItemReadyToPlaceEvent(const BuildingEvent *event) const
 {
-    event.buildingListItem->getList()->startFlashing();
+    event->buildingListItem->getList()->startFlashing();
 }
 
-void cSideBar::onSpecialReadyToDeployEvent(const s_GameEvent &event) const
+void cSideBar::onSpecialReadyToDeployEvent(const BuildingEvent *event) const
 {
-    event.buildingListItem->getList()->startFlashing();
+    event->buildingListItem->getList()->startFlashing();
 }
 
-void cSideBar::onListBecameAvailableEvent(const s_GameEvent &event)
+void cSideBar::onListBecameAvailableEvent(const BuildingEvent *event)
 {
-    event.buildingList->startFlashing();
+    event->buildingList->startFlashing();
 }
 
-void cSideBar::onListBecameUnavailableEvent(const s_GameEvent &event)
+void cSideBar::onListBecameUnavailableEvent(const BuildingEvent *event)
 {
     cBuildingList *pList = getSelectedList();
-    if (pList == event.buildingList) {
+    if (pList == event->buildingList) {
         findFirstActiveListAndSelectIt();
     }
 }

--- a/src/sidebar/cSideBar.cpp
+++ b/src/sidebar/cSideBar.cpp
@@ -276,11 +276,8 @@ void cSideBar::cancelBuildingListItem(cBuildingListItem *item)
             s_GameEvent event {
                 .eventType = eGameEventType::GAME_EVENT_LIST_ITEM_CANCELLED,
                 .entityType = item->getBuildType(),
-                .entityID = -1,
                 .player = m_player,
                 .entitySpecificType = item->getBuildId(),
-                .atCell = -1,
-                .isReinforce = false,
                 .buildingListItem = item
             };
 

--- a/src/sidebar/cSideBar.h
+++ b/src/sidebar/cSideBar.h
@@ -124,11 +124,11 @@ private:
 
     cBuildingList *getSelectedList() const;
 
-    void onListBecameUnavailableEvent(const s_GameEvent &event);
+    void onListBecameUnavailableEvent(const BuildingEvent *event);
 
-    void onListBecameAvailableEvent(const s_GameEvent &event);
+    void onListBecameAvailableEvent(const BuildingEvent *event);
 
-    void onSpecialReadyToDeployEvent(const s_GameEvent &event) const;
+    void onSpecialReadyToDeployEvent(const BuildingEvent *event) const;
 
-    void onListItemReadyToPlaceEvent(const s_GameEvent &event) const;
+    void onListItemReadyToPlaceEvent(const BuildingEvent *event) const;
 };


### PR DESCRIPTION
## **Goal**

Next step of the process of splitting `sGameEvent` to use only the `std::variant data`


## Reviewer, be careful  !!
- This PR was difficult to write because it was long and sometimes too mechanical.
- If everything compiles, an incorrect branch will delete the event.