### PR TITLE
Show move cursor when hovering minimap with units selected

### DIFF
--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -209,17 +209,18 @@ void cMiniMapDrawer::onNotifyMouseEvent(const s_MouseEvent &event)
             return;
         case eMouseEventType::MOUSE_LEFT_BUTTON_CLICKED:
             onMouseClickedLeft(event);
-            return;
+            break;
         case eMouseEventType::MOUSE_LEFT_BUTTON_PRESSED:
             onMousePressedLeft(event);
-            return;
+            break;
         case eMouseEventType::MOUSE_RIGHT_BUTTON_PRESSED:
             onMousePressedRight(event);
-            return;
+            break;
         default:
             return;
     }
 
+    updateMouseCursor();
 }
 
 void cMiniMapDrawer::drawTerrain()
@@ -391,6 +392,19 @@ int cMiniMapDrawer::getMapWidthInPixels() const {
 void cMiniMapDrawer::onMouseAt(const s_MouseEvent &event)
 {
     m_isMouseOver = m_RectMinimap.isPointWithin(event.coords.x, event.coords.y);
+    updateMouseCursor();
+}
+
+void cMiniMapDrawer::updateMouseCursor()
+{
+    if (m_isMouseOver &&
+        m_status != NOTAVAILABLE) {
+        if (m_player->hasAnyUnitSelected()) {
+            game.getMouse()->setTile(MOUSE_MOVE);
+        } else {
+            game.getMouse()->setTile(MOUSE_NORMAL);
+        }
+    }
 }
 
 void cMiniMapDrawer::onMouseClickedLeft(const s_MouseEvent &event) {

--- a/src/drawers/cMiniMapDrawer.h
+++ b/src/drawers/cMiniMapDrawer.h
@@ -68,6 +68,7 @@ private:
     void onMousePressedLeft(const s_MouseEvent &event);
     void onMousePressedRight(const s_MouseEvent &event);
     void onMouseClickedLeft(const s_MouseEvent &event);
+    void updateMouseCursor();
     void cleanDrawTerrain() const;
     int getMouseCell(int mouseX, int mouseY);
 


### PR DESCRIPTION
## Summary

- When the mouse hovers over the minimap and units are selected, the cursor changes to the move icon to indicate units will be sent there on click
- When no units are selected, the normal cursor is shown
- Cursor is re-asserted after click/press events to prevent the mouse state machine from overwriting it

## How it works

`cMiniMapDrawer::updateMouseCursor()` centralises the cursor logic. It is called from `onMouseAt` (hover) and also at the end of `onNotifyMouseEvent` for click/press events. This is necessary because `cMouseUnitsSelectedState` calls `setTile()` before the minimap drawer runs in the observer chain, so the minimap must re-assert the cursor last.

## Testing Steps

1. Select one or more units
2. Hover the mouse over the minimap — cursor should change to the move icon
3. Click to move units — cursor should remain the move icon (not revert to normal)
4. Deselect all units, hover over minimap — cursor should show the normal pointer

Closes #1004

<img width="206" height="204" alt="image" src="https://github.com/user-attachments/assets/1cb696b8-f326-44f2-9267-77d4cf193c44" />
