### PR TITLE
Play acknowledgement sound when ordering units to move via minimap

### DIFF
--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -25,6 +25,7 @@
 
 #include "data/gfxaudio.h"
 #include "gameobjects/particles/cParticle.h"
+#include "utils/RNG.hpp"
 
 cMiniMapDrawer::cMiniMapDrawer(GameContext *ctx, cMap *map, cPlayer *player, cMapCamera *mapCamera) :
     m_isMouseOver(false),
@@ -421,6 +422,14 @@ void cMiniMapDrawer::onMouseClickedLeft(const s_MouseEvent &event) {
 
             auto absPoint = m_map->getGeometry().getAbsolutePositionFromCell(mouseCellOnMinimap);
             cParticle::create(absPoint.x, absPoint.y, D2TM_PARTICLE_MOVE, -1, -1);
+
+            sSelectedUnitTypes selectedUnitTypes = m_player->getSelectedUnitTypes();
+            if (selectedUnitTypes.hasInfantry) {
+                game.playSound(SOUND_MOVINGOUT + RNG::rnd(2));
+            }
+            if (selectedUnitTypes.hasVehicles) {
+                game.playSound(SOUND_ACKNOWLEDGED + RNG::rnd(3));
+            }
         }
     }
 }

--- a/src/player/cPlayer.cpp
+++ b/src/player/cPlayer.cpp
@@ -1675,6 +1675,24 @@ bool cPlayer::hasAnyUnitSelected() {
     return false;
 }
 
+sSelectedUnitTypes cPlayer::getSelectedUnitTypes() const
+{
+    sSelectedUnitTypes result;
+    for (size_t i = 0; i < m_objects->getUnitsSize(); i++) {
+        if (result.hasInfantry && result.hasVehicles) break;
+        cUnit *pUnit = m_objects->getUnit(i);
+        if (!pUnit || !pUnit->isValid()) continue;
+        if (!pUnit->belongsTo(this)) continue;
+        if (!pUnit->isSelected()) continue;
+        if (pUnit->isInfantryUnit()) {
+            result.hasInfantry = true;
+        } else {
+            result.hasVehicles = true;
+        }
+    }
+    return result;
+}
+
 bool cPlayer::hasEnoughPowerFor(int structureType) const
 {
     assert(structureType > -1 && "hasEnoughPowerFor called with structureType < 0!");

--- a/src/player/cPlayer.h
+++ b/src/player/cPlayer.h
@@ -74,6 +74,11 @@ struct s_PlaceResult {
     std::set<int> structureIds = std::set<int>();
 };
 
+struct sSelectedUnitTypes {
+    bool hasInfantry = false;
+    bool hasVehicles = false;
+};
+
 struct sGameServices;
 class cGameSettings;
 class cInfoContext;
@@ -444,6 +449,7 @@ public:
     int getSpecialUnitType();
 
     bool hasAnyUnitSelected();
+    sSelectedUnitTypes getSelectedUnitTypes() const;
 
     static std::string getHouseNameForId(int house);
 


### PR DESCRIPTION
## Summary

- When units are ordered to move via a minimap click, an acknowledgement sound now plays
- Infantry units: `SOUND_MOVINGOUT` (randomly varied), vehicles: `SOUND_ACKNOWLEDGED` (randomly varied)
- Introduces `sSelectedUnitTypes` struct on `cPlayer` with `hasInfantry` / `hasVehicles` fields, populated by the new `getSelectedUnitTypes()` method — the minimap drawer queries this instead of iterating units itself

## Testing Steps

1. Select infantry units and click the minimap — should hear the moving out sound
2. Select vehicle units and click the minimap — should hear the acknowledged sound
3. Select a mix — both sounds should play

Closes #1006