### PR TITLE
master / feature editor grid axes (2)

### DIFF
--- a/src/controls/cKeyBindings.cpp
+++ b/src/controls/cKeyBindings.cpp
@@ -50,7 +50,7 @@ void cKeyBindings::loadDefaults()
     bind(eKeyAction::GROUP_5, {SDL_SCANCODE_5});
 
     // Editor
-    bind(eKeyAction::EDITOR_SAVE,     {SDL_SCANCODE_S});
+    bind(eKeyAction::EDITOR_SAVE,     {SDL_SCANCODE_S}, true, false, false);
     bind(eKeyAction::EDITOR_ZOOM_IN,  {SDL_SCANCODE_PAGEUP});
     bind(eKeyAction::EDITOR_ZOOM_OUT, {SDL_SCANCODE_PAGEDOWN});
     bind(eKeyAction::EDITOR_DISPLAY_GRID, {SDL_SCANCODE_G});

--- a/src/controls/cKeyBindings.cpp
+++ b/src/controls/cKeyBindings.cpp
@@ -53,6 +53,8 @@ void cKeyBindings::loadDefaults()
     bind(eKeyAction::EDITOR_SAVE,     {SDL_SCANCODE_S});
     bind(eKeyAction::EDITOR_ZOOM_IN,  {SDL_SCANCODE_PAGEUP});
     bind(eKeyAction::EDITOR_ZOOM_OUT, {SDL_SCANCODE_PAGEDOWN});
+    bind(eKeyAction::EDITOR_DISPLAY_GRID, {SDL_SCANCODE_G});
+    bind(eKeyAction::EDITOR_DISPLAY_AXES, {SDL_SCANCODE_A});
 
     // UI / menus
     bind(eKeyAction::MENU_BACK,    {SDL_SCANCODE_ESCAPE});
@@ -115,6 +117,8 @@ void cKeyBindings::loadFromSection(const cSection &section)
         {"EDITOR_SAVE",               eKeyAction::EDITOR_SAVE},
         {"EDITOR_ZOOM_IN",            eKeyAction::EDITOR_ZOOM_IN},
         {"EDITOR_ZOOM_OUT",           eKeyAction::EDITOR_ZOOM_OUT},
+        {"EDITOR_DISPLAY_GRID",       eKeyAction::EDITOR_DISPLAY_GRID},
+        {"EDITOR_DISPLAY_AXES",       eKeyAction::EDITOR_DISPLAY_AXES},
         {"MENU_BACK",                 eKeyAction::MENU_BACK},
         {"MENU_CONFIRM",              eKeyAction::MENU_CONFIRM},
         {"MENU_CANCEL",               eKeyAction::MENU_CANCEL},

--- a/src/controls/eKeyAction.h
+++ b/src/controls/eKeyAction.h
@@ -41,6 +41,8 @@ enum class eKeyAction {
     EDITOR_SAVE,
     EDITOR_ZOOM_IN,
     EDITOR_ZOOM_OUT,
+    EDITOR_DISPLAY_GRID,
+    EDITOR_DISPLAY_AXES,
     // UI / menus
     MENU_BACK,
     MENU_CONFIRM,

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -21,6 +21,7 @@ const int minTileSize = 4;
 const int maxTileSize = 64;
 const int deltaTileSize = 4;
 const Color editorGridColor = Color{128, 128, 128, 180};
+const Color editorCenterLineColor = Color{32, 176, 32, 220};
 
 
 cEditorState::cEditorState(sGameServices* services) 
@@ -297,6 +298,7 @@ void cEditorState::draw() const
 {
     drawMap();
     drawGrid();
+    drawAxes();
     if (m_currentBar == m_startCellBar.get())
         drawStartCells();
     m_selectBar->draw();
@@ -579,6 +581,41 @@ void cEditorState::drawGrid() const
     }
 }
 
+void cEditorState::drawAxes() const
+{
+    if (m_mapData == nullptr) {
+        return;
+    }
+
+    const int viewportTop = heightBarSize;
+    const int viewportBottom = heightBarSize + mapSizeArea.getHeight() - 1;
+    const int viewportLeft = 0;
+    
+    const int mapLeftOnScreen = -cameraX;
+    const int mapRightOnScreen = static_cast<int>(m_mapData->getCols() * tileLenSize) - cameraX;
+    const int mapTopOnScreen = heightBarSize - cameraY;
+    const int mapBottomOnScreen = heightBarSize + static_cast<int>(m_mapData->getRows() * tileLenSize) - cameraY;
+
+    const int viewportRight = mapSizeArea.getWidth() - 1;
+    const int gridLeft = std::max(viewportLeft, mapLeftOnScreen);
+    const int gridRight = std::min(viewportRight, mapRightOnScreen);
+    const int gridTop = std::max(viewportTop, mapTopOnScreen);
+    const int gridBottom = std::min(viewportBottom, mapBottomOnScreen);
+
+    if (gridLeft > gridRight || gridTop > gridBottom) {
+        return;
+    }
+
+    const int middleX = (static_cast<int>(m_mapData->getCols()) * tileLenSize) / 2 - cameraX;
+    if (middleX >= gridLeft && middleX <= gridRight) {
+        m_renderDrawer->renderLine(middleX, gridTop, middleX, gridBottom, editorCenterLineColor);
+    }
+
+    const int middleY = heightBarSize + (static_cast<int>(m_mapData->getRows()) * tileLenSize) / 2 - cameraY;
+    if (middleY >= gridTop && middleY <= gridBottom) {
+        m_renderDrawer->renderLine(gridLeft, middleY, gridRight, middleY, editorCenterLineColor);
+    }
+}
 
 void cEditorState::updateVisibleTiles()
 {

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -747,7 +747,7 @@ static std::string normalizeStringForFileName(const std::string& input)
     std::replace(output.begin(), output.end(), ' ', '_');
     // Remove characters that are not alphanumeric or underscores
     output.erase(std::remove_if(output.begin(), output.end(),
-        [](char c) { return !std::isalnum(c) && c != '_'; }), output.end());
+        [](unsigned char c) { return !std::isalnum(c) && c != '_'; }), output.end());
     if (output.empty()) {
         output = "custom_map";
     }

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -20,6 +20,7 @@ const int heightButtonSize = 40;
 const int minTileSize = 4;
 const int maxTileSize = 64;
 const int deltaTileSize = 4;
+const Color editorGridColor = Color{128, 128, 128, 180};
 
 
 cEditorState::cEditorState(sGameServices* services) 
@@ -295,6 +296,7 @@ void cEditorState::thinkFast()
 void cEditorState::draw() const
 {
     drawMap();
+    drawGrid();
     if (m_currentBar == m_startCellBar.get())
         drawStartCells();
     m_selectBar->draw();
@@ -534,6 +536,49 @@ void cEditorState::drawMap() const
         }
     }
 }
+
+void cEditorState::drawGrid() const
+{
+    if (m_mapData == nullptr) {
+        return;
+    }
+
+    const int viewportTop = heightBarSize;
+    const int viewportBottom = heightBarSize + mapSizeArea.getHeight() - 1;
+    const int viewportLeft = 0;
+    const int viewportRight = mapSizeArea.getWidth() - 1;
+
+    const int mapLeftOnScreen = -cameraX;
+    const int mapRightOnScreen = static_cast<int>(m_mapData->getCols() * tileLenSize) - cameraX;
+    const int mapTopOnScreen = heightBarSize - cameraY;
+    const int mapBottomOnScreen = heightBarSize + static_cast<int>(m_mapData->getRows() * tileLenSize) - cameraY;
+
+    const int gridLeft = std::max(viewportLeft, mapLeftOnScreen);
+    const int gridRight = std::min(viewportRight, mapRightOnScreen);
+    const int gridTop = std::max(viewportTop, mapTopOnScreen);
+    const int gridBottom = std::min(viewportBottom, mapBottomOnScreen);
+
+    if (gridLeft > gridRight || gridTop > gridBottom) {
+        return;
+    }
+
+    for (int i = startX; i <= static_cast<int>(endX); i++) {
+        int lineX = (i * tileLenSize) - cameraX;
+        if (lineX < gridLeft || lineX > gridRight) {
+            continue;
+        }
+        m_renderDrawer->renderLine(lineX, gridTop, lineX, gridBottom, editorGridColor);
+    }
+
+    for (int j = startY; j <= static_cast<int>(endY); j++) {
+        int lineY = heightBarSize + (j * tileLenSize) - cameraY;
+        if (lineY < gridTop || lineY > gridBottom) {
+            continue;
+        }
+        m_renderDrawer->renderLine(gridLeft, lineY, gridRight, lineY, editorGridColor);
+    }
+}
+
 
 void cEditorState::updateVisibleTiles()
 {

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -750,6 +750,7 @@ static std::string normalizeStringForFileName(const std::string& input)
         [](unsigned char c) { return !std::isalnum(c) && c != '_'; }), output.end());
     if (output.empty()) {
         output = "custom_map";
+        //@mira : log warning about empty name after normalization*/
     }
     return output;
 }
@@ -762,6 +763,7 @@ void cEditorState::saveMap() const
     // file verification
     if (!saveFile.is_open()){
         std::cerr << "unable to open modified map for saving " << fileName << std::endl;
+        //@mira : log error about unable to save map*/
         return;
     }
     // map card
@@ -811,4 +813,5 @@ void cEditorState::saveMap() const
     }
 
     saveFile.close();
+    //@mira : log info about successful map saving*/
 }

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -297,8 +297,10 @@ void cEditorState::thinkFast()
 void cEditorState::draw() const
 {
     drawMap();
-    drawGrid();
-    drawAxes();
+    if (m_displayGrid)
+        drawGrid();
+    if (m_displayAxes)
+        drawAxes();
     if (m_currentBar == m_startCellBar.get())
         drawStartCells();
     m_selectBar->draw();
@@ -392,6 +394,18 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
         // to test : updateVisibleTiles();
         m_selectBar->onNotifyKeyboardEvent(event);
         m_currentBar->onNotifyKeyboardEvent(event);
+
+        if (event.isAction(eKeyAction::EDITOR_DISPLAY_GRID)) {
+            // toggle grid display
+            //std::cout << "Toggle grid display" << std::endl;
+            m_displayGrid = !m_displayGrid;
+
+        }
+        if (event.isAction(eKeyAction::EDITOR_DISPLAY_AXES)) {
+            // toggle axes display
+            //std::cout << "Toggle axes display" << std::endl;
+            m_displayAxes = !m_displayAxes;
+        }
     }
 
     if (event.isType(eKeyEventType::HOLD)) {
@@ -444,6 +458,8 @@ void cEditorState::loadMap(s_PreviewMap* map)
     }
     updateVisibleTiles();
     normalizeModifications();
+    m_displayGrid = false;
+    m_displayAxes = false;
 }
 
 void cEditorState::normalizeModifications()

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -57,6 +57,7 @@ private:
     void drawMap() const;
     void drawStartCells() const;
     void drawGrid() const;
+    void drawAxes() const;
     void modifyTile(int posX, int posY, int tileID);
     void modifyStartCell(int posX, int posY, int startCellID);
     void normalizeModifications();

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -92,6 +92,8 @@ private:
     // map modification 
     int idTerrainToMapModif = -1;
     int idStartCellPlayer = -1;
+    bool m_displayGrid = false;
+    bool m_displayAxes = false;
 
     // startCell positions 
     std::array<cPoint,5> startCells;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -56,6 +56,7 @@ private:
 
     void drawMap() const;
     void drawStartCells() const;
+    void drawGrid() const;
     void modifyTile(int posX, int posY, int tileID);
     void modifyStartCell(int posX, int posY, int startCellID);
     void normalizeModifications();


### PR DESCRIPTION
## **Goal**

MapEditor can how display grid and axes

### Changes
- Add grid drawing
- Add axes drawing
- Add keys toggle drawing
- Save map is now CTRL+S

## Testing Steps
On editor press :
- G to display/mask Grid
- A to display/mask Axes

## Screenshots
<img width="1330" height="801" alt="Capture d’écran du 2026-04-27 06-43-12" src="https://github.com/user-attachments/assets/0c4df9a0-9a37-4d73-b409-0afaa276b038" />


