### PR TITLE
Allow human player to select Sardaukar in skirmish

### DIFF
--- a/src/gameobjects/particles/cParticle.cpp
+++ b/src/gameobjects/particles/cParticle.cpp
@@ -116,6 +116,11 @@ void cParticle::think_position()
 // draw
 void cParticle::draw()
 {
+    if (bmp == nullptr) {
+        logbook(std::format("cParticle::draw() - bmp is null for particle type [{}], iHousePal [{}], iAlpha [{}]", iType, iHousePal, iAlpha));
+        return;
+    }
+
     s_ParticleInfo particleInfo = getParticleInfo();
     int frameWidth = getFrameWidth();
     int frameHeight = getFrameHeight();
@@ -855,6 +860,9 @@ void cParticle::recolorForHouseIfGiven() {
         bmp = recoloredBmp;
         particleTextureCache[cacheKey] = recoloredBmp;
     } else {
-        bmp = gfxdata->getTexture(bmpIndex);
+        Texture* fallback = gfxdata->getTexture(bmpIndex);
+        if (fallback != nullptr) {
+            bmp = fallback;
+        }
     }
 }

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -264,15 +264,14 @@ void cUnit::createSquishedParticle()
 {
     int iDieX = pos_x_centered();
     int iDieY = pos_y_centered();
-    int iHouse = getPlayer()->getHouse();
     // when we do not 'blow up', we died by something else. Only infantry will be 'squished' here now.
     if (iType == SOLDIER || iType == TROOPER || iType == UNIT_FREMEN_ONE) {
         int iType1 = D2TM_PARTICLE_SQUISH01 + RNG::rnd(2);
-        cParticle::create(iDieX, iDieY, iType1, iHouse, rendering.iFrame);
+        cParticle::create(iDieX, iDieY, iType1, iPlayer, rendering.iFrame);
         m_interface->playSoundWithDistance(SOUND_SQUISH, distanceBetweenCellAndCenterOfScreen(position.iCell));
     }
     else if (iType == TROOPERS || iType == INFANTRY || iType == UNIT_FREMEN_THREE) {
-        cParticle::create(iDieX, iDieY, D2TM_PARTICLE_SQUISH03, iHouse, rendering.iFrame);
+        cParticle::create(iDieX, iDieY, D2TM_PARTICLE_SQUISH03, iPlayer, rendering.iFrame);
         m_interface->playSoundWithDistance(SOUND_SQUISH, distanceBetweenCellAndCenterOfScreen(position.iCell));
     }
 }

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -645,13 +645,7 @@ void cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState(in
                 bool bOk = false;
 
                 while (bOk == false) {
-                    if (p > HUMAN) {
-                        iHouse = RNG::rnd(4) + 1;
-                        // cpu player
-                    }
-                    else {  // human may not be sardaukar
-                        iHouse = RNG::rnd(3) + 1; // hark = 1, atr = 2, ord = 3, sar = 4
-                    }
+                    iHouse = RNG::rnd(4) + 1; // hark = 1, atr = 2, ord = 3, sar = 4
 
                     bool houseInUse = false;
                     for (int pl = 0; pl < AI_WORM; pl++) {
@@ -926,15 +920,8 @@ void cSetupSkirmishState::onMouseRightButtonClickedAtPlayerList()  // draw playe
             // on click:
             if (houseRec.isPointWithin(m_mouse->getX(), m_mouse->getY())) {
                 sSkirmishPlayer.iHouse--;
-                if (p > 0) {
-                    if (sSkirmishPlayer.iHouse < 0) {
-                        sSkirmishPlayer.iHouse = SARDAUKAR;
-                    }
-                }
-                else {
-                    if (sSkirmishPlayer.iHouse < 0) {
-                        sSkirmishPlayer.iHouse = ORDOS;
-                    }
+                if (sSkirmishPlayer.iHouse < 0) {
+                    sSkirmishPlayer.iHouse = SARDAUKAR;
                 }
             }
 
@@ -1024,17 +1011,8 @@ void cSetupSkirmishState::onMouseLeftButtonClickedAtPlayerList()
             // on click:
             if (houseRec.isPointWithin(m_mouse->getX(), m_mouse->getY())) {
                 sSkirmishPlayer.iHouse++;
-
-                // Only human player can be Sardaukar?
-                if (p > 0) {
-                    if (sSkirmishPlayer.iHouse > SARDAUKAR) {
-                        sSkirmishPlayer.iHouse = 0;
-                    }
-                }
-                else {
-                    if (sSkirmishPlayer.iHouse > ORDOS) {
-                        sSkirmishPlayer.iHouse = 0;
-                    }
+                if (sSkirmishPlayer.iHouse > SARDAUKAR) {
+                    sSkirmishPlayer.iHouse = 0;
                 }
             }
 

--- a/src/player/cPlayerDifficultySettings.h
+++ b/src/player/cPlayerDifficultySettings.h
@@ -9,7 +9,7 @@
 
 /**
  * This class holds properties for a player which have overall influence on the
- * player performance. Typically these are characterized as house properties. For instance:
+ * player performance. Typically, these are characterized as house properties. For instance:
  * - overall harvesting speed
  * - overall move speed of units
  * - overall damage inflicted

--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -181,7 +181,7 @@ void cBuildingListUpdater::onStructureCreatedCampaignMode(int structureType) con
             list->addUnitToList(SIEGETANK, 0);
         }
 
-        if (techLevel > 7 && (house != HARKONNEN && house != SARDAUKAR)) {
+        if (techLevel > 7 && (house != HARKONNEN)) {
             list->addUnitToList(ORNITHOPTER, 0);
         }
     }

--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -266,7 +266,7 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
             list->addUnitToList(SIEGETANK, 0);
         }
 
-        if (techLevel > 7 && (house != HARKONNEN && house != SARDAUKAR)) {
+        if (techLevel > 7 && house != HARKONNEN) {
             list->addUnitToList(ORNITHOPTER, 0);
         }
 
@@ -345,7 +345,6 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
         }
         else {
             listUnits->addUnitToList(TRIKE, SUBLIST_LIGHTFCTRY);
-            listUnits->addUnitToList(RAIDER, SUBLIST_LIGHTFCTRY);
             listUnits->addUnitToList(QUAD, SUBLIST_LIGHTFCTRY);
         }
     }
@@ -373,7 +372,8 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
     // Heavyfactory
     if (techLevel >= 7) {
         if (m_player->hasAtleastOneStructure(HEAVYFACTORY) &&
-                m_player->hasAtleastOneStructure(IX)) {
+            m_player->hasAtleastOneStructure(IX)) {
+
             if (m_player->getHouse() == ATREIDES) {
                 listUnits->addUnitToList(SONICTANK, SUBLIST_HEAVYFCTRY);
             }
@@ -381,6 +381,10 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
                 listUnits->addUnitToList(DEVASTATOR, SUBLIST_HEAVYFCTRY);
             }
             else if (m_player->getHouse() == ORDOS) {
+                listUnits->addUnitToList(DEVIATOR, SUBLIST_HEAVYFCTRY);
+            } else if (m_player->getHouse() == SARDAUKAR) {
+                listUnits->addUnitToList(SONICTANK, SUBLIST_HEAVYFCTRY);
+                listUnits->addUnitToList(DEVASTATOR, SUBLIST_HEAVYFCTRY);
                 listUnits->addUnitToList(DEVIATOR, SUBLIST_HEAVYFCTRY);
             }
         }
@@ -392,6 +396,10 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
                 listUnits->removeItemFromListByBuildId(DEVASTATOR);
             }
             else if (m_player->getHouse() == ORDOS) {
+                listUnits->removeItemFromListByBuildId(DEVIATOR);
+            } else if (m_player->getHouse() == SARDAUKAR) {
+                listUnits->removeItemFromListByBuildId(SONICTANK);
+                listUnits->removeItemFromListByBuildId(DEVASTATOR);
                 listUnits->removeItemFromListByBuildId(DEVIATOR);
             }
         }


### PR DESCRIPTION
## Summary

- Human player can now cycle to and be randomly assigned Sardaukar as a faction in skirmish setup
- Removes the three code locations that blocked the human player from selecting SARDAUKAR (increment cap, decrement wrap, and random assignment)
- Fixes a particle crash that occurred when a Sardaukar unit died: `cParticle::draw()` now guards against a null `bmp` with a logbook entry instead of crashing SDL
- Fixes particle recolor for Sardaukar: `createSquishedParticle()` was passing the house ID (4) as the player index, causing `recolorForHouseIfGiven()` to look up AI_CPU4 instead of the actual owning player — now passes `iPlayer` instead
- Fixes `recolorForHouseIfGiven()` fallback: only replaces `bmp` with the `getTexture()` fallback when it is non-null, so a valid texture set by `init()` is never overwritten with null

## Test plan

- [ ] Start a skirmish, click the house selector for Player 1 (human) and verify Sardaukar appears when cycling through factions (left and right click)
- [ ] Set Player 1 house to Random and start a match several times — confirm Sardaukar occasionally gets assigned
- [ ] Play a game as Sardaukar until infantry units die — verify no crash and squish particles appear in the correct colour
- [ ] Verify the logbook does not contain "bmp is null" entries during normal gameplay

Closes #137