### PR TITLE
feedback / Highlighting - selection size on MapEditor

### DIFF
--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -826,10 +826,12 @@ void cEditorState::modifyTile(int posX, int posY, int tileID)
     int brushEndTileX = 0;
     int brushEndTileY = 0;
     getBrushTileBounds(tileX, tileY, brushStartTileX, brushStartTileY, brushEndTileX, brushEndTileY);
-    m_hasChanged = true;
     for (int brushTileY = brushStartTileY; brushTileY <= brushEndTileY; brushTileY++) {
         for (int brushTileX = brushStartTileX; brushTileX <= brushEndTileX; brushTileX++) {
-            (*m_mapData)[brushTileY][brushTileX] = tileID;
+            if ((*m_mapData)[brushTileY][brushTileX] != tileID) {
+                (*m_mapData)[brushTileY][brushTileX] = tileID;
+                m_hasChanged = true;
+            }
         }
     }
 }
@@ -843,6 +845,7 @@ void cEditorState::modifyStartCell(int posX, int posY, int startCellID)
     int tileY = (cameraY + posY) / tileLenSize;
     if (m_mapData && tileX >= 1 && tileY >= 1 && tileX < (int)m_mapData->getCols()-1 && tileY < (int)m_mapData->getRows()-1) {
         startCells[startCellID]={tileX, tileY};
+        m_hasChanged = true;
     }
 }
 
@@ -879,6 +882,7 @@ void cEditorState::modifySymmetricArea(Direction dir)
             }
             break;
     }
+    m_hasChanged = true;
 }
 
 void cEditorState::drawStartCells() const

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -4,8 +4,10 @@
 #include "gui/GuiStateButton.h"
 #include "gui/GuiButton.h"
 #include "gui/GuiButtonGroup.h"
+#include "gui/GuiValueButton.h"
 #include "data/gfxdata.h"
 #include "drawers/SDLDrawer.hpp"
+#include "drawers/cTextDrawer.h"
 #include "utils/Graphics.hpp"
 #include "context/GameContext.hpp"
 #include "game/cGameInterface.h"
@@ -35,12 +37,14 @@ cEditorState::cEditorState(sGameServices* services)
     m_gfxdata(m_ctx->getGraphicsContext()->gfxdata.get()),
     m_gfxeditor(m_ctx->getGraphicsContext()->gfxeditor.get()),
     m_settings(services->settings),
-    m_interface(m_ctx->getGameInterface())
+    m_interface(m_ctx->getGameInterface()),
+    m_textDrawer(m_ctx->getTextContext()->getBeneTextDrawer())
 {
     assert(m_gfxdata != nullptr);
     assert(m_gfxeditor != nullptr);
     assert(m_settings != nullptr);
     assert(m_interface != nullptr);
+    assert(m_textDrawer != nullptr);
 
     const cRectangle &selectRect = cRectangle(0, 0, m_settings->getScreenW(), heightBarSize);
     const cRectangle &modifRect = cRectangle(m_settings->getScreenW()-heightBarSize, heightBarSize, heightBarSize, m_settings->getScreenH()-heightBarSize);
@@ -194,6 +198,22 @@ void cEditorState::populateTopologyBar()
             .build();
     guiButton->setGroup(m_topologyGroup.get());
     m_topologyBar->addAutoGuiObject(std::move(guiButton));
+
+    auto cursorSizeButton = GuiValueButtonBuilder()
+        .withRect(cRectangle(0, 0, heightButtonSize, heightButtonSize))
+        .withRenderer(m_renderDrawer)
+        .withTextDrawer(m_textDrawer)
+        .withTheme(cGuiThemeBuilder().light().build())
+        .withLabel("size")
+            .withInitialValue(m_topologyCursorSizeSentinel)
+        .withStepValue(2)
+        .withMinValue(1)
+        .withMaxValue(11)
+        .onChanged([this](int value) {
+        setCursorSize(value);
+        })
+        .build();
+    m_topologyBar->addAutoGuiObject(std::move(cursorSizeButton));
 }
 
 void cEditorState::populateStartCellBar()

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -124,7 +124,7 @@ void cEditorState::populateSelectBar()
             .withKind(GuiRenderKind::WITH_STRETCHED_TEXTURE)
             .onClick([this]() {
                 saveMap();
-                hasChanged = false;
+                m_hasChanged = false;
             })
             .build();
     m_selectBar->addGuiObject(std::move(guiIcon));
@@ -420,16 +420,16 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
     }
     if (event.isType(eKeyEventType::PRESSED)) {
         if (event.isAction(eKeyAction::MENU_BACK)) {
-            if (hasChanged) {
+            if (m_hasChanged) {
                 saveMap(true);
-                hasChanged = false;
+                m_hasChanged = false;
             }
             m_interface->setTransitionToWithFadingOut(GAME_MENU);
         }
         if (event.isAction(eKeyAction::EDITOR_SAVE)) {
             //std::cout << "Save" << std::endl;
             saveMap();
-            hasChanged = false;
+            m_hasChanged = false;
         }
         if (event.isAction(eKeyAction::EDITOR_ZOOM_IN)) {
             zoomAtMapPosition(m_settings->getScreenW()/2, m_settings->getScreenH()/2, ZoomDirection::zoomIn);
@@ -826,7 +826,7 @@ void cEditorState::modifyTile(int posX, int posY, int tileID)
     int brushEndTileX = 0;
     int brushEndTileY = 0;
     getBrushTileBounds(tileX, tileY, brushStartTileX, brushStartTileY, brushEndTileX, brushEndTileY);
-    hasChanged = true;
+    m_hasChanged = true;
     for (int brushTileY = brushStartTileY; brushTileY <= brushEndTileY; brushTileY++) {
         for (int brushTileX = brushStartTileX; brushTileX <= brushEndTileX; brushTileX++) {
             (*m_mapData)[brushTileY][brushTileX] = tileID;

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -207,7 +207,7 @@ void cEditorState::populateTopologyBar()
         .withTextDrawer(m_textDrawer)
         .withTheme(cGuiThemeBuilder().light().build())
         .withLabel("size")
-            .withInitialValue(m_topologyCursorSizeSentinel)
+            .withInitialValue(m_topologyCursorSize)
         .withStepValue(2)
         .withMinValue(1)
         .withMaxValue(maxPenSize)
@@ -522,7 +522,7 @@ void cEditorState::setCursorSize(int value)
         normalizedValue -= 1;
     }
 
-    m_topologyCursorSizeSentinel = normalizedValue;
+    m_topologyCursorSize = normalizedValue;
     m_cursorSize = getActiveCursorSize();
 }
 
@@ -535,7 +535,7 @@ void cEditorState::setCurrentBar(GuiBar* bar)
 int cEditorState::getActiveCursorSize() const
 {
     if (m_currentBar == m_topologyBar.get()) {
-        return m_topologyCursorSizeSentinel;
+        return m_topologyCursorSize;
     }
 
     return 1;

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -633,10 +633,22 @@ void cEditorState::drawHoveredCellHighlight() const
         return;
     }
 
-    const int cellScreenX = tileX * tileLenSize - cameraX;
-    const int cellScreenY = heightBarSize + tileY * tileLenSize - cameraY;
+    int highlightStartTileX = 0;
+    int highlightStartTileY = 0;
+    int highlightEndTileX = 0;
+    int highlightEndTileY = 0;
+    getBrushTileBounds(tileX, tileY, highlightStartTileX, highlightStartTileY, highlightEndTileX, highlightEndTileY);
 
-    cRectangle cellRect(cellScreenX, cellScreenY, tileLenSize, tileLenSize);
+    if (highlightStartTileX > highlightEndTileX || highlightStartTileY > highlightEndTileY) {
+        return;
+    }
+
+    const int cellScreenX = highlightStartTileX * tileLenSize - cameraX;
+    const int cellScreenY = heightBarSize + highlightStartTileY * tileLenSize - cameraY;
+    const int highlightWidth = (highlightEndTileX - highlightStartTileX + 1) * tileLenSize;
+    const int highlightHeight = (highlightEndTileY - highlightStartTileY + 1) * tileLenSize;
+
+    cRectangle cellRect(cellScreenX, cellScreenY, highlightWidth, highlightHeight);
     m_renderDrawer->renderRectFillColor(cellRect, editorHoveredCellFillColor, editorHoveredCellFillColor.a);
     m_renderDrawer->renderRectColor(cellRect, editorHoveredCellBorderColor, editorHoveredCellBorderColor.a);
 }
@@ -649,6 +661,16 @@ int cEditorState::getNormalizedCursorSize() const
     }
 
     return cursorSize;
+}
+
+void cEditorState::getBrushTileBounds(int centerTileX, int centerTileY, int &brushStartTileX, int &brushStartTileY, int &brushEndTileX, int &brushEndTileY) const
+{
+    const int cursorRadius = getNormalizedCursorSize() / 2;
+
+    brushStartTileX = std::max(1, centerTileX - cursorRadius);
+    brushStartTileY = std::max(1, centerTileY - cursorRadius);
+    brushEndTileX = std::min(static_cast<int>(m_mapData->getCols()) - 2, centerTileX + cursorRadius);
+    brushEndTileY = std::min(static_cast<int>(m_mapData->getRows()) - 2, centerTileY + cursorRadius);
 }
 
 void cEditorState::drawGrid() const
@@ -764,10 +786,24 @@ void cEditorState::modifyTile(int posX, int posY, int tileID)
     if (tileID == -1) {
         return;
     }
+
     int tileX = (cameraX + posX) / tileLenSize;
     int tileY = (cameraY + posY) / tileLenSize;
-    if (m_mapData && tileX >= 1 && tileY >= 1 && tileX < (int)m_mapData->getCols()-1 && tileY < (int)m_mapData->getRows()-1) {
-        (*m_mapData)[tileY][tileX] = tileID;
+
+    if (m_mapData == nullptr || tileX < 1 || tileY < 1 || tileX >= static_cast<int>(m_mapData->getCols()) - 1 || tileY >= static_cast<int>(m_mapData->getRows()) - 1) {
+        return;
+    }
+
+    int brushStartTileX = 0;
+    int brushStartTileY = 0;
+    int brushEndTileX = 0;
+    int brushEndTileY = 0;
+    getBrushTileBounds(tileX, tileY, brushStartTileX, brushStartTileY, brushEndTileX, brushEndTileY);
+
+    for (int brushTileY = brushStartTileY; brushTileY <= brushEndTileY; brushTileY++) {
+        for (int brushTileX = brushStartTileX; brushTileX <= brushEndTileX; brushTileX++) {
+            (*m_mapData)[brushTileY][brushTileX] = tileID;
+        }
     }
 }
 

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -26,6 +26,7 @@ const int heightButtonSize = 40;
 const int minTileSize = 4;
 const int maxTileSize = 64;
 const int deltaTileSize = 4;
+const int maxPenSize = 11; // must be odd to have a center
 const Color editorGridColor = Color{128, 128, 128, 180};
 const Color editorCenterLineColor = Color{32, 176, 32, 220};
 const Color editorHoveredCellFillColor = Color{255, 230, 64, 96};
@@ -208,7 +209,7 @@ void cEditorState::populateTopologyBar()
             .withInitialValue(m_topologyCursorSizeSentinel)
         .withStepValue(2)
         .withMinValue(1)
-        .withMaxValue(11)
+        .withMaxValue(maxPenSize)
         .onChanged([this](int value) {
         setCursorSize(value);
         })
@@ -510,7 +511,7 @@ void cEditorState::setCursorSize(int value)
         normalizedValue += 1;
     }
 
-    normalizedValue = std::min(normalizedValue, 7);
+    normalizedValue = std::min(normalizedValue, maxPenSize);
     if (normalizedValue % 2 == 0) {
         normalizedValue -= 1;
     }

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -63,6 +63,7 @@ cEditorState::cEditorState(sGameServices* services)
     populateTopologyBar();
     populateStartCellBar();
     populateSymmetricBar();
+    setCurrentBar(m_topologyBar.get());
     startCells.fill({-1, -1});
 }
 
@@ -80,7 +81,7 @@ void cEditorState::populateSelectBar()
             .withTexture(m_gfxeditor->getTexture(STONELAYER))
             .withRenderer(m_renderDrawer)
             .onClick([this]() {
-                m_currentBar = m_topologyBar.get();
+                setCurrentBar(m_topologyBar.get());
             })
             .build();
     guiButton->setGroup(m_selectGroup.get());
@@ -92,7 +93,7 @@ void cEditorState::populateSelectBar()
             .withTexture(m_gfxeditor->getTexture(STARTPOSITION))
             .withRenderer(m_renderDrawer)
             .onClick([this]() {
-                m_currentBar = m_startCellBar.get();
+                setCurrentBar(m_startCellBar.get());
             })
             .build();
     guiButton->setGroup(m_selectGroup.get());
@@ -103,7 +104,7 @@ void cEditorState::populateSelectBar()
             .withTexture(m_gfxeditor->getTexture(FLIPHORZ))
             .withRenderer(m_renderDrawer)
             .onClick([this]() {
-                m_currentBar = m_symmetricBar.get();
+                setCurrentBar(m_symmetricBar.get());
             })
             .build();
     guiButton->setGroup(m_selectGroup.get());
@@ -482,6 +483,37 @@ void cEditorState::loadMap(s_PreviewMap* map)
     m_displayAxes = false;
 }
 
+void cEditorState::setCursorSize(int value)
+{
+    int normalizedValue = std::max(1, value);
+    if (normalizedValue % 2 == 0) {
+        normalizedValue += 1;
+    }
+
+    normalizedValue = std::min(normalizedValue, 7);
+    if (normalizedValue % 2 == 0) {
+        normalizedValue -= 1;
+    }
+
+    m_topologyCursorSizeSentinel = normalizedValue;
+    m_cursorSize = getActiveCursorSize();
+}
+
+void cEditorState::setCurrentBar(GuiBar* bar)
+{
+    m_currentBar = bar;
+    m_cursorSize = getActiveCursorSize();
+}
+
+int cEditorState::getActiveCursorSize() const
+{
+    if (m_currentBar == m_topologyBar.get()) {
+        return m_topologyCursorSizeSentinel;
+    }
+
+    return 1;
+}
+
 void cEditorState::normalizeModifications()
 {
     for (size_t j = 0; j < m_mapData->getRows(); j++) {
@@ -607,6 +639,16 @@ void cEditorState::drawHoveredCellHighlight() const
     cRectangle cellRect(cellScreenX, cellScreenY, tileLenSize, tileLenSize);
     m_renderDrawer->renderRectFillColor(cellRect, editorHoveredCellFillColor, editorHoveredCellFillColor.a);
     m_renderDrawer->renderRectColor(cellRect, editorHoveredCellBorderColor, editorHoveredCellBorderColor.a);
+}
+
+int cEditorState::getNormalizedCursorSize() const
+{
+    int cursorSize = std::max(1, getActiveCursorSize());
+    if (cursorSize % 2 == 0) {
+        cursorSize += 1;
+    }
+
+    return cursorSize;
 }
 
 void cEditorState::drawGrid() const

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -9,6 +9,7 @@
 #include "utils/Graphics.hpp"
 #include "context/GameContext.hpp"
 #include "game/cGameInterface.h"
+#include "controls/cMouse.h"
 #include "map/cPreviewMaps.h"
 #include "data/gfxeditor.h"
 
@@ -25,6 +26,8 @@ const int maxTileSize = 64;
 const int deltaTileSize = 4;
 const Color editorGridColor = Color{128, 128, 128, 180};
 const Color editorCenterLineColor = Color{32, 176, 32, 220};
+const Color editorHoveredCellFillColor = Color{255, 230, 64, 96};
+const Color editorHoveredCellBorderColor = Color{255, 230, 64, 220};
 
 
 cEditorState::cEditorState(sGameServices* services) 
@@ -313,6 +316,7 @@ void cEditorState::thinkFast()
 void cEditorState::draw() const
 {
     drawMap();
+    drawHoveredCellHighlight();
     if (m_displayGrid)
         drawGrid();
     if (m_displayAxes)
@@ -569,6 +573,40 @@ void cEditorState::drawMap() const
             }
         }
     }
+}
+
+void cEditorState::drawHoveredCellHighlight() const
+{
+    if (m_mapData == nullptr) {
+        return;
+    }
+
+    cMouse *mouse = m_interface->getMouse();
+    if (mouse == nullptr) {
+        return;
+    }
+
+    const cPoint mouseCoords = mouse->getMouseCoords();
+    if (!mouseCoords.isWithinRectangle(&mapSizeArea)) {
+        return;
+    }
+
+    const int mouseMapX = mouseCoords.x;
+    const int mouseMapY = mouseCoords.y - mapSizeArea.getY();
+
+    const int tileX = (cameraX + mouseMapX) / tileLenSize;
+    const int tileY = (cameraY + mouseMapY) / tileLenSize;
+
+    if (tileX < 0 || tileY < 0 || tileX >= static_cast<int>(m_mapData->getCols()) || tileY >= static_cast<int>(m_mapData->getRows())) {
+        return;
+    }
+
+    const int cellScreenX = tileX * tileLenSize - cameraX;
+    const int cellScreenY = heightBarSize + tileY * tileLenSize - cameraY;
+
+    cRectangle cellRect(cellScreenX, cellScreenY, tileLenSize, tileLenSize);
+    m_renderDrawer->renderRectFillColor(cellRect, editorHoveredCellFillColor, editorHoveredCellFillColor.a);
+    m_renderDrawer->renderRectColor(cellRect, editorHoveredCellBorderColor, editorHoveredCellBorderColor.a);
 }
 
 void cEditorState::drawGrid() const

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -124,6 +124,7 @@ void cEditorState::populateSelectBar()
             .withKind(GuiRenderKind::WITH_STRETCHED_TEXTURE)
             .onClick([this]() {
                 saveMap();
+                hasChanged = false;
             })
             .build();
     m_selectBar->addGuiObject(std::move(guiIcon));
@@ -419,11 +420,16 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
     }
     if (event.isType(eKeyEventType::PRESSED)) {
         if (event.isAction(eKeyAction::MENU_BACK)) {
+            if (hasChanged) {
+                saveMap(true);
+                hasChanged = false;
+            }
             m_interface->setTransitionToWithFadingOut(GAME_MENU);
         }
         if (event.isAction(eKeyAction::EDITOR_SAVE)) {
             //std::cout << "Save" << std::endl;
             saveMap();
+            hasChanged = false;
         }
         if (event.isAction(eKeyAction::EDITOR_ZOOM_IN)) {
             zoomAtMapPosition(m_settings->getScreenW()/2, m_settings->getScreenH()/2, ZoomDirection::zoomIn);
@@ -820,7 +826,7 @@ void cEditorState::modifyTile(int posX, int posY, int tileID)
     int brushEndTileX = 0;
     int brushEndTileY = 0;
     getBrushTileBounds(tileX, tileY, brushStartTileX, brushStartTileY, brushEndTileX, brushEndTileY);
-
+    hasChanged = true;
     for (int brushTileY = brushStartTileY; brushTileY <= brushEndTileY; brushTileY++) {
         for (int brushTileX = brushStartTileX; brushTileX <= brushEndTileX; brushTileX++) {
             (*m_mapData)[brushTileY][brushTileX] = tileID;
@@ -908,10 +914,17 @@ static std::string normalizeStringForFileName(const std::string& input)
     return output;
 }
 
-void cEditorState::saveMap() const
+void cEditorState::saveMap(bool backup) const
 {
+    std::string fileName;
     // creating file
-    std::string fileName = "skirmish/"+normalizeStringForFileName(m_mapName)+".ini";
+    if (!backup) {
+        // if no name provided, use map name
+        fileName = "skirmish/"+normalizeStringForFileName(m_mapName)+".ini";
+    } else {
+        fileName = "skirmish/backup.ini";
+    }
+    
     std::ofstream saveFile(fileName);
     // file verification
     if (!saveFile.is_open()){

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -55,6 +55,7 @@ private:
     void modifySymmetricArea(Direction dir);
 
     void drawMap() const;
+    void drawHoveredCellHighlight() const;
     void drawStartCells() const;
     void drawGrid() const;
     void drawAxes() const;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -27,6 +27,7 @@ public:
     void thinkFast() override;
     void draw() const override;
     void loadMap(s_PreviewMap* map);
+    void setCursorSize(int value);
 
     void onNotifyMouseEvent(const s_MouseEvent &event) override;
     void onNotifyKeyboardEvent(const cKeyboardEvent &event) override;
@@ -52,6 +53,7 @@ private:
     void populateStartCellBar();
     void populateSelectBar();
     void populateSymmetricBar();
+    void setCurrentBar(GuiBar* bar);
     void modifySymmetricArea(Direction dir);
 
     void drawMap() const;
@@ -59,6 +61,8 @@ private:
     void drawStartCells() const;
     void drawGrid() const;
     void drawAxes() const;
+    int getActiveCursorSize() const;
+    int getNormalizedCursorSize() const;
     void modifyTile(int posX, int posY, int tileID);
     void modifyStartCell(int posX, int posY, int startCellID);
     void normalizeModifications();
@@ -93,6 +97,8 @@ private:
     // map modification 
     int idTerrainToMapModif = -1;
     int idStartCellPlayer = -1;
+    int m_cursorSize = 1;
+    int m_topologyCursorSizeSentinel = 1;
     bool m_displayGrid = false;
     bool m_displayAxes = false;
 

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -103,7 +103,7 @@ private:
     int m_topologyCursorSizeSentinel = 1;
     bool m_displayGrid = false;
     bool m_displayAxes = false;
-    bool hasChanged = false;
+    bool m_hasChanged = false;
 
     // startCell positions 
     std::array<cPoint,5> startCells;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -63,6 +63,7 @@ private:
     void drawAxes() const;
     int getActiveCursorSize() const;
     int getNormalizedCursorSize() const;
+    void getBrushTileBounds(int centerTileX, int centerTileY, int &brushStartTileX, int &brushStartTileY, int &brushEndTileX, int &brushEndTileY) const;
     void modifyTile(int posX, int posY, int tileID);
     void modifyStartCell(int posX, int posY, int startCellID);
     void normalizeModifications();

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -73,7 +73,7 @@ private:
     void zoomAtMapPosition(int screenX, int screenY, ZoomDirection direction);
     void updateVisibleTiles();
 
-    void saveMap() const;
+    void saveMap(bool backup = false) const;
     std::unique_ptr<GuiBar> m_selectBar;
     std::unique_ptr<GuiBar> m_topologyBar;
     std::unique_ptr<GuiBar> m_startCellBar;
@@ -103,6 +103,7 @@ private:
     int m_topologyCursorSizeSentinel = 1;
     bool m_displayGrid = false;
     bool m_displayAxes = false;
+    bool hasChanged = false;
 
     // startCell positions 
     std::array<cPoint,5> startCells;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -38,6 +38,7 @@ private:
     Graphics *m_gfxeditor = nullptr;
     cGameSettings *m_settings = nullptr;
     cGameInterface* m_interface = nullptr;
+    cTextDrawer *m_textDrawer = nullptr;
     std::string m_mapName, m_mapAuthor, m_mapDescription;
     enum class ZoomDirection : char {
         zoomIn,

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -100,7 +100,7 @@ private:
     int idTerrainToMapModif = -1;
     int idStartCellPlayer = -1;
     int m_cursorSize = 1;
-    int m_topologyCursorSizeSentinel = 1;
+    int m_topologyCursorSize = 1;
     bool m_displayGrid = false;
     bool m_displayAxes = false;
     bool m_hasChanged = false;

--- a/src/gui/GuiValueButton.cpp
+++ b/src/gui/GuiValueButton.cpp
@@ -1,0 +1,135 @@
+#include "gui/GuiValueButton.h"
+
+#include "drawers/SDLDrawer.hpp"
+#include "drawers/cTextDrawer.h"
+
+#include <algorithm>
+#include <cassert>
+
+GuiValueButton::GuiValueButton(SDLDrawer* drawer, const cRectangle& rect, int initialValue, int stepValue, int minValue, int maxValue)
+    : GuiObject(drawer, rect)
+    , m_value(initialValue)
+    , m_stepValue(std::max(1, stepValue))
+    , m_minValue(std::min(minValue, maxValue))
+    , m_maxValue(std::max(minValue, maxValue))
+{
+    assert(drawer != nullptr);
+    updateValue(initialValue);
+}
+
+void GuiValueButton::onNotifyMouseEvent(const s_MouseEvent &event)
+{
+    switch (event.eventType) {
+        case MOUSE_MOVED_TO:
+            m_focus = m_rect.isPointWithin(event.coords);
+            if (!m_focus) {
+                m_pressed = false;
+            }
+            break;
+        case MOUSE_LEFT_BUTTON_PRESSED:
+        case MOUSE_RIGHT_BUTTON_PRESSED:
+            m_pressed = m_rect.isPointWithin(event.coords);
+            break;
+        case MOUSE_LEFT_BUTTON_CLICKED:
+            if (m_rect.isPointWithin(event.coords)) {
+                decreaseValue();
+            }
+            m_pressed = false;
+            break;
+        case MOUSE_RIGHT_BUTTON_CLICKED:
+            if (m_rect.isPointWithin(event.coords)) {
+                increaseValue();
+            }
+            m_pressed = false;
+            break;
+        default:
+            break;
+    }
+}
+
+void GuiValueButton::onNotifyKeyboardEvent(const cKeyboardEvent &)
+{
+}
+
+void GuiValueButton::draw() const
+{
+    m_renderDrawer->renderRectFillColor(m_rect, m_theme.fillColor);
+    if (m_pressed) {
+        m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.borderDark, m_theme.borderLight);
+    } else {
+        m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.borderLight, m_theme.borderDark);
+    }
+
+    if (m_textDrawer != nullptr) {
+        Color textColor = m_focus ? m_theme.textColorHover : m_theme.textColor;
+        if (!m_label.empty() || m_texture != nullptr) {
+            const int topHeight = m_rect.getHeight() / 2;
+            const int bottomHeight = m_rect.getHeight() - topHeight;
+            const cRectangle topRect(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), topHeight);
+            const cRectangle bottomRect(m_rect.getX(), m_rect.getY() + topHeight, m_rect.getWidth(), bottomHeight);
+
+            if (m_texture != nullptr) {
+                m_renderDrawer->renderStrechFullSprite(m_texture, topRect);
+            } else {
+                m_textDrawer->drawTextCenteredInBox(m_label, topRect, textColor);
+            }
+            m_textDrawer->drawTextCenteredInBox(std::to_string(m_value), bottomRect, textColor);
+            return;
+        }
+
+        m_textDrawer->drawTextCenteredInBox(std::to_string(m_value), m_rect, textColor);
+    }
+}
+
+void GuiValueButton::setTextDrawer(cTextDrawer *drawer)
+{
+    m_textDrawer = drawer;
+}
+
+void GuiValueButton::setOnChanged(std::function<void(int)> callback)
+{
+    m_onChanged = std::move(callback);
+}
+
+void GuiValueButton::setLabel(const std::string& label)
+{
+    m_label = label;
+}
+
+void GuiValueButton::setTexture(Texture *texture)
+{
+    m_texture = texture;
+}
+
+int GuiValueButton::getValue() const
+{
+    return m_value;
+}
+
+void GuiValueButton::setValue(int value)
+{
+    updateValue(value);
+}
+
+void GuiValueButton::increaseValue()
+{
+    updateValue(m_value + m_stepValue);
+}
+
+void GuiValueButton::decreaseValue()
+{
+    updateValue(m_value - m_stepValue);
+}
+
+void GuiValueButton::updateValue(int nextValue)
+{
+    const int clampedValue = std::clamp(nextValue, m_minValue, m_maxValue);
+    if (clampedValue == m_value) {
+        return;
+    }
+
+    m_value = clampedValue;
+    if (m_onChanged) {
+        m_onChanged(m_value);
+    }
+}

--- a/src/gui/GuiValueButton.h
+++ b/src/gui/GuiValueButton.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include "gui/GuiObject.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+
+class SDLDrawer;
+class cTextDrawer;
+class Texture;
+
+class GuiValueButton : public GuiObject {
+public:
+    GuiValueButton(SDLDrawer* drawer, const cRectangle& rect, int initialValue, int stepValue, int minValue, int maxValue);
+
+    void onNotifyMouseEvent(const s_MouseEvent &event) override;
+    void onNotifyKeyboardEvent(const cKeyboardEvent &event) override;
+    void draw() const override;
+
+    void setTextDrawer(cTextDrawer *drawer);
+    void setOnChanged(std::function<void(int)> callback);
+    void setLabel(const std::string& label);
+    void setTexture(Texture *texture);
+
+    int getValue() const;
+    void setValue(int value);
+
+private:
+    void increaseValue();
+    void decreaseValue();
+    void updateValue(int nextValue);
+
+    cTextDrawer *m_textDrawer = nullptr;
+    std::function<void(int)> m_onChanged = nullptr;
+    std::string m_label;
+    Texture *m_texture = nullptr;
+    int m_value = 0;
+    int m_stepValue = 1;
+    int m_minValue = 0;
+    int m_maxValue = 0;
+    bool m_focus = false;
+    bool m_pressed = false;
+};
+
+class GuiValueButtonBuilder {
+public:
+    GuiValueButtonBuilder& withRect(const cRectangle& rect) {
+        params.rect = rect;
+        return *this;
+    }
+
+    GuiValueButtonBuilder& withRenderer(SDLDrawer* render) {
+        params.renderer = render;
+        return *this;
+    }
+
+    GuiValueButtonBuilder& withTextDrawer(cTextDrawer* drawer) {
+        params.drawer = drawer;
+        return *this;
+    }
+
+    GuiValueButtonBuilder& withTheme(const GuiTheme& theme) {
+        params.theme = theme;
+        return *this;
+    }
+
+    GuiValueButtonBuilder& withInitialValue(int value) {
+        params.initialValue = value;
+        return *this;
+    }
+
+    GuiValueButtonBuilder& withStepValue(int value) {
+        params.stepValue = value;
+        return *this;
+    }
+
+    GuiValueButtonBuilder& withMinValue(int value) {
+        params.minValue = value;
+        return *this;
+    }
+
+    GuiValueButtonBuilder& withMaxValue(int value) {
+        params.maxValue = value;
+        return *this;
+    }
+
+    GuiValueButtonBuilder& onChanged(std::function<void(int)> callback) {
+        params.onChanged = std::move(callback);
+        return *this;
+    }
+
+    GuiValueButtonBuilder& withLabel(const std::string& label) {
+        params.label = label;
+        return *this;
+    }
+
+    GuiValueButtonBuilder& withTexture(Texture* texture) {
+        params.texture = texture;
+        return *this;
+    }
+
+    std::unique_ptr<GuiValueButton> build() const {
+        auto button = std::make_unique<GuiValueButton>(params.renderer, params.rect, params.initialValue, params.stepValue, params.minValue, params.maxValue);
+        button->setTextDrawer(params.drawer);
+        button->setTheme(params.theme);
+        button->setLabel(params.label);
+        button->setTexture(params.texture);
+        if (params.onChanged) {
+            button->setOnChanged(params.onChanged);
+        }
+        return button;
+    }
+
+private:
+    struct {
+        cRectangle rect;
+        SDLDrawer* renderer = nullptr;
+        cTextDrawer* drawer = nullptr;
+        GuiTheme theme = cGuiThemeBuilder().light().build();
+        int initialValue = 0;
+        int stepValue = 1;
+        int minValue = 0;
+        int maxValue = 0;
+        std::string label;
+        Texture* texture = nullptr;
+        std::function<void(int)> onChanged = nullptr;
+    } params;
+};


### PR DESCRIPTION
From #1040 
From #1043 

## **Goal**

Feedback from Ripps regarding the map editor.

### Changes
- The cell on the map that the mouse hovers over is colored light yellow.
- The selection size can be modified from 1 to 11
- Exiting the map editor saves the map under the name "backup" if it has been modified previously.

## Screenshots

- Highlighting
<img width="143" height="159" alt="Capture d’écran du 2026-05-01 07-37-41" src="https://github.com/user-attachments/assets/54811d92-4a6e-4fd9-853a-ee985cdcb83e" />

- PenSize


https://github.com/user-attachments/assets/73169fa9-aaec-4f7d-8f8e-2c682ee654fa


close #1040 
close #1043