### PR TITLE
feature  / undo redo on MapEditor

### DIFF
--- a/src/controls/cKeyBindings.cpp
+++ b/src/controls/cKeyBindings.cpp
@@ -67,6 +67,8 @@ void cKeyBindings::loadDefaults()
     bind(eKeyAction::EDITOR_ZOOM_OUT, {SDL_SCANCODE_PAGEDOWN});
     bind(eKeyAction::EDITOR_DISPLAY_GRID, {SDL_SCANCODE_G});
     bind(eKeyAction::EDITOR_DISPLAY_AXES, {SDL_SCANCODE_A});
+    bind(eKeyAction::EDITOR_UNDO,     {SDL_SCANCODE_Z}, true, false, false);
+    bind(eKeyAction::EDITOR_REDO,     {SDL_SCANCODE_Y}, true, false, false);
 
     // UI / menus
     bind(eKeyAction::MENU_BACK,    {SDL_SCANCODE_ESCAPE});
@@ -143,6 +145,8 @@ void cKeyBindings::loadFromSection(const cSection &section)
         {"EDITOR_ZOOM_OUT",           eKeyAction::EDITOR_ZOOM_OUT},
         {"EDITOR_DISPLAY_GRID",       eKeyAction::EDITOR_DISPLAY_GRID},
         {"EDITOR_DISPLAY_AXES",       eKeyAction::EDITOR_DISPLAY_AXES},
+        {"EDITOR_UNDO",               eKeyAction::EDITOR_UNDO},
+        {"EDITOR_REDO",               eKeyAction::EDITOR_REDO},
         {"MENU_BACK",                 eKeyAction::MENU_BACK},
         {"MENU_CONFIRM",              eKeyAction::MENU_CONFIRM},
         {"MENU_CANCEL",               eKeyAction::MENU_CANCEL},

--- a/src/controls/eKeyAction.h
+++ b/src/controls/eKeyAction.h
@@ -55,6 +55,8 @@ enum class eKeyAction {
     EDITOR_ZOOM_OUT,
     EDITOR_DISPLAY_GRID,
     EDITOR_DISPLAY_AXES,
+    EDITOR_UNDO,
+    EDITOR_REDO,
     // UI / menus
     MENU_BACK,
     MENU_CONFIRM,

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -1,4 +1,5 @@
 #include "gamestates/cEditorState.h"
+#include "gamestates/cEditorState/cEditorUndoRedoHistory.h"
 #include "controls/eKeyAction.h"
 #include "gui/GuiBar.h"
 #include "gui/GuiStateButton.h"
@@ -20,6 +21,7 @@
 #include <fstream>
 #include <algorithm>
 #include <cctype>
+#include <memory>
 
 const int heightBarSize = 48;
 const int heightButtonSize = 40;
@@ -46,6 +48,8 @@ cEditorState::cEditorState(sGameServices* services)
     assert(m_settings != nullptr);
     assert(m_interface != nullptr);
     assert(m_textDrawer != nullptr);
+
+    m_undoRedo = std::make_unique<cEditorUndoRedoHistory>();
 
     const cRectangle &selectRect = cRectangle(0, 0, m_settings->getScreenW(), heightBarSize);
     const cRectangle &modifRect = cRectangle(m_settings->getScreenW()-heightBarSize, heightBarSize, heightBarSize, m_settings->getScreenH()-heightBarSize);
@@ -74,89 +78,7 @@ cEditorState::cEditorState(sGameServices* services)
 
 cEditorState::~cEditorState()
 {
-
 }
-
-// ---- Undo/Redo helpers ---------------------------------------------------
-
-void cEditorState::beginRecordGroup()
-{
-    m_undoStack.push_back(Marker{});
-    m_redoStack.clear();
-}
-
-void cEditorState::recordTileChange(int col, int row, int oldTileID, int newTileID)
-{
-    m_undoStack.push_back(TileChange{col, row, oldTileID, newTileID});
-}
-
-void cEditorState::recordStartCellChange(int playerID, cPoint oldPos, cPoint newPos)
-{
-    m_undoStack.push_back(StartCellChange{playerID, oldPos, newPos});
-}
-
-void cEditorState::applyUndo()
-{
-    if (m_undoStack.empty()) return;
-
-    // Collect entries back to the most recent Marker
-    std::vector<EditorChange> group;
-    while (!m_undoStack.empty() && !std::holds_alternative<Marker>(m_undoStack.back())) {
-        group.push_back(m_undoStack.back());
-        m_undoStack.pop_back();
-    }
-    if (!m_undoStack.empty()) {
-        m_undoStack.pop_back(); // pop the Marker itself
-    }
-
-    if (group.empty()) return;
-
-    // Push redo marker + reversed changes
-    m_redoStack.push_back(Marker{});
-    for (auto &change : group) {
-        if (auto *tc = std::get_if<TileChange>(&change)) {
-            (*m_mapData)[tc->row][tc->col] = tc->oldTileID;
-            m_redoStack.push_back(TileChange{tc->col, tc->row, tc->oldTileID, tc->newTileID});
-        } else if (auto *sc = std::get_if<StartCellChange>(&change)) {
-            startCells[sc->playerID] = sc->oldPos;
-            m_redoStack.push_back(StartCellChange{sc->playerID, sc->oldPos, sc->newPos});
-        }
-    }
-
-    m_hasChanged = true;
-}
-
-void cEditorState::applyRedo()
-{
-    if (m_redoStack.empty()) return;
-
-    std::vector<EditorChange> group;
-    while (!m_redoStack.empty() && !std::holds_alternative<Marker>(m_redoStack.back())) {
-        group.push_back(m_redoStack.back());
-        m_redoStack.pop_back();
-    }
-    if (!m_redoStack.empty()) {
-        m_redoStack.pop_back(); // pop the Marker
-    }
-
-    if (group.empty()) return;
-
-    // Push undo marker + re-applied changes
-    m_undoStack.push_back(Marker{});
-    for (auto &change : group) {
-        if (auto *tc = std::get_if<TileChange>(&change)) {
-            (*m_mapData)[tc->row][tc->col] = tc->newTileID;
-            m_undoStack.push_back(TileChange{tc->col, tc->row, tc->oldTileID, tc->newTileID});
-        } else if (auto *sc = std::get_if<StartCellChange>(&change)) {
-            startCells[sc->playerID] = sc->newPos;
-            m_undoStack.push_back(StartCellChange{sc->playerID, sc->oldPos, sc->newPos});
-        }
-    }
-
-    m_hasChanged = true;
-}
-
-// --------------------------------------------------------------------------
 
 void cEditorState::populateSelectBar()
 {
@@ -536,10 +458,14 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
             m_displayAxes = !m_displayAxes;
         }
         if (event.isAction(eKeyAction::EDITOR_UNDO)) {
-            applyUndo();
+            if (m_undoRedo->applyUndo(*m_mapData, startCells)) {
+                m_hasChanged = true;
+            }
         }
         if (event.isAction(eKeyAction::EDITOR_REDO)) {
-            applyRedo();
+            if (m_undoRedo->applyRedo(*m_mapData, startCells)) {
+                m_hasChanged = true;
+            }
         }
     }
 
@@ -596,8 +522,7 @@ void cEditorState::loadMap(s_PreviewMap* map)
     m_displayGrid = false;
     m_displayAxes = false;
     m_hasChanged = false;
-    m_undoStack.clear();
-    m_redoStack.clear();
+    m_undoRedo->clear();
 }
 
 void cEditorState::setCursorSize(int value)
@@ -925,11 +850,11 @@ void cEditorState::modifyTile(int posX, int posY, int tileID)
             }
 
             if (!hasRecordedGroup) {
-                beginRecordGroup();
+                m_undoRedo->beginRecordGroup();
                 hasRecordedGroup = true;
             }
 
-            recordTileChange(brushTileX, brushTileY, oldTileID, tileID);
+            m_undoRedo->recordTileChange(brushTileX, brushTileY, oldTileID, tileID);
             (*m_mapData)[brushTileY][brushTileX] = tileID;
             m_hasChanged = true;
         }
@@ -947,8 +872,8 @@ void cEditorState::modifyStartCell(int posX, int posY, int startCellID)
         cPoint oldPos = startCells[startCellID];
         cPoint newPos = {tileX, tileY};
         if (oldPos.x == newPos.x && oldPos.y == newPos.y) return;
-        beginRecordGroup();
-        recordStartCellChange(startCellID, oldPos, newPos);
+        m_undoRedo->beginRecordGroup();
+        m_undoRedo->recordStartCellChange(startCellID, oldPos, newPos);
         startCells[startCellID] = newPos;
         m_hasChanged = true;
     }
@@ -957,7 +882,7 @@ void cEditorState::modifyStartCell(int posX, int posY, int startCellID)
 void cEditorState::modifySymmetricArea(Direction dir)
 {
     // std::cout << "modifySymmetricArea " << static_cast<int>(dir) << std::endl;
-    beginRecordGroup();
+    m_undoRedo->beginRecordGroup();
     switch (dir) {
         case Direction::bottom:
             for (size_t j = 1; j < (m_mapData->getRows())/2; j++) {
@@ -966,7 +891,7 @@ void cEditorState::modifySymmetricArea(Direction dir)
                     int oldVal = (*m_mapData)[mirrorJ][i];
                     int newVal = (*m_mapData)[j][i];
                     if (oldVal != newVal) {
-                        recordTileChange(i, mirrorJ, oldVal, newVal);
+                        m_undoRedo->recordTileChange(i, mirrorJ, oldVal, newVal);
                         (*m_mapData)[mirrorJ][i] = newVal;
                     }
                 }
@@ -979,7 +904,7 @@ void cEditorState::modifySymmetricArea(Direction dir)
                     int oldVal = (*m_mapData)[j][i];
                     int newVal = (*m_mapData)[mirrorJ][i];
                     if (oldVal != newVal) {
-                        recordTileChange(i, j, oldVal, newVal);
+                        m_undoRedo->recordTileChange(i, j, oldVal, newVal);
                         (*m_mapData)[j][i] = newVal;
                     }
                 }
@@ -992,7 +917,7 @@ void cEditorState::modifySymmetricArea(Direction dir)
                     int oldVal = (*m_mapData)[j][mirrorI];
                     int newVal = (*m_mapData)[j][i];
                     if (oldVal != newVal) {
-                        recordTileChange(mirrorI, j, oldVal, newVal);
+                        m_undoRedo->recordTileChange(mirrorI, j, oldVal, newVal);
                         (*m_mapData)[j][mirrorI] = newVal;
                     }
                 }
@@ -1005,7 +930,7 @@ void cEditorState::modifySymmetricArea(Direction dir)
                     int oldVal = (*m_mapData)[j][i];
                     int newVal = (*m_mapData)[j][mirrorI];
                     if (oldVal != newVal) {
-                        recordTileChange(i, j, oldVal, newVal);
+                        m_undoRedo->recordTileChange(i, j, oldVal, newVal);
                         (*m_mapData)[j][i] = newVal;
                     }
                 }

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -77,6 +77,87 @@ cEditorState::~cEditorState()
 
 }
 
+// ---- Undo/Redo helpers ---------------------------------------------------
+
+void cEditorState::beginRecordGroup()
+{
+    m_undoStack.push_back(Marker{});
+    m_redoStack.clear();
+}
+
+void cEditorState::recordTileChange(int col, int row, int oldTileID, int newTileID)
+{
+    m_undoStack.push_back(TileChange{col, row, oldTileID, newTileID});
+}
+
+void cEditorState::recordStartCellChange(int playerID, cPoint oldPos, cPoint newPos)
+{
+    m_undoStack.push_back(StartCellChange{playerID, oldPos, newPos});
+}
+
+void cEditorState::applyUndo()
+{
+    if (m_undoStack.empty()) return;
+
+    // Collect entries back to the most recent Marker
+    std::vector<EditorChange> group;
+    while (!m_undoStack.empty() && !std::holds_alternative<Marker>(m_undoStack.back())) {
+        group.push_back(m_undoStack.back());
+        m_undoStack.pop_back();
+    }
+    if (!m_undoStack.empty()) {
+        m_undoStack.pop_back(); // pop the Marker itself
+    }
+
+    if (group.empty()) return;
+
+    // Push redo marker + reversed changes
+    m_redoStack.push_back(Marker{});
+    for (auto &change : group) {
+        if (auto *tc = std::get_if<TileChange>(&change)) {
+            (*m_mapData)[tc->row][tc->col] = tc->oldTileID;
+            m_redoStack.push_back(TileChange{tc->col, tc->row, tc->oldTileID, tc->newTileID});
+        } else if (auto *sc = std::get_if<StartCellChange>(&change)) {
+            startCells[sc->playerID] = sc->oldPos;
+            m_redoStack.push_back(StartCellChange{sc->playerID, sc->oldPos, sc->newPos});
+        }
+    }
+
+    m_hasChanged = true;
+}
+
+void cEditorState::applyRedo()
+{
+    if (m_redoStack.empty()) return;
+
+    std::vector<EditorChange> group;
+    while (!m_redoStack.empty() && !std::holds_alternative<Marker>(m_redoStack.back())) {
+        group.push_back(m_redoStack.back());
+        m_redoStack.pop_back();
+    }
+    if (!m_redoStack.empty()) {
+        m_redoStack.pop_back(); // pop the Marker
+    }
+
+    if (group.empty()) return;
+
+    // Push undo marker + re-applied changes
+    m_undoStack.push_back(Marker{});
+    for (auto &change : group) {
+        if (auto *tc = std::get_if<TileChange>(&change)) {
+            (*m_mapData)[tc->row][tc->col] = tc->newTileID;
+            m_undoStack.push_back(TileChange{tc->col, tc->row, tc->oldTileID, tc->newTileID});
+        } else if (auto *sc = std::get_if<StartCellChange>(&change)) {
+            startCells[sc->playerID] = sc->newPos;
+            m_undoStack.push_back(StartCellChange{sc->playerID, sc->oldPos, sc->newPos});
+        }
+    }
+
+    m_hasChanged = true;
+}
+
+// --------------------------------------------------------------------------
+
 void cEditorState::populateSelectBar()
 {
     m_selectGroup = std::make_unique<GuiButtonGroup>();
@@ -454,6 +535,12 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
             //std::cout << "Toggle axes display" << std::endl;
             m_displayAxes = !m_displayAxes;
         }
+        if (event.isAction(eKeyAction::EDITOR_UNDO)) {
+            applyUndo();
+        }
+        if (event.isAction(eKeyAction::EDITOR_REDO)) {
+            applyRedo();
+        }
     }
 
     if (event.isType(eKeyEventType::HOLD)) {
@@ -508,6 +595,9 @@ void cEditorState::loadMap(s_PreviewMap* map)
     normalizeModifications();
     m_displayGrid = false;
     m_displayAxes = false;
+    m_hasChanged = false;
+    m_undoStack.clear();
+    m_redoStack.clear();
 }
 
 void cEditorState::setCursorSize(int value)
@@ -816,7 +906,6 @@ void cEditorState::modifyTile(int posX, int posY, int tileID)
 
     int tileX = (cameraX + posX) / tileLenSize;
     int tileY = (cameraY + posY) / tileLenSize;
-
     if (m_mapData == nullptr || tileX < 1 || tileY < 1 || tileX >= static_cast<int>(m_mapData->getCols()) - 1 || tileY >= static_cast<int>(m_mapData->getRows()) - 1) {
         return;
     }
@@ -826,12 +915,23 @@ void cEditorState::modifyTile(int posX, int posY, int tileID)
     int brushEndTileX = 0;
     int brushEndTileY = 0;
     getBrushTileBounds(tileX, tileY, brushStartTileX, brushStartTileY, brushEndTileX, brushEndTileY);
+
+    bool hasRecordedGroup = false;
     for (int brushTileY = brushStartTileY; brushTileY <= brushEndTileY; brushTileY++) {
         for (int brushTileX = brushStartTileX; brushTileX <= brushEndTileX; brushTileX++) {
-            if ((*m_mapData)[brushTileY][brushTileX] != tileID) {
-                (*m_mapData)[brushTileY][brushTileX] = tileID;
-                m_hasChanged = true;
+            int oldTileID = (*m_mapData)[brushTileY][brushTileX];
+            if (oldTileID == tileID) {
+                continue;
             }
+
+            if (!hasRecordedGroup) {
+                beginRecordGroup();
+                hasRecordedGroup = true;
+            }
+
+            recordTileChange(brushTileX, brushTileY, oldTileID, tileID);
+            (*m_mapData)[brushTileY][brushTileX] = tileID;
+            m_hasChanged = true;
         }
     }
 }
@@ -844,7 +944,12 @@ void cEditorState::modifyStartCell(int posX, int posY, int startCellID)
     int tileX = (cameraX + posX) / tileLenSize;
     int tileY = (cameraY + posY) / tileLenSize;
     if (m_mapData && tileX >= 1 && tileY >= 1 && tileX < (int)m_mapData->getCols()-1 && tileY < (int)m_mapData->getRows()-1) {
-        startCells[startCellID]={tileX, tileY};
+        cPoint oldPos = startCells[startCellID];
+        cPoint newPos = {tileX, tileY};
+        if (oldPos.x == newPos.x && oldPos.y == newPos.y) return;
+        beginRecordGroup();
+        recordStartCellChange(startCellID, oldPos, newPos);
+        startCells[startCellID] = newPos;
         m_hasChanged = true;
     }
 }
@@ -852,32 +957,57 @@ void cEditorState::modifyStartCell(int posX, int posY, int startCellID)
 void cEditorState::modifySymmetricArea(Direction dir)
 {
     // std::cout << "modifySymmetricArea " << static_cast<int>(dir) << std::endl;
+    beginRecordGroup();
     switch (dir) {
         case Direction::bottom:
             for (size_t j = 1; j < (m_mapData->getRows())/2; j++) {
                 for (size_t i = 1; i < m_mapData->getCols(); i++) {
-                    (*m_mapData)[(m_mapData->getRows()-1)-j][i] = (*m_mapData)[j][i];
+                    size_t mirrorJ = (m_mapData->getRows()-1)-j;
+                    int oldVal = (*m_mapData)[mirrorJ][i];
+                    int newVal = (*m_mapData)[j][i];
+                    if (oldVal != newVal) {
+                        recordTileChange(i, mirrorJ, oldVal, newVal);
+                        (*m_mapData)[mirrorJ][i] = newVal;
+                    }
                 }
             }
             break;
         case Direction::top:
             for (size_t j = 1; j < (m_mapData->getRows())/2; j++) {
                 for (size_t i = 1; i < m_mapData->getCols(); i++) {
-                    (*m_mapData)[j][i] = (*m_mapData)[(m_mapData->getRows()-1)-j][i];
+                    size_t mirrorJ = (m_mapData->getRows()-1)-j;
+                    int oldVal = (*m_mapData)[j][i];
+                    int newVal = (*m_mapData)[mirrorJ][i];
+                    if (oldVal != newVal) {
+                        recordTileChange(i, j, oldVal, newVal);
+                        (*m_mapData)[j][i] = newVal;
+                    }
                 }
             }
             break;
         case Direction::right:
             for (size_t j = 1; j < m_mapData->getRows(); j++) {
                 for (size_t i = 1; i < (m_mapData->getCols())/2; i++) {
-                    (*m_mapData)[j][(m_mapData->getCols()-1)-i] = (*m_mapData)[j][i];
+                    size_t mirrorI = (m_mapData->getCols()-1)-i;
+                    int oldVal = (*m_mapData)[j][mirrorI];
+                    int newVal = (*m_mapData)[j][i];
+                    if (oldVal != newVal) {
+                        recordTileChange(mirrorI, j, oldVal, newVal);
+                        (*m_mapData)[j][mirrorI] = newVal;
+                    }
                 }
             }
             break;
         case Direction::left:
             for (size_t j = 1; j < m_mapData->getRows(); j++) {
                 for (size_t i = 1; i < (m_mapData->getCols())/2; i++) {
-                    (*m_mapData)[j][i] = (*m_mapData)[j][(m_mapData->getCols()-1)-i];
+                    size_t mirrorI = (m_mapData->getCols()-1)-i;
+                    int oldVal = (*m_mapData)[j][i];
+                    int newVal = (*m_mapData)[j][mirrorI];
+                    if (oldVal != newVal) {
+                        recordTileChange(i, j, oldVal, newVal);
+                        (*m_mapData)[j][i] = newVal;
+                    }
                 }
             }
             break;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -9,8 +9,6 @@
 #include <memory>
 #include <array>
 #include <string>
-#include <variant>
-#include <vector>
 
 class Texture;
 class Graphics;
@@ -20,6 +18,7 @@ class GuiBar;
 class GuiButtonGroup;
 class cTextDrawer;
 class cGameInterface;
+class cEditorUndoRedoHistory;
 
 class cEditorState : public cGameState {
 public:
@@ -36,21 +35,6 @@ public:
 
     eGameStateType getType() override;
 private:
-    // ---- Undo/Redo -------------------------------------------------------
-    struct Marker {};
-    struct TileChange    { int col, row, oldTileID, newTileID; };
-    struct StartCellChange { int playerID; cPoint oldPos, newPos; };
-    using EditorChange = std::variant<Marker, TileChange, StartCellChange>;
-
-    std::vector<EditorChange> m_undoStack;
-    std::vector<EditorChange> m_redoStack;
-
-    void recordTileChange(int col, int row, int oldTileID, int newTileID);
-    void recordStartCellChange(int playerID, cPoint oldPos, cPoint newPos);
-    void beginRecordGroup();
-    void applyUndo();
-    void applyRedo();
-    // -----------------------------------------------------------------------
     Graphics *m_gfxdata = nullptr;
     Graphics *m_gfxeditor = nullptr;
     cGameSettings *m_settings = nullptr;
@@ -101,6 +85,8 @@ private:
     std::unique_ptr<GuiButtonGroup> m_topologyGroup;
     std::unique_ptr<GuiButtonGroup> m_startCellGroup;
     std::unique_ptr<GuiButtonGroup> m_symmetricGroup;
+
+    std::unique_ptr<cEditorUndoRedoHistory> m_undoRedo;
 
     cRectangle mapSizeArea;
     int tileLenSize = 16;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -9,6 +9,8 @@
 #include <memory>
 #include <array>
 #include <string>
+#include <variant>
+#include <vector>
 
 class Texture;
 class Graphics;
@@ -34,6 +36,21 @@ public:
 
     eGameStateType getType() override;
 private:
+    // ---- Undo/Redo -------------------------------------------------------
+    struct Marker {};
+    struct TileChange    { int col, row, oldTileID, newTileID; };
+    struct StartCellChange { int playerID; cPoint oldPos, newPos; };
+    using EditorChange = std::variant<Marker, TileChange, StartCellChange>;
+
+    std::vector<EditorChange> m_undoStack;
+    std::vector<EditorChange> m_redoStack;
+
+    void recordTileChange(int col, int row, int oldTileID, int newTileID);
+    void recordStartCellChange(int playerID, cPoint oldPos, cPoint newPos);
+    void beginRecordGroup();
+    void applyUndo();
+    void applyRedo();
+    // -----------------------------------------------------------------------
     Graphics *m_gfxdata = nullptr;
     Graphics *m_gfxeditor = nullptr;
     cGameSettings *m_settings = nullptr;

--- a/src/gamestates/cEditorState/cEditorUndoRedoHistory.cpp
+++ b/src/gamestates/cEditorState/cEditorUndoRedoHistory.cpp
@@ -1,0 +1,81 @@
+#include "gamestates/cEditorState/cEditorUndoRedoHistory.h"
+
+void cEditorUndoRedoHistory::clear()
+{
+    m_undoStack.clear();
+    m_redoStack.clear();
+}
+
+void cEditorUndoRedoHistory::beginRecordGroup()
+{
+    m_undoStack.push_back(Marker{});
+    m_redoStack.clear();
+}
+
+void cEditorUndoRedoHistory::recordTileChange(int col, int row, int oldTileID, int newTileID)
+{
+    m_undoStack.push_back(TileChange{col, row, oldTileID, newTileID});
+}
+
+void cEditorUndoRedoHistory::recordStartCellChange(int playerID, cPoint oldPos, cPoint newPos)
+{
+    m_undoStack.push_back(StartCellChange{playerID, oldPos, newPos});
+}
+
+bool cEditorUndoRedoHistory::applyUndo(Matrix<int> &mapData, std::array<cPoint, 5> &startCells)
+{
+    if (m_undoStack.empty()) return false;
+
+    std::vector<EditorChange> group;
+    while (!m_undoStack.empty() && !std::holds_alternative<Marker>(m_undoStack.back())) {
+        group.push_back(m_undoStack.back());
+        m_undoStack.pop_back();
+    }
+    if (!m_undoStack.empty()) {
+        m_undoStack.pop_back();
+    }
+
+    if (group.empty()) return false;
+
+    m_redoStack.push_back(Marker{});
+    for (auto &change : group) {
+        if (auto *tc = std::get_if<TileChange>(&change)) {
+            mapData[tc->row][tc->col] = tc->oldTileID;
+            m_redoStack.push_back(TileChange{tc->col, tc->row, tc->oldTileID, tc->newTileID});
+        } else if (auto *sc = std::get_if<StartCellChange>(&change)) {
+            startCells[sc->playerID] = sc->oldPos;
+            m_redoStack.push_back(StartCellChange{sc->playerID, sc->oldPos, sc->newPos});
+        }
+    }
+
+    return true;
+}
+
+bool cEditorUndoRedoHistory::applyRedo(Matrix<int> &mapData, std::array<cPoint, 5> &startCells)
+{
+    if (m_redoStack.empty()) return false;
+
+    std::vector<EditorChange> group;
+    while (!m_redoStack.empty() && !std::holds_alternative<Marker>(m_redoStack.back())) {
+        group.push_back(m_redoStack.back());
+        m_redoStack.pop_back();
+    }
+    if (!m_redoStack.empty()) {
+        m_redoStack.pop_back();
+    }
+
+    if (group.empty()) return false;
+
+    m_undoStack.push_back(Marker{});
+    for (auto &change : group) {
+        if (auto *tc = std::get_if<TileChange>(&change)) {
+            mapData[tc->row][tc->col] = tc->newTileID;
+            m_undoStack.push_back(TileChange{tc->col, tc->row, tc->oldTileID, tc->newTileID});
+        } else if (auto *sc = std::get_if<StartCellChange>(&change)) {
+            startCells[sc->playerID] = sc->newPos;
+            m_undoStack.push_back(StartCellChange{sc->playerID, sc->oldPos, sc->newPos});
+        }
+    }
+
+    return true;
+}

--- a/src/gamestates/cEditorState/cEditorUndoRedoHistory.h
+++ b/src/gamestates/cEditorState/cEditorUndoRedoHistory.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "utils/cMatrix.h"
+#include "utils/cPoint.h"
+
+#include <array>
+#include <variant>
+#include <vector>
+
+class cEditorUndoRedoHistory {
+public:
+    void clear();
+
+    void beginRecordGroup();
+    void recordTileChange(int col, int row, int oldTileID, int newTileID);
+    void recordStartCellChange(int playerID, cPoint oldPos, cPoint newPos);
+
+    bool applyUndo(Matrix<int> &mapData, std::array<cPoint, 5> &startCells);
+    bool applyRedo(Matrix<int> &mapData, std::array<cPoint, 5> &startCells);
+
+private:
+    struct Marker {};
+    struct TileChange { int col, row, oldTileID, newTileID; };
+    struct StartCellChange { int playerID; cPoint oldPos, newPos; };
+    using EditorChange = std::variant<Marker, TileChange, StartCellChange>;
+
+    std::vector<EditorChange> m_undoStack;
+    std::vector<EditorChange> m_redoStack;
+};


### PR DESCRIPTION
From #1044 

## **Goal**

When editing a terrain, it is possible to go back/forward using an undo/redo function accessible via the CTRL-Z / CTRL-Y keys.


### Changes
- Undo CTRL + Z
- Redo CTRL + Y
