### PR TITLE
Add independent IX upgrades for Sardaukar Heavy Factory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,70 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
 ## Project Overview
 
 D2TM (Dune II - The Maker) is a C++23 remake of the classic RTS game Dune II. 
@@ -128,4 +192,3 @@ From comments in `cGame.h`:
 - produce small PR's (a very limited set of changes)
 - branch names are usually: `<prefix>/<ticket-githubnr here>/<short-description-of-feature>`
   - prefixes can be `feature` (new feature), `bugfix` or `improv` (for technical improvements usually)
--

--- a/src/context/cInfoContextCreator.cpp
+++ b/src/context/cInfoContextCreator.cpp
@@ -1272,7 +1272,9 @@ void cInfoContextCreator::initUpgrades(cUpgradeInfos& upgradeInfos)
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].icon = ICON_UNIT_SONICTANK;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].cost = game.m_infoContext->getUnitInfo(SONICTANK).cost / 2;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].structureType = IX;
-    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].atUpgradeLevel = 0; // After upgrade to Rocket Launcher
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].needsStructureType = HEAVYFACTORY;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].atUpgradeLevel = 0;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].dependsOnStructureLevel = false;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].providesType = UNIT;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].providesTypeId = SONICTANK;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].providesTypeList = eListType::LIST_UNITS;
@@ -1289,7 +1291,9 @@ void cInfoContextCreator::initUpgrades(cUpgradeInfos& upgradeInfos)
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].icon = ICON_UNIT_DEVIATOR;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].cost = game.m_infoContext->getUnitInfo(DEVIATOR).cost / 2;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].structureType = IX;
-    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].atUpgradeLevel = 0; // After upgrade to Rocket Launcher
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].needsStructureType = HEAVYFACTORY;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].atUpgradeLevel = 0;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].dependsOnStructureLevel = false;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].providesType = UNIT;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].providesTypeId = DEVIATOR;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].providesTypeList = eListType::LIST_UNITS;
@@ -1306,7 +1310,9 @@ void cInfoContextCreator::initUpgrades(cUpgradeInfos& upgradeInfos)
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].icon = ICON_UNIT_DEVASTATOR;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].cost = game.m_infoContext->getUnitInfo(DEVASTATOR).cost / 2;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].structureType = IX;
-    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].atUpgradeLevel = 0; // After upgrade to Rocket Launcher
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].needsStructureType = HEAVYFACTORY;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].atUpgradeLevel = 0;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].dependsOnStructureLevel = false;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].providesType = UNIT;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].providesTypeId = DEVASTATOR;
     upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].providesTypeList = eListType::LIST_UNITS;

--- a/src/context/cInfoContextCreator.cpp
+++ b/src/context/cInfoContextCreator.cpp
@@ -1264,6 +1264,57 @@ void cInfoContextCreator::initUpgrades(cUpgradeInfos& upgradeInfos)
         upgradeInfos[UPGRADE_TYPE_BARRACKS_INFANTRY].buildTime = 150;
     }
     strcpy(upgradeInfos[UPGRADE_TYPE_BARRACKS_INFANTRY].description, "Build Infantry at Barracks");
+
+    // HEAVY FACTORY: Sardaukar - Allow building Sonic Tank
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].enabled = true;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].house = Sardaukar;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].techLevel = 3;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].icon = ICON_UNIT_SONICTANK;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].cost = game.m_infoContext->getUnitInfo(SONICTANK).cost / 2;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].structureType = IX;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].atUpgradeLevel = 0; // After upgrade to Rocket Launcher
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].providesType = UNIT;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].providesTypeId = SONICTANK;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].providesTypeList = eListType::LIST_UNITS;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].providesTypeSubList = SUBLIST_HEAVYFCTRY;
+    if (!game.m_gameSettings->isCheatMode()) {
+        upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].buildTime = 150;
+    }
+    strcpy(upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK].description, "Build SonicTank at Heavy Factory");
+
+    // HEAVY FACTORY: Sardaukar - Allow building Deviator
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].enabled = true;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].house = Sardaukar;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].techLevel = 3;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].icon = ICON_UNIT_DEVIATOR;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].cost = game.m_infoContext->getUnitInfo(DEVIATOR).cost / 2;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].structureType = IX;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].atUpgradeLevel = 0; // After upgrade to Rocket Launcher
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].providesType = UNIT;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].providesTypeId = DEVIATOR;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].providesTypeList = eListType::LIST_UNITS;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].providesTypeSubList = SUBLIST_HEAVYFCTRY;
+    if (!game.m_gameSettings->isCheatMode()) {
+        upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].buildTime = 150;
+    }
+    strcpy(upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR].description, "Build Deviator at Heavy Factory");
+
+    // HEAVY FACTORY: Sardaukar - Allow building Devastator
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].enabled = true;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].house = Sardaukar;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].techLevel = 3;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].icon = ICON_UNIT_DEVASTATOR;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].cost = game.m_infoContext->getUnitInfo(DEVASTATOR).cost / 2;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].structureType = IX;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].atUpgradeLevel = 0; // After upgrade to Rocket Launcher
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].providesType = UNIT;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].providesTypeId = DEVASTATOR;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].providesTypeList = eListType::LIST_UNITS;
+    upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].providesTypeSubList = SUBLIST_HEAVYFCTRY;
+    if (!game.m_gameSettings->isCheatMode()) {
+        upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].buildTime = 150;
+    }
+    strcpy(upgradeInfos[UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR].description, "Build Devastator at Heavy Factory");
 }
 
 /*****************************

--- a/src/gameobjects/cUpgradeInfo.h
+++ b/src/gameobjects/cUpgradeInfo.h
@@ -24,6 +24,7 @@ struct s_UpgradeInfo {
     unsigned char house; // 8-bit-flag for which house this upgrade applies.
     int techLevel;      // the minimum techlevel required for this upgrade
     int atUpgradeLevel; // linear upgradeLevel per structure type, this is the nr where this upgrade is offered. (0 = start)
+    bool dependsOnStructureLevel = true; // when true, uses the shared linear structureUpgradeLevel chain; when false, tracked individually per upgrade
     int structureType;  // if > -1 then increase upgradeLevel for structureType (this is the structureType being 'upgraded')
     int needsStructureType; // the upgrade is only available when this structure is available, this is additional to the structureType property
     // above, so if you require CONSTYARD *and* RADAR you set structureType=CONSTYARD and needsStructure=RADAR, keep -1

--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -230,6 +230,10 @@ void cPlayer::init(int id, std::unique_ptr<brains::cPlayerBrain> brain)
         iStructureUpgradeLevel[i] = 0;
     }
 
+    for (int i = 0; i < MAX_UPGRADETYPES; i++) {
+        m_appliedUpgrades[i] = false;
+    }
+
     credits = 0;
     maxCredits_ = 1000;
     focusCell_ = 0;

--- a/src/gameobjects/players/cPlayer.h
+++ b/src/gameobjects/players/cPlayer.h
@@ -28,6 +28,7 @@
 #include "utils/cRectangle.h"
 
 
+#include "gameobjects/cUpgradeInfo.h"
 #include "gameobjects/units/cUnitInfos.h"
 
 #include <set>
@@ -283,6 +284,20 @@ public:
         if (structureType < 0) return;
         if (structureType >= MAX_STRUCTURETYPES) return;
         iStructureUpgradeLevel[structureType]++;
+    }
+
+    bool isUpgradeApplied(int upgradeIndex) const {
+        if (upgradeIndex < 0 || upgradeIndex >= MAX_UPGRADETYPES) {
+            return false;
+        }
+        return m_appliedUpgrades[upgradeIndex];
+    }
+
+    void setUpgradeApplied(int upgradeIndex) {
+        if (upgradeIndex < 0 || upgradeIndex >= MAX_UPGRADETYPES) {
+            return;
+        }
+        m_appliedUpgrades[upgradeIndex] = true;
     }
 
     void setTeam(int value) {
@@ -596,6 +611,7 @@ private:
     int iPrimaryBuilding[MAX_STRUCTURETYPES];    // remember the primary ID (structure id) of each structure type
     int iStructures[MAX_STRUCTURETYPES]; // remember what is built for each type of structure
     int iStructureUpgradeLevel[MAX_STRUCTURETYPES]; // remember the upgrade level for each structure type
+    bool m_appliedUpgrades[MAX_UPGRADETYPES]; // tracks which independent upgrades have been applied
 
     int powerUsage_;      // total amount of power usage
     int powerProduce_;      // total amount of power generated

--- a/src/include/definitions.h
+++ b/src/include/definitions.h
@@ -145,6 +145,11 @@ constexpr int MAX_UNIT_GROUPS = 5;
 // Barracks (Atreides & Ordos)
 #define UPGRADE_TYPE_BARRACKS_INFANTRY            9 // upgrade BARRACKS to get Infantry
 
+// Heavy Factory: Sardaukar only
+#define UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK     10 // upgrade for Sardaukar to get Sonic Tank
+#define UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR      11 // upgrade for Sardaukar to get Deviator
+#define UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR    12 // upgrade for Sardaukar to get Devastator
+
 #define MUSIC_WIN           0
 #define MUSIC_LOSE          1
 #define MUSIC_ATTACK        2

--- a/src/sidebar/cBuildingList.cpp
+++ b/src/sidebar/cBuildingList.cpp
@@ -79,8 +79,12 @@ cBuildingListItem *cBuildingList::getItemByBuildId(int buildId)
 
 void cBuildingList::addUpgradeToList(int upgradeType)
 {
-    cBuildingListItem *item = new cBuildingListItem(upgradeType, game.m_infoContext->getUpgradeInfo(upgradeType),
-            game.m_infoContext->getUpgradeInfo(upgradeType).providesTypeSubList);
+    auto upgradeInfo = game.m_infoContext->getUpgradeInfo(upgradeType);
+    cBuildingListItem *item = new cBuildingListItem(
+        upgradeType,
+        upgradeInfo
+    );
+
     if (!addItemToList(item)) {
         delete item;
     }

--- a/src/sidebar/cBuildingList.cpp
+++ b/src/sidebar/cBuildingList.cpp
@@ -118,8 +118,6 @@ void cBuildingList::addSpecialToList(int specialType, int subList)
 bool cBuildingList::addItemToList(cBuildingListItem *item)
 {
     if (isItemInList(item)) {
-//		logbook("Will not add, item is already in list.");
-        // item is already in list, do not add
         return false;
     }
 
@@ -136,9 +134,6 @@ bool cBuildingList::addItemToList(cBuildingListItem *item)
     item->setSlotId(slotId);
     item->setList(this);
     m_maxItems = slotId + 1;
-//	char msg[355];
-//	sprintf(msg, "Icon added with id [%d] added to cBuilding list, put in slot[%d], set m_maxItems to [%d]", item->getBuildId(), slot, m_maxItems);
-//	logbook(msg);
 
     // notify game that the item just has been added!
     cPlayer *pPlayer = m_itemBuilder->getPlayer();

--- a/src/sidebar/cBuildingListItem.cpp
+++ b/src/sidebar/cBuildingListItem.cpp
@@ -5,7 +5,6 @@
 #include "include/d2tmc.h"
 #include "sidebar/cBuildingList.h"
 #include "context/cInfoContext.h"
-#include "context/cGameObjectContext.h"
 #include "game/cGameSettings.h"
 #include <format>
 #include <cassert>
@@ -112,6 +111,10 @@ cBuildingListItem::cBuildingListItem(int theID, s_UnitInfo entry, cBuildingList 
 }
 
 cBuildingListItem::cBuildingListItem(int theID, s_UnitInfo entry, int subList) : cBuildingListItem(theID, entry, nullptr, subList)
+{
+}
+
+cBuildingListItem::cBuildingListItem(int theID, s_UpgradeInfo entry) : cBuildingListItem(theID, entry, entry.providesTypeSubList)
 {
 }
 

--- a/src/sidebar/cBuildingListItem.h
+++ b/src/sidebar/cBuildingListItem.h
@@ -29,7 +29,7 @@ public:
     cBuildingListItem(int theID, s_StructureInfo entry, int subList);
     cBuildingListItem(int theID, s_SpecialInfo entry, int subList);
     cBuildingListItem(int theID, s_UnitInfo entry, int subList);
-    cBuildingListItem(int theID, s_UpgradeInfo entry, int subList);
+    cBuildingListItem(int theID, s_UpgradeInfo entry);
 
     static const int DefaultTimerCap = 35;
     static const int DebugTimerCap = 2;
@@ -256,6 +256,8 @@ public:
     void decreaseFlashingTimer();
 
 private:
+    cBuildingListItem(int theID, s_UpgradeInfo entry, int subList);
+
     void setProgress(int value) {
         m_progress = value;
     }

--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -151,11 +151,22 @@ void cBuildingListUpdater::onStructureCreatedCampaignMode(int structureType) con
         if (house == ATREIDES) {
             listUnits->addUnitToList(SONICTANK, SUBLIST_HEAVYFCTRY);
         }
-        else if (house == HARKONNEN || house == SARDAUKAR) {
+        else if (house == HARKONNEN) {
             listUnits->addUnitToList(DEVASTATOR, SUBLIST_HEAVYFCTRY);
         }
         else if (house == ORDOS) {
             listUnits->addUnitToList(DEVIATOR, SUBLIST_HEAVYFCTRY);
+        }
+        else if (house == SARDAUKAR) {
+            if (m_player->isUpgradeApplied(UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK)) {
+                listUnits->addUnitToList(SONICTANK, SUBLIST_HEAVYFCTRY);
+            }
+            if (m_player->isUpgradeApplied(UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR)) {
+                listUnits->addUnitToList(DEVASTATOR, SUBLIST_HEAVYFCTRY);
+            }
+            if (m_player->isUpgradeApplied(UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR)) {
+                listUnits->addUnitToList(DEVIATOR, SUBLIST_HEAVYFCTRY);
+            }
         }
     }
 
@@ -383,9 +394,15 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
             else if (m_player->getHouse() == ORDOS) {
                 listUnits->addUnitToList(DEVIATOR, SUBLIST_HEAVYFCTRY);
             } else if (m_player->getHouse() == SARDAUKAR) {
-                listUnits->addUnitToList(SONICTANK, SUBLIST_HEAVYFCTRY);
-                listUnits->addUnitToList(DEVASTATOR, SUBLIST_HEAVYFCTRY);
-                listUnits->addUnitToList(DEVIATOR, SUBLIST_HEAVYFCTRY);
+                if (m_player->isUpgradeApplied(UPGRADE_TYPE_HEAVYFCTRY_SAR_SONICTANK)) {
+                    listUnits->addUnitToList(SONICTANK, SUBLIST_HEAVYFCTRY);
+                }
+                if (m_player->isUpgradeApplied(UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVASTATOR)) {
+                    listUnits->addUnitToList(DEVASTATOR, SUBLIST_HEAVYFCTRY);
+                }
+                if (m_player->isUpgradeApplied(UPGRADE_TYPE_HEAVYFCTRY_SAR_DEVIATOR)) {
+                    listUnits->addUnitToList(DEVIATOR, SUBLIST_HEAVYFCTRY);
+                }
             }
         }
         else {
@@ -528,30 +545,40 @@ void cBuildingListUpdater::evaluateUpgrades()
             }
         }
 
-        // check if the structure to upgradeInfo is at the expected level
-        int structureUpgradeLevel = m_player->getStructureUpgradeLevel(upgradeInfo.structureType);
+        // check if the upgrade has been done already / is at the expected level
+        if (upgradeInfo.dependsOnStructureLevel) {
+            int structureUpgradeLevel = m_player->getStructureUpgradeLevel(upgradeInfo.structureType);
 
-        if (structureUpgradeLevel != upgradeInfo.atUpgradeLevel) {
-            // already at correct upgradeInfo level, no = comparison because that means it should be offered
-            if (structureUpgradeLevel > upgradeInfo.atUpgradeLevel) {
-                // this upgradeInfo has been executed already, so apply again,
-                // but only if we have the required structure(s)
+            if (structureUpgradeLevel != upgradeInfo.atUpgradeLevel) {
+                // already at correct upgradeInfo level, no = comparison because that means it should be offered
+                if (structureUpgradeLevel > upgradeInfo.atUpgradeLevel) {
+                    // this upgradeInfo has been executed already, so apply again,
+                    // but only if we have the required structure(s)
+                    if (hasRequiredStructureType) {
+                        applyUpgrade(upgradeInfo);
+                        m_player->log(std::format(
+                                        "Upgrade [{}] has already been achieved, so re-apply. StructureUpgradeLevel={} and upgradeInfo.atUpgradeLevel={}.",
+                                        upgradeInfo.description, structureUpgradeLevel, upgradeInfo.atUpgradeLevel));
+                    }
+                    else {
+                        m_player->log(std::format(
+                                        "Upgrade [{}] has already been achieved, But will not be re-applied because required (additional) structure type is/are present.",
+                                        upgradeInfo.description));
+                    }
+                }
+                addToUpgradesList = false;
+                m_player->log(std::format(
+                                "Upgrade [{}] will not be offered because it has a different atUpgradeLevel. StructureUpgradeLevel={} and upgradeInfo.atUpgradeLevel={} not required additional structureType (upgradeInfo.needsStructureType).",
+                                upgradeInfo.description, structureUpgradeLevel, upgradeInfo.atUpgradeLevel));
+            }
+        } else {
+            if (m_player->isUpgradeApplied(i)) {
                 if (hasRequiredStructureType) {
                     applyUpgrade(upgradeInfo);
-                    m_player->log(std::format(
-                                    "Upgrade [{}] has already been achieved, so re-apply. StructureUpgradeLevel={} and upgradeInfo.atUpgradeLevel={}.",
-                                    upgradeInfo.description, structureUpgradeLevel, upgradeInfo.atUpgradeLevel));
+                    m_player->log(std::format("Upgrade [{}] has already been applied independently, so re-apply.", upgradeInfo.description));
                 }
-                else {
-                    m_player->log(std::format(
-                                    "Upgrade [{}] has already been achieved, But will not be re-applied because required (additional) structure type is/are present.",
-                                    upgradeInfo.description));
-                }
+                addToUpgradesList = false;
             }
-            addToUpgradesList = false;
-            m_player->log(std::format(
-                            "Upgrade [{}] will not be offered because it has a different atUpgradeLevel. StructureUpgradeLevel={} and upgradeInfo.atUpgradeLevel={} not required additional structureType (upgradeInfo.needsStructureType).",
-                            upgradeInfo.description, structureUpgradeLevel, upgradeInfo.atUpgradeLevel));
         }
 
         if (addToUpgradesList) {
@@ -599,7 +626,11 @@ void cBuildingListUpdater::onUpgradeCompleted(cBuildingListItem *item)
     const s_UpgradeInfo &upgradeType = item->getUpgradeInfo();
 
     // Upgrade structure + provide any unit or structure
-    m_player->increaseStructureUpgradeLevel(upgradeType.structureType);
+    if (upgradeType.dependsOnStructureLevel) {
+        m_player->increaseStructureUpgradeLevel(upgradeType.structureType);
+    } else {
+        m_player->setUpgradeApplied(item->getBuildId());
+    }
 
     applyUpgrade(upgradeType);
 


### PR DESCRIPTION
## Summary

- Adds 3 separate upgrades for Sardaukar that unlock SonicTank, Deviator, and Devastator at the Heavy Factory when IX is built — each purchased independently in any order
- Introduces `dependsOnStructureLevel` flag on `s_UpgradeInfo` to opt out of the shared linear upgrade chain; when `false`, the upgrade is tracked individually via a new `m_appliedUpgrades[]` array on `cPlayer`
- Fixes two bugs uncovered during development: upgrades were visible without a Heavy Factory, and completing one upgrade silently unlocked all three units

This is a step in implementing https://github.com/stefanhendriks/Dune-II---The-Maker/issues/1060

## Test plan

- [ ] Play as Sardaukar in skirmish, build Heavy Factory + IX — confirm all 3 upgrades appear
- [ ] Apply one upgrade — confirm only that unit becomes buildable; the other 2 upgrades remain in the list
- [ ] Apply remaining upgrades one by one — each unlocks its unit independently
- [ ] Destroy IX or Heavy Factory — confirm the units are removed from the build list
- [ ] Play as Atreides/Harkonnen/Ordos — confirm their existing upgrade chains are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)