### PR TITLE
Feedback on Ripps mapeditor

### DIFF
--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -480,6 +480,7 @@ void cEditorState::loadMap(s_PreviewMap* map)
     m_mapAuthor = map->author;
     m_mapDescription = map->description;
     m_mapName = map->name;
+    startCells.fill({-1, -1});
     for (int i=0; i<MAX_SKIRMISHMAP_PLAYERS; i++) {
         if (map->iStartCell[i] !=-1) {
             //std::cout << "startCell " << map->iStartCell[i] << std::endl;

--- a/src/gamestates/cNewMapEditorState.h
+++ b/src/gamestates/cNewMapEditorState.h
@@ -39,5 +39,5 @@ private:
     GuiTextInput* m_inputDescription = nullptr;
     GuiCycleButton* m_cycleWidth = nullptr;
     GuiCycleButton* m_cycleHeight = nullptr;
-    std::vector<int> m_sizesMap = {16, 24, 32, 64, 96, 128, 160, 192, 224, 256};
+    std::vector<int> m_sizesMap = {16, 24, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 232, 256};
 };

--- a/src/gamestates/cNewmapEditorState.cpp
+++ b/src/gamestates/cNewmapEditorState.cpp
@@ -11,6 +11,7 @@
 #include "gameobjects/map/cPreviewMaps.h"
 
 #include <cassert>
+#include <chrono>
 
 static const int borderSize = 2;
 
@@ -179,7 +180,8 @@ void cNewMapEditorState::constructWindow()
             // On récupère les valeurs localement pour être sûr
             std::string name = m_inputName->getText();
             if (name.empty()) {
-                name = "New unamed map";
+                auto now = std::chrono::system_clock::now();
+                std::string name = std::format("New unnamed map {:%Y-%m-%d %H:%M:%S}", now);
             }
             std::string author = m_inputAuthor->getText();
             if (author.empty()) {

--- a/src/gamestates/cNewmapEditorState.cpp
+++ b/src/gamestates/cNewmapEditorState.cpp
@@ -178,8 +178,17 @@ void cNewMapEditorState::constructWindow()
         .onClick([this](){
             // On récupère les valeurs localement pour être sûr
             std::string name = m_inputName->getText();
+            if (name.empty()) {
+                name = "New unamed map";
+            }
             std::string author = m_inputAuthor->getText();
+            if (author.empty()) {
+                author = "Unknown user";
+            }
             std::string desc = m_inputDescription->getText();
+            if (desc.empty()) {
+                desc = "Made with D2TM: Internal Editor";
+            }
             int width = m_cycleWidth->getSelectedValue()+borderSize;
             int height = m_cycleHeight->getSelectedValue()+borderSize;
             s_PreviewMap newMap = cPreviewMaps::createEmptyMap(name, author, desc, width, height);


### PR DESCRIPTION
For #1094 
For #1092 
For #1084 

## **Goal**

Fix feedback on `MapEditor`

### Changes

- More size map possibility
- Default values on map creation
- Clean values when recreating map
