### PR TITLE
Skirmish screen: truncate map names longer than 18 chars

### DIFF
--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -1229,11 +1229,18 @@ void cSetupSkirmishState::drawMapList(const cRectangle &selectMapArea) const
             textColor = colorDisabled;
         }
 
-        std::string displayName = mapToRender.name;
-        if (displayName.length() > 18) {
-            displayName = displayName.substr(0, 15) + "...";
+        const int availableTextWidth = mapItemButtonWidth - 8;
+        const std::string *nameToRender = &mapToRender.name;
+        std::string truncatedName;
+        if (m_textDrawer->getTextLength(mapToRender.name) > availableTextWidth) {
+            truncatedName = mapToRender.name;
+            while (!truncatedName.empty() && m_textDrawer->getTextLength(truncatedName + "...") > availableTextWidth) {
+                truncatedName.pop_back();
+            }
+            truncatedName += "...";
+            nameToRender = &truncatedName;
         }
-        m_textDrawer->drawText(iDrawX + 4, iDrawY + 4, textColor, displayName);
+        m_textDrawer->drawText(iDrawX + 4, iDrawY + 4, textColor, *nameToRender);
 
         Texture *tex = nullptr;
         if (mapIndexToRender == 0) {

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -1229,7 +1229,11 @@ void cSetupSkirmishState::drawMapList(const cRectangle &selectMapArea) const
             textColor = colorDisabled;
         }
 
-        m_textDrawer->drawText(iDrawX + 4, iDrawY + 4, textColor, mapToRender.name);
+        std::string displayName = mapToRender.name;
+        if (displayName.length() > 18) {
+            displayName = displayName.substr(0, 15) + "...";
+        }
+        m_textDrawer->drawText(iDrawX + 4, iDrawY + 4, textColor, displayName);
 
         Texture *tex = nullptr;
         if (mapIndexToRender == 0) {


### PR DESCRIPTION
## Summary
- Fixes #1093
- Map names that exceed the available pixel width of the map button (137px) are now truncated with \`...\` in the skirmish map selection grid
- Truncation is based on rendered pixel width via \`getTextLength()\`, so proportional fonts are handled correctly
- No string allocation occurs when the name already fits

## Test plan
- [ ] Open skirmish screen and verify map names that are too wide are truncated with \`...\`
- [ ] Verify short/narrow map names are unchanged
- [ ] Verify selected/hovered state colors still apply to truncated names