### PR TITLE
Spawning ornithopter for debug purposes should be for the currently controlling player

### DIFF
--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -236,7 +236,7 @@ void cGamePlaying::drawCombatMouse() const
 {
     auto m_mouse = m_interface->getMouse();
     if (m_mouse->isBoxSelecting()) {
-        m_renderDrawer->renderRectColor(m_mouse->getBoxSelectRectangle(), Color::Blue);
+        m_renderDrawer->renderRectColor(m_mouse->getBoxSelectRectangle(), Color::White);
     }
 
     if (m_mouse->isMapScrolling()) {

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -446,7 +446,7 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
     }
 
     if (event.isAction(eKeyAction::DEBUG_SPAWN_ORNITHOPTER)) {
-        int mc = humanPlayer->getGameControlsContext()->getMouseCell();
+        int mc = m_controlledPlayer->getGameControlsContext()->getMouseCell();
         cUnits::unitCreate(mc, ORNITHOPTER, m_controlledPlayer->getId(), false, false);
     }
 

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -252,6 +252,7 @@ void cGamePlaying::missionInit()
 {
     m_objects->getMap().thinkSlow();
     m_TIMER_evaluatePlayerStatus = 5;
+    m_controlledPlayer = m_objects->getPlayer(HUMAN);
 }
 
 
@@ -366,20 +367,24 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
     const cPlayer *humanPlayer = m_objects->getPlayer(HUMAN);
 
     if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_0)) {
-        m_drawManager->setPlayerToDraw(m_objects->getPlayer(0));
-        m_interface->setPlayerToInteractFor(m_objects->getPlayer(0));
+        m_controlledPlayer = m_objects->getPlayer(0);
+        m_drawManager->setPlayerToDraw(m_controlledPlayer);
+        m_interface->setPlayerToInteractFor(m_controlledPlayer);
     }
     else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_1)) {
-        m_drawManager->setPlayerToDraw(m_objects->getPlayer(1));
-        m_interface->setPlayerToInteractFor(m_objects->getPlayer(1));
+        m_controlledPlayer = m_objects->getPlayer(1);
+        m_drawManager->setPlayerToDraw(m_controlledPlayer);
+        m_interface->setPlayerToInteractFor(m_controlledPlayer);
     }
     else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_2)) {
-        m_drawManager->setPlayerToDraw(m_objects->getPlayer(2));
-        m_interface->setPlayerToInteractFor(m_objects->getPlayer(2));
+        m_controlledPlayer = m_objects->getPlayer(2);
+        m_drawManager->setPlayerToDraw(m_controlledPlayer);
+        m_interface->setPlayerToInteractFor(m_controlledPlayer);
     }
     else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_3)) {
-        m_drawManager->setPlayerToDraw(m_objects->getPlayer(3));
-        m_interface->setPlayerToInteractFor(m_objects->getPlayer(3));
+        m_controlledPlayer = m_objects->getPlayer(3);
+        m_drawManager->setPlayerToDraw(m_controlledPlayer);
+        m_interface->setPlayerToInteractFor(m_controlledPlayer);
     }
 
     if (event.isAction(eKeyAction::DEBUG_WIN)) {
@@ -442,7 +447,7 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
 
     if (event.isAction(eKeyAction::DEBUG_SPAWN_ORNITHOPTER)) {
         int mc = humanPlayer->getGameControlsContext()->getMouseCell();
-        cUnits::unitCreate(mc, ORNITHOPTER, m_drawManager->getPlayer()->getId(), false, false);
+        cUnits::unitCreate(mc, ORNITHOPTER, m_controlledPlayer->getId(), false, false);
     }
 
     if (event.isAction(eKeyAction::DEBUG_SPAWN_WORM)) {

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -442,7 +442,7 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
 
     if (event.isAction(eKeyAction::DEBUG_SPAWN_ORNITHOPTER)) {
         int mc = humanPlayer->getGameControlsContext()->getMouseCell();
-        cUnits::unitCreate(mc, ORNITHOPTER, 1, false, false);
+        cUnits::unitCreate(mc, ORNITHOPTER, m_drawManager->getPlayer()->getId(), false, false);
     }
 
     if (event.isAction(eKeyAction::DEBUG_SPAWN_WORM)) {

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -402,7 +402,7 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
     }
 
     if (event.isAction(eKeyAction::DEBUG_DESTROY_AT_CURSOR)) {
-        int mc = humanPlayer->getGameControlsContext()->getMouseCell();
+        int mc = m_controlledPlayer->getGameControlsContext()->getMouseCell();
         if (mc > -1) {
             int idOfUnitAtCell = m_objects->getMap().getCellIdUnitLayer(mc);
             if (idOfUnitAtCell > -1) {
@@ -434,7 +434,7 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
             }
         }
     } else if (event.isAction(eKeyAction::DEBUG_REVEAL_MAP)) {
-        m_objects->getMap().clear_all(HUMAN);
+        m_objects->getMap().clear_all(m_controlledPlayer->getId());
     }
 
     if (event.isAction(eKeyAction::DEBUG_KILL_CARRYALLS)) {

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -48,6 +48,10 @@ cGamePlaying::cGamePlaying(sGameServices* services) :
     assert(m_drawManager != nullptr);
     m_textDrawer = m_ctx->getTextContext()->getBeneTextDrawer();
     assert(m_textDrawer != nullptr);
+
+    m_controlledPlayer = m_objects->getPlayer(HUMAN);
+    m_drawManager->setPlayerToDraw(m_controlledPlayer);
+    m_interface->setPlayerToInteractFor(m_controlledPlayer);
 }
 
 cGamePlaying::~cGamePlaying()

--- a/src/gamestates/cGamePlaying.h
+++ b/src/gamestates/cGamePlaying.h
@@ -12,6 +12,7 @@ class cMapCamera;
 class cGameInterface;
 class cStructureFactory;
 class cDrawManager;
+class cPlayer;
 class cTextDrawer;
 
 class cGamePlaying : public cGameState {
@@ -39,6 +40,7 @@ private:
     cMapCamera* m_mapCamera = nullptr;
     cStructureFactory* m_structureFactory = nullptr;
     cDrawManager *m_drawManager = nullptr;
+    cPlayer *m_controlledPlayer = nullptr;
     cTextDrawer* m_textDrawer = nullptr;
     void evaluatePlayerStatus();
     void drawCombatMouse() const;

--- a/src/managers/cDrawManager.h
+++ b/src/managers/cDrawManager.h
@@ -66,8 +66,6 @@ public:
 
     void setPlayerToDraw(cPlayer *playerToDraw);
 
-    cPlayer *getPlayer() const { return m_player; }
-
     void think();
 
     void init();

--- a/src/managers/cDrawManager.h
+++ b/src/managers/cDrawManager.h
@@ -66,6 +66,8 @@ public:
 
     void setPlayerToDraw(cPlayer *playerToDraw);
 
+    cPlayer *getPlayer() const { return m_player; }
+
     void think();
 
     void init();


### PR DESCRIPTION
## Summary
- Debug ornithopter spawn (TAB+F8) was hardcoded to always create units for player index 1
- Added `m_controlledPlayer` member to `cGamePlaying`, initialized in the constructor to the human player — so it resets correctly on every new game/restart
- On TAB+digit debug player switch, `m_controlledPlayer` is updated alongside the existing draw/interact manager calls
- All cursor-based debug actions now read the mouse cell from `m_controlledPlayer`'s context (after a player switch the interaction manager routes mouse events to the new player's context, making the old humanPlayer cell stale)
- TAB+F5 (reveal map) and TAB+F4 (destroy at cursor) also respect the currently controlled player
- Fixed regression: multi-unit select rectangle was drawn in blue instead of white

Closes #1122

## Test plan
- [ ] TAB+F8: ornithopter spawns at cursor under player 0 by default
- [ ] TAB+1, then TAB+F8: ornithopter spawns at cursor under player 1
- [ ] TAB+F5: clears shroud for the currently controlled player
- [ ] TAB+F4: destroys unit/structure at cursor position for currently controlled player
- [ ] Quit and restart skirmish: controlled player resets to player 0 (human), not the previously viewed player
- [ ] Multi-unit box select rectangle is drawn in white