### PR TITLE
Multi-select rectangle and viewport drag line should pulse/fade like selected units

### DIFF
--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -236,13 +236,13 @@ void cGamePlaying::drawCombatMouse() const
 {
     auto m_mouse = m_interface->getMouse();
     if (m_mouse->isBoxSelecting()) {
-        m_renderDrawer->renderRectColor(m_mouse->getBoxSelectRectangle(), Color::White);
+        m_renderDrawer->renderRectColor(m_mouse->getBoxSelectRectangle(), m_interface->getColorFadeSelected(255, 255, 255));
     }
 
     if (m_mouse->isMapScrolling()) {
         cPoint startPoint = m_mouse->getDragLineStartPoint();
         cPoint endPoint = m_mouse->getDragLineEndPoint();
-        m_renderDrawer->renderLine( startPoint.x, startPoint.y, endPoint.x, endPoint.y, Color{255,255,255,255});
+        m_renderDrawer->renderLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y, m_interface->getColorFadeSelected(255, 255, 255));
     }
     m_mouse->draw();
 


### PR DESCRIPTION
## Summary
- The multi-unit box-select rectangle and the viewport drag line previously had a pulsing white-to-grey animation in v0.7.0
- Both were hardcoded to static white; this restores the fading by reusing the existing `getColorFadeSelected(255, 255, 255)` call
- `cScreenFader::m_fadeSelect` already oscillates between ~31% and 100% brightness on every `thinkFast` tick — no new logic needed

## Test plan
- [ ] Hold left-click and drag to box-select units: rectangle should pulse white ↔ grey
- [ ] Hold right-click to drag/scroll the viewport: the line should pulse white ↔ grey