### PR TITLE
Fix limit mapsize

### DIFF
--- a/src/gamestates/cNewMapEditorState.h
+++ b/src/gamestates/cNewMapEditorState.h
@@ -39,5 +39,5 @@ private:
     GuiTextInput* m_inputDescription = nullptr;
     GuiCycleButton* m_cycleWidth = nullptr;
     GuiCycleButton* m_cycleHeight = nullptr;
-    std::vector<int> m_sizesMap = {16, 24, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 232, 256};
+    std::vector<int> m_sizesMap = {16, 24, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192};
 };


### PR DESCRIPTION
## **Goal**

Limiting card dimensions is necessary to:
- avoid unnecessary CPU stress
- address the current map size being uninspiring.

### Changes
- Max size limit fixed to 192