### PR TITLE
Multi-select box and drag line are more visible

### DIFF
--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -145,7 +145,6 @@ public:
 
     int getMaxVolume();
 
-    Color getColorFadeSelectedLimited(int r, int g, int b, float minFade);
     Color getColorFadeSelectedLimited(Color color, float minFade);
     Color getColorFadeSelected(int r, int g, int b, bool rFlag = true, bool gFlag = true, bool bFlag = true);
 

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -146,6 +146,7 @@ public:
     int getMaxVolume();
 
     Color getColorFadeSelectedLimited(int r, int g, int b, float minFade);
+    Color getColorFadeSelectedLimited(Color color, float minFade);
     Color getColorFadeSelected(int r, int g, int b, bool rFlag = true, bool gFlag = true, bool bFlag = true);
 
     cMouse *getMouse() {

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -145,6 +145,7 @@ public:
 
     int getMaxVolume();
 
+    Color getColorFadeSelectedLimited(int r, int g, int b, float minFade);
     Color getColorFadeSelected(int r, int g, int b, bool rFlag = true, bool gFlag = true, bool bFlag = true);
 
     cMouse *getMouse() {

--- a/src/game/cGameInterface.cpp
+++ b/src/game/cGameInterface.cpp
@@ -189,6 +189,11 @@ Color cGameInterface::getColorFadeSelectedLimited(int r, int g, int b, float min
     return m_game->getColorFadeSelectedLimited(r, g, b, minFade);
 }
 
+Color cGameInterface::getColorFadeSelectedLimited(Color color, float minFade) const
+{
+    return m_game->getColorFadeSelectedLimited(color, minFade);
+}
+
 Color cGameInterface::getColorFadeSelected(int r, int g, int b) const
 {
     return m_game->getColorFadeSelected(r, g, b);

--- a/src/game/cGameInterface.cpp
+++ b/src/game/cGameInterface.cpp
@@ -184,11 +184,6 @@ void cGameInterface::loadScenario() const
     m_game->loadScenario();
 }
 
-Color cGameInterface::getColorFadeSelectedLimited(int r, int g, int b, float minFade) const
-{
-    return m_game->getColorFadeSelectedLimited(r, g, b, minFade);
-}
-
 Color cGameInterface::getColorFadeSelectedLimited(Color color, float minFade) const
 {
     return m_game->getColorFadeSelectedLimited(color, minFade);

--- a/src/game/cGameInterface.cpp
+++ b/src/game/cGameInterface.cpp
@@ -184,6 +184,11 @@ void cGameInterface::loadScenario() const
     m_game->loadScenario();
 }
 
+Color cGameInterface::getColorFadeSelectedLimited(int r, int g, int b, float minFade) const
+{
+    return m_game->getColorFadeSelectedLimited(r, g, b, minFade);
+}
+
 Color cGameInterface::getColorFadeSelected(int r, int g, int b) const
 {
     return m_game->getColorFadeSelected(r, g, b);

--- a/src/game/cGameInterface.h
+++ b/src/game/cGameInterface.h
@@ -56,7 +56,6 @@ public:
 
     void reduceShaking() const;
     void shakeScreen(int duration) const;
-    Color getColorFadeSelectedLimited(int r, int g, int b, float minFade) const;
     Color getColorFadeSelectedLimited(Color color, float minFade) const;
     Color getColorFadeSelected(int r, int g, int b) const;
     void setWinFlags(int value) const;

--- a/src/game/cGameInterface.h
+++ b/src/game/cGameInterface.h
@@ -57,6 +57,7 @@ public:
     void reduceShaking() const;
     void shakeScreen(int duration) const;
     Color getColorFadeSelectedLimited(int r, int g, int b, float minFade) const;
+    Color getColorFadeSelectedLimited(Color color, float minFade) const;
     Color getColorFadeSelected(int r, int g, int b) const;
     void setWinFlags(int value) const;
     void setLoseFlags(int value) const;

--- a/src/game/cGameInterface.h
+++ b/src/game/cGameInterface.h
@@ -56,6 +56,7 @@ public:
 
     void reduceShaking() const;
     void shakeScreen(int duration) const;
+    Color getColorFadeSelectedLimited(int r, int g, int b, float minFade) const;
     Color getColorFadeSelected(int r, int g, int b) const;
     void setWinFlags(int value) const;
     void setLoseFlags(int value) const;

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1266,6 +1266,11 @@ Color cGame::getColorFadeSelectedLimited(int r, int g, int b, float minFade)
     return m_cScreenFader->getColorFadeSelectedLimited(r, g, b, minFade);
 }
 
+Color cGame::getColorFadeSelectedLimited(Color color, float minFade)
+{
+    return m_cScreenFader->getColorFadeSelectedLimited(color, minFade);
+}
+
 Color cGame::getColorFadeSelected(int r, int g, int b, bool rFlag, bool gFlag, bool bFlag)
 {
     return m_cScreenFader->getColorFadeSelected(r,g,b,rFlag,gFlag,bFlag);

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1261,11 +1261,6 @@ void cGame::reduceShaking() const {
 }
 
 
-Color cGame::getColorFadeSelectedLimited(int r, int g, int b, float minFade)
-{
-    return m_cScreenFader->getColorFadeSelectedLimited(r, g, b, minFade);
-}
-
 Color cGame::getColorFadeSelectedLimited(Color color, float minFade)
 {
     return m_cScreenFader->getColorFadeSelectedLimited(color, minFade);

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1261,6 +1261,11 @@ void cGame::reduceShaking() const {
 }
 
 
+Color cGame::getColorFadeSelectedLimited(int r, int g, int b, float minFade)
+{
+    return m_cScreenFader->getColorFadeSelectedLimited(r, g, b, minFade);
+}
+
 Color cGame::getColorFadeSelected(int r, int g, int b, bool rFlag, bool gFlag, bool bFlag)
 {
     return m_cScreenFader->getColorFadeSelected(r,g,b,rFlag,gFlag,bFlag);

--- a/src/game/cScreenFader.cpp
+++ b/src/game/cScreenFader.cpp
@@ -98,6 +98,11 @@ Color cScreenFader::getColorFadeSelectedLimited(int r, int g, int b, float minFa
     return Color{desiredRed, desiredGreen, desiredBlue, 255};
 }
 
+Color cScreenFader::getColorFadeSelectedLimited(Color color, float minFade)
+{
+    return getColorFadeSelectedLimited(color.r, color.g, color.b, minFade);
+}
+
 Color cScreenFader::getColorFadeSelected(int r, int g, int b, bool rFlag, bool gFlag, bool bFlag)
 {
     return getColorFadeSelectedLimited(r, g, b, 0.0f, rFlag, gFlag, bFlag);

--- a/src/game/cScreenFader.cpp
+++ b/src/game/cScreenFader.cpp
@@ -1,6 +1,6 @@
 #include "game/cScreenFader.h"
 #include "utils/Color.hpp"
-// #include <algorithm>
+#include <algorithm>
 
 cScreenFader::cScreenFader() : m_action(eFadeAction::None), m_alpha(0)
 {}
@@ -89,10 +89,16 @@ eFadeAction cScreenFader::getAction() const
     return m_action;
 }
 
+Color cScreenFader::getColorFadeSelectedLimited(int r, int g, int b, float minFade, bool rFlag, bool gFlag, bool bFlag)
+{
+    float fade = std::max(m_fadeSelect, minFade);
+    unsigned char desiredRed = rFlag ? r * fade : r;
+    unsigned char desiredGreen = gFlag ? g * fade : g;
+    unsigned char desiredBlue = bFlag ? b * fade : b;
+    return Color{desiredRed, desiredGreen, desiredBlue, 255};
+}
+
 Color cScreenFader::getColorFadeSelected(int r, int g, int b, bool rFlag, bool gFlag, bool bFlag)
 {
-    unsigned char desiredRed = rFlag ? r * m_fadeSelect : r;
-    unsigned char desiredGreen = gFlag ? g * m_fadeSelect : g;
-    unsigned char desiredBlue = bFlag ? b * m_fadeSelect : b;
-    return Color{desiredRed, desiredGreen, desiredBlue,255};
+    return getColorFadeSelectedLimited(r, g, b, 0.0f, rFlag, gFlag, bFlag);
 }

--- a/src/game/cScreenFader.h
+++ b/src/game/cScreenFader.h
@@ -18,11 +18,11 @@ public:
     eFadeAction getAction() const;
     void inititialize();
 
-    Color getColorFadeSelectedLimited(int r, int g, int b, float minFade, bool rFlag = true, bool gFlag = true, bool bFlag = true);
     Color getColorFadeSelectedLimited(Color color, float minFade);
     Color getColorFadeSelected(int r, int g, int b, bool rFlag = true, bool gFlag = true, bool bFlag = true);
 
 private:
+    Color getColorFadeSelectedLimited(int r, int g, int b, float minFade, bool rFlag = true, bool gFlag = true, bool bFlag = true);
     eFadeAction m_action;
     Uint8 m_alpha;
     float m_fadeSelect;                 // fade color when selected

--- a/src/game/cScreenFader.h
+++ b/src/game/cScreenFader.h
@@ -18,6 +18,7 @@ public:
     eFadeAction getAction() const;
     void inititialize();
 
+    Color getColorFadeSelectedLimited(int r, int g, int b, float minFade, bool rFlag = true, bool gFlag = true, bool bFlag = true);
     Color getColorFadeSelected(int r, int g, int b, bool rFlag = true, bool gFlag = true, bool bFlag = true);
 
 private:

--- a/src/game/cScreenFader.h
+++ b/src/game/cScreenFader.h
@@ -19,6 +19,7 @@ public:
     void inititialize();
 
     Color getColorFadeSelectedLimited(int r, int g, int b, float minFade, bool rFlag = true, bool gFlag = true, bool bFlag = true);
+    Color getColorFadeSelectedLimited(Color color, float minFade);
     Color getColorFadeSelected(int r, int g, int b, bool rFlag = true, bool gFlag = true, bool bFlag = true);
 
 private:

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -308,13 +308,13 @@ void cGamePlaying::drawCombatMouse() const
 {
     auto m_mouse = m_interface->getMouse();
     if (m_mouse->isBoxSelecting()) {
-        m_renderDrawer->renderRectColor(m_mouse->getBoxSelectRectangle(), m_interface->getColorFadeSelectedLimited(255, 255, 255, 0.5f));
+        m_renderDrawer->renderRectColor(m_mouse->getBoxSelectRectangle(), m_interface->getColorFadeSelectedLimited(Color::White, 0.5f));
     }
 
     if (m_mouse->isMapScrolling()) {
         cPoint startPoint = m_mouse->getDragLineStartPoint();
         cPoint endPoint = m_mouse->getDragLineEndPoint();
-        m_renderDrawer->renderLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y, m_interface->getColorFadeSelectedLimited(255, 255, 255, 0.5f));
+        m_renderDrawer->renderLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y, m_interface->getColorFadeSelectedLimited(Color::White, 0.5f));
     }
     m_mouse->draw();
 

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -308,13 +308,13 @@ void cGamePlaying::drawCombatMouse() const
 {
     auto m_mouse = m_interface->getMouse();
     if (m_mouse->isBoxSelecting()) {
-        m_renderDrawer->renderRectColor(m_mouse->getBoxSelectRectangle(), m_interface->getColorFadeSelected(255, 255, 255));
+        m_renderDrawer->renderRectColor(m_mouse->getBoxSelectRectangle(), m_interface->getColorFadeSelectedLimited(255, 255, 255, 0.5f));
     }
 
     if (m_mouse->isMapScrolling()) {
         cPoint startPoint = m_mouse->getDragLineStartPoint();
         cPoint endPoint = m_mouse->getDragLineEndPoint();
-        m_renderDrawer->renderLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y, m_interface->getColorFadeSelected(255, 255, 255));
+        m_renderDrawer->renderLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y, m_interface->getColorFadeSelectedLimited(255, 255, 255, 0.5f));
     }
     m_mouse->draw();
 


### PR DESCRIPTION
## Summary

- The pulsing white multi-select rectangle and viewport drag line could fade as dark as (80,80,80), making them hard to see against terrain (issue #1132)
- Added `getColorFadeSelectedLimited(Color color, float minFade)` to `cScreenFader` (and threaded through `cGame` / `cGameInterface`) which clamps the fade multiplier to a caller-supplied minimum
- `getColorFadeSelected` now delegates to the internal `int r,g,b` implementation (with `minFade = 0.0f`), so the clamping logic lives in one place — no behaviour change for existing callers
- The `int r,g,b` overload is private in `cScreenFader` (internal use only); the public API only exposes the `Color` overload
- `drawCombatMouse` uses `getColorFadeSelectedLimited(Color::White, 0.5f)`: the two visuals now pulse between (128,128,128) and (255,255,255) instead of (80,80,80)–(255,255,255)

## Test plan

- [ ] Build with `./rebuildmacos.sh` — all tests pass
- [ ] Run `./create_release.sh` and launch the game
- [ ] Start a skirmish and drag a multi-select box — the pulsing rectangle should remain clearly visible at its darkest point
- [ ] Hold right-click to scroll the viewport — the drag line should similarly remain visible
- [ ] Confirm selected-unit highlight boxes and sidebar item fading are visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)