### PR TITLE
Harvester will remember where it mined spice and goes back to it when dumped credits at refinery

### DIFF
--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -3982,29 +3982,51 @@ int cUnit::findHarvestSpot(int id)
     cUnit *cUnit = game.m_gameObjectsContext->getUnit(id);
     cUnit->updateCellXAndY();
 
-    // for rememberedHarvestCell first
+    // First attempt: only look around remembered harvest cell (max radius 2),
+    // then fall back to the old global search.
     int rememberedHarvestCell = cUnit->iHarvestCellMemory;
     if (rememberedHarvestCell > -1 &&
-            game.m_gameObjectsContext->getMapGeometry()->isValidCell(rememberedHarvestCell) &&
-            game.m_gameObjectsContext->getMap().getCellCredits(rememberedHarvestCell) > 0) {
+            game.m_gameObjectsContext->getMapGeometry()->isValidCell(rememberedHarvestCell)) {
 
-        int rememberedCellType = game.m_gameObjectsContext->getMap().getCellType(rememberedHarvestCell);
-        if (rememberedCellType == TERRAIN_SPICE || rememberedCellType == TERRAIN_SPICEHILL) {
-            int rememberedDx = game.m_gameObjectsContext->getMapGeometry()->getCellX(rememberedHarvestCell);
-            int rememberedDy = game.m_gameObjectsContext->getMapGeometry()->getCellY(rememberedHarvestCell);
+        auto canUseHarvestCell = [&](int candidateCell) {
+            if (candidateCell < 0) return false;
+            if (!game.m_gameObjectsContext->getMapGeometry()->isValidCell(candidateCell)) return false;
+            if (game.m_gameObjectsContext->getMap().getCellCredits(candidateCell) <= 0) return false;
 
-            if (game.m_gameObjectsContext->getMapGeometry()->isWithinBoundaries(rememberedDx, rememberedDy)) {
-                bool rememberedCellCanBeUsed = true;
+            int cellType = game.m_gameObjectsContext->getMap().getCellType(candidateCell);
+            if (cellType != TERRAIN_SPICE && cellType != TERRAIN_SPICEHILL) return false;
 
-                if (rememberedHarvestCell != cUnit->getCell()) {
-                    int idOfUnitAtRememberedCell = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(rememberedHarvestCell);
-                    if (idOfUnitAtRememberedCell > -1 || game.m_gameObjectsContext->getMap().occupied(rememberedHarvestCell, id)) {
-                        rememberedCellCanBeUsed = false;
-                    }
-                }
+            int candidateDx = game.m_gameObjectsContext->getMapGeometry()->getCellX(candidateCell);
+            int candidateDy = game.m_gameObjectsContext->getMapGeometry()->getCellY(candidateCell);
+            if (!game.m_gameObjectsContext->getMapGeometry()->isWithinBoundaries(candidateDx, candidateDy)) return false;
 
-                if (rememberedCellCanBeUsed) {
-                    return rememberedHarvestCell;
+            if (candidateCell != cUnit->getCell()) {
+                int idOfUnitAtCandidateCell = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(candidateCell);
+                if (idOfUnitAtCandidateCell > -1 || game.m_gameObjectsContext->getMap().occupied(candidateCell, id)) return false;
+            }
+
+            return true;
+        };
+
+        int rememberedDx = game.m_gameObjectsContext->getMapGeometry()->getCellX(rememberedHarvestCell);
+        int rememberedDy = game.m_gameObjectsContext->getMapGeometry()->getCellY(rememberedHarvestCell);
+
+        // Radius 0 checks remembered cell first, then ring 1 and ring 2.
+        for (int searchRadius = 0; searchRadius <= 2; searchRadius++) {
+            for (int dx = -searchRadius; dx <= searchRadius; dx++) {
+                for (int dy = -searchRadius; dy <= searchRadius; dy++) {
+                    if (searchRadius > 0 && std::abs(dx) != searchRadius && std::abs(dy) != searchRadius) continue;
+
+                    int candidateDx = rememberedDx + dx;
+                    int candidateDy = rememberedDy + dy;
+
+                    if (!game.m_gameObjectsContext->getMapGeometry()->isWithinBoundaries(candidateDx, candidateDy)) continue;
+
+                    int candidateCell = game.m_gameObjectsContext->getMapGeometry()->getCellWithMapDimensions(candidateDx, candidateDy);
+                    if (!canUseHarvestCell(candidateCell)) continue;
+
+                    cUnit->iHarvestCellMemory = candidateCell;
+                    return candidateCell;
                 }
             }
         }

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -3817,7 +3817,8 @@ void cUnit::think_harvester()
     if (position.iCell == movement.iGoalCell) {
         int cellType = m_map->getCellType(position.iCell);
         // when on spice, harvest
-        if (cellType == TERRAIN_SPICE ||cellType == TERRAIN_SPICEHILL) {
+        if (cellType == TERRAIN_SPICE || cellType == TERRAIN_SPICEHILL) {
+            iHarvestCellMemory = position.iCell;
             // do timer stuff
             if (iCredits < getUnitInfo().credit_capacity)
                 harvestTimer.increment();
@@ -3990,6 +3991,33 @@ int cUnit::findHarvestSpot(int id)
     int TargetSpiceDistance = 40;
     int TargetSpiceHillDistance = 40;
 
+    int rememberedHarvestCell = cUnit->iHarvestCellMemory;
+    if (rememberedHarvestCell > -1 &&
+            game.m_gameObjectsContext->getMapGeometry()->isValidCell(rememberedHarvestCell) &&
+            game.m_gameObjectsContext->getMap().getCellCredits(rememberedHarvestCell) > 0) {
+
+        int rememberedCellType = game.m_gameObjectsContext->getMap().getCellType(rememberedHarvestCell);
+        if (rememberedCellType == TERRAIN_SPICE || rememberedCellType == TERRAIN_SPICEHILL) {
+            int rememberedDx = game.m_gameObjectsContext->getMapGeometry()->getCellX(rememberedHarvestCell);
+            int rememberedDy = game.m_gameObjectsContext->getMapGeometry()->getCellY(rememberedHarvestCell);
+
+            if (game.m_gameObjectsContext->getMapGeometry()->isWithinBoundaries(rememberedDx, rememberedDy)) {
+                bool rememberedCellCanBeUsed = true;
+
+                if (rememberedHarvestCell != cUnit->getCell()) {
+                    int idOfUnitAtRememberedCell = game.m_gameObjectsContext->getMap().getCellIdUnitLayer(rememberedHarvestCell);
+                    if (idOfUnitAtRememberedCell > -1 || game.m_gameObjectsContext->getMap().occupied(rememberedHarvestCell, id)) {
+                        rememberedCellCanBeUsed = false;
+                    }
+                }
+
+                if (rememberedCellCanBeUsed) {
+                    return rememberedHarvestCell;
+                }
+            }
+        }
+    }
+
 
     for (int i = 0; i < game.m_gameObjectsContext->getMap().getMaxCells(); i++)
         if (game.m_gameObjectsContext->getMap().getCellCredits(i) > 0 && i != cUnit->getCell()) {
@@ -4040,16 +4068,19 @@ int cUnit::findHarvestSpot(int id)
         }
 
     // when distance is greater then 3 (meaning 'far' away)
-    if (TargetSpiceHillDistance >= 3 && TargetSpiceDistance >= 3) {
-        return TargetSpice;
-    }
-    else {
+    int chosenCell = TargetSpice;
+    if (!(TargetSpiceHillDistance >= 3 && TargetSpiceDistance >= 3)) {
         // when both are close, prefer spice hill
-        if (TargetSpiceHill > -1 && (TargetSpiceHillDistance <= TargetSpiceDistance))
-            return TargetSpiceHill;
+        if (TargetSpiceHill > -1 && (TargetSpiceHillDistance <= TargetSpiceDistance)) {
+            chosenCell = TargetSpiceHill;
+        }
     }
 
-    return TargetSpice;
+    if (chosenCell > -1) {
+        cUnit->iHarvestCellMemory = chosenCell;
+    }
+
+    return chosenCell;
 }
 
 int cUnit::carryallFreeForTransfer(int iPlayer)

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -3981,16 +3981,8 @@ int cUnit::findHarvestSpot(int id)
     // finds the closest harvest spot
     cUnit *cUnit = game.m_gameObjectsContext->getUnit(id);
     cUnit->updateCellXAndY();
-    int cx = cUnit->getCellX();
-    int cy = cUnit->getCellY();
 
-    int TargetSpice = -1;
-    int TargetSpiceHill = -1;
-
-    // distances
-    int TargetSpiceDistance = 40;
-    int TargetSpiceHillDistance = 40;
-
+    // for rememberedHarvestCell first
     int rememberedHarvestCell = cUnit->iHarvestCellMemory;
     if (rememberedHarvestCell > -1 &&
             game.m_gameObjectsContext->getMapGeometry()->isValidCell(rememberedHarvestCell) &&
@@ -4018,6 +4010,16 @@ int cUnit::findHarvestSpot(int id)
         }
     }
 
+    // Next attempt: research for new one area
+    int cx = cUnit->getCellX();
+    int cy = cUnit->getCellY();
+
+    int TargetSpice = -1;
+    int TargetSpiceHill = -1;
+
+    // distances
+    int TargetSpiceDistance = 40;
+    int TargetSpiceHillDistance = 40;
 
     for (int i = 0; i < game.m_gameObjectsContext->getMap().getMaxCells(); i++)
         if (game.m_gameObjectsContext->getMap().getCellCredits(i) > 0 && i != cUnit->getCell()) {

--- a/src/gameobjects/units/cUnit.h
+++ b/src/gameobjects/units/cUnit.h
@@ -166,6 +166,7 @@ public:
 
     // Harvester specific
     int iCredits;       // credits stored in this baby
+    int iHarvestCellMemory; // remembers the last spice cell this harvester was working on
 
     // Carry-All specific
     // -1 = none, 0 = new (and stay), 1 = carrying existing unit , 2 = new (and leave)


### PR DESCRIPTION
## **Goal**

Harvester remember last spot for spice.

With this:
- is to reduce (a little)  search duration from spice spot and prepare better optimization
- harvester will extract all spice before changing area