### PR TITLE
Palace super weapons auto-build on palace construction

### DIFF
--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -1697,10 +1697,9 @@ void cPlayer::onNotifyGameEvent(const s_GameEvent &event)
 
         case eGameEventType::GAME_EVENT_LIST_ITEM_ADDED:
         case eGameEventType::GAME_EVENT_LIST_ITEM_CANCELLED:
-        case eGameEventType::GAME_EVENT_SPECIAL_LAUNCH:
-            if (const auto *commonEvent = std::get_if<CommonEvent>(&event.data)) {
-                if (cBuildingListItem::isAutoBuild(commonEvent->entityType, commonEvent->entitySpecificType)) {
-                    startBuilding(commonEvent->entityType, commonEvent->entitySpecificType);
+            if (const auto *buildEvent = std::get_if<BuildingEvent>(&event.data)) {
+                if (buildEvent->player == this && cBuildingListItem::isAutoBuild(buildEvent->entityType, buildEvent->entitySpecificType)) {
+                    startBuilding(buildEvent->entityType, buildEvent->entitySpecificType);
                 }
             }
             break;


### PR DESCRIPTION
## Summary

- `GAME_EVENT_LIST_ITEM_ADDED` and `GAME_EVENT_LIST_ITEM_CANCELLED` carry `BuildingEvent` data, but the auto-build handler in `cPlayer::onNotifyGameEvent` was extracting `CommonEvent` — so `std::get_if` always returned `nullptr` and the palace special never started building automatically.
- Fixed by switching those two cases to extract `BuildingEvent` (with a `player == this` guard so only the owning player triggers the auto-build).
- Removed the now-dead `GAME_EVENT_SPECIAL_LAUNCH` grouping from those cases: post-launch restart is already handled correctly via `GAME_EVENT_LIST_ITEM_FINISHED` inside `onEventSpecialLaunch`.

## Root cause

The `autoBuild` flag on specials (DeathHand, Fremen, Saboteur) is intended to make the palace automatically start building its weapon as soon as it is placed. The trigger fires via `GAME_EVENT_LIST_ITEM_ADDED`, but at some point the event was refactored from `CommonEvent` to `BuildingEvent` and this handler was not updated.

## Test plan

- [ ] Play a skirmish as Harkonnen/Sardaukar — DeathHand should start building automatically once a Palace is placed (no manual click needed)
- [ ] Play a skirmish as Atreides — Fremen should start building automatically
- [ ] Play a skirmish as Ordos — Saboteur should start building automatically
- [ ] Verify AI players also auto-build (all three super weapons)
- [ ] Verify the weapon rebuilds automatically after each use

Fixes #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)