### PR TITLE
Debug player switch ignores inactive players

### DIFF
--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -481,29 +481,34 @@ void cGamePlaying::onKeyPressedGamePlaying(const cKeyboardEvent &event)
     }
 }
 
+void cGamePlaying::tryDebugSwitchToPlayer(int playerIndex)
+{
+    cPlayer *targetPlayer = m_objects->getPlayer(playerIndex);
+    if (targetPlayer->getHouse() == GENERALHOUSE || !targetPlayer->isAlive()) {
+        m_controlledPlayer->addNotification(
+            std::format("Player {} is not active.", playerIndex), eNotificationType::NEUTRAL);
+        return;
+    }
+    m_controlledPlayer = targetPlayer;
+    m_drawManager->setPlayerToDraw(m_controlledPlayer);
+    m_interface->setPlayerToInteractFor(m_controlledPlayer);
+}
+
 void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
 {
     const cPlayer *humanPlayer = m_objects->getPlayer(HUMAN);
 
     if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_0)) {
-        m_controlledPlayer = m_objects->getPlayer(0);
-        m_drawManager->setPlayerToDraw(m_controlledPlayer);
-        m_interface->setPlayerToInteractFor(m_controlledPlayer);
+        tryDebugSwitchToPlayer(0);
     }
     else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_1)) {
-        m_controlledPlayer = m_objects->getPlayer(1);
-        m_drawManager->setPlayerToDraw(m_controlledPlayer);
-        m_interface->setPlayerToInteractFor(m_controlledPlayer);
+        tryDebugSwitchToPlayer(1);
     }
     else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_2)) {
-        m_controlledPlayer = m_objects->getPlayer(2);
-        m_drawManager->setPlayerToDraw(m_controlledPlayer);
-        m_interface->setPlayerToInteractFor(m_controlledPlayer);
+        tryDebugSwitchToPlayer(2);
     }
     else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_3)) {
-        m_controlledPlayer = m_objects->getPlayer(3);
-        m_drawManager->setPlayerToDraw(m_controlledPlayer);
-        m_interface->setPlayerToInteractFor(m_controlledPlayer);
+        tryDebugSwitchToPlayer(3);
     }
 
     if (event.isAction(eKeyAction::DEBUG_WIN)) {

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -347,6 +347,10 @@ void cGamePlaying::onKeyDownGamePlaying(const cKeyboardEvent &event)
     }
 
     if (m_settings->isDebugMode()) { // debug mode has additional keys
+        if (event.hasKey(SDL_SCANCODE_TAB)) {
+            onKeyDownDebugMode(event);
+        }
+
         if (event.isAction(eKeyAction::DEBUG_CLEAR_SHROUD_AT_CURSOR)) {
             int mouseCell = humanPlayer->getGameControlsContext()->getMouseCell();
             if (mouseCell > -1) {
@@ -424,10 +428,6 @@ void cGamePlaying::onKeyPressedGamePlaying(const cKeyboardEvent &event)
         }
     }
 
-    if (m_settings->isDebugMode() && event.hasKey(SDL_SCANCODE_TAB)) {
-        onKeyDownDebugMode(event);
-    }
-
     if (event.isAction(eKeyAction::TOGGLE_FPS)) {
         m_settings->setDrawFps(false);
     }
@@ -498,17 +498,20 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
 {
     const cPlayer *humanPlayer = m_objects->getPlayer(HUMAN);
 
-    if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_0)) {
-        tryDebugSwitchToPlayer(0);
-    }
-    else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_1)) {
-        tryDebugSwitchToPlayer(1);
-    }
-    else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_2)) {
-        tryDebugSwitchToPlayer(2);
-    }
-    else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_3)) {
-        tryDebugSwitchToPlayer(3);
+    eKeyAction switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_0; // placeholder
+    int switchTarget = -1;
+    if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_0))      { switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_0; switchTarget = 0; }
+    else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_1)) { switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_1; switchTarget = 1; }
+    else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_2)) { switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_2; switchTarget = 2; }
+    else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_3)) { switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_3; switchTarget = 3; }
+
+    if (switchTarget >= 0) {
+        if (!m_lastDebugSwitchAction || *m_lastDebugSwitchAction != switchAction) {
+            m_lastDebugSwitchAction = switchAction;
+            tryDebugSwitchToPlayer(switchTarget);
+        }
+    } else {
+        m_lastDebugSwitchAction.reset(); // no switch key held: allow next press
     }
 
     if (event.isAction(eKeyAction::DEBUG_WIN)) {

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -500,10 +500,19 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
 
     eKeyAction switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_0; // placeholder
     int switchTarget = -1;
-    if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_0))      { switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_0; switchTarget = 0; }
-    else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_1)) { switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_1; switchTarget = 1; }
-    else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_2)) { switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_2; switchTarget = 2; }
-    else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_3)) { switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_3; switchTarget = 3; }
+    if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_0)) {
+        switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_0;
+        switchTarget = 0;
+    } else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_1)) {
+        switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_1;
+        switchTarget = 1;
+    } else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_2)) {
+        switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_2;
+        switchTarget = 2;
+    } else if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_3)) {
+        switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_3;
+        switchTarget = 3;
+    }
 
     if (switchTarget >= 0) {
         if (!m_lastDebugSwitchAction || *m_lastDebugSwitchAction != switchAction) {

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -347,10 +347,6 @@ void cGamePlaying::onKeyDownGamePlaying(const cKeyboardEvent &event)
     }
 
     if (m_settings->isDebugMode()) { // debug mode has additional keys
-        if (event.hasKey(SDL_SCANCODE_TAB)) {
-            onKeyDownDebugMode(event);
-        }
-
         if (event.isAction(eKeyAction::DEBUG_CLEAR_SHROUD_AT_CURSOR)) {
             int mouseCell = humanPlayer->getGameControlsContext()->getMouseCell();
             if (mouseCell > -1) {
@@ -426,6 +422,10 @@ void cGamePlaying::onKeyPressedGamePlaying(const cKeyboardEvent &event)
                 centerCameraOnUnits(unitIds);
             }
         }
+    }
+
+    if (m_settings->isDebugMode() && event.hasKey(SDL_SCANCODE_TAB)) {
+        onKeyDownDebugMode(event);
     }
 
     if (event.isAction(eKeyAction::TOGGLE_FPS)) {

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -498,7 +498,7 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
 {
     const cPlayer *humanPlayer = m_objects->getPlayer(HUMAN);
 
-    eKeyAction switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_0; // placeholder
+    eKeyAction switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_0;
     int switchTarget = -1;
     if (event.isAction(eKeyAction::DEBUG_SWITCH_PLAYER_0)) {
         switchAction = eKeyAction::DEBUG_SWITCH_PLAYER_0;
@@ -515,7 +515,7 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
     }
 
     if (switchTarget >= 0) {
-        if (!m_lastDebugSwitchAction || *m_lastDebugSwitchAction != switchAction) {
+        if (!m_lastDebugSwitchAction || m_lastDebugSwitchAction != switchAction) {
             m_lastDebugSwitchAction = switchAction;
             tryDebugSwitchToPlayer(switchTarget);
         }

--- a/src/gamestates/cGamePlaying.h
+++ b/src/gamestates/cGamePlaying.h
@@ -52,6 +52,7 @@ private:
     void onKeyDownGamePlaying(const cKeyboardEvent &event);
     void onKeyPressedGamePlaying(const cKeyboardEvent &event);
     void onKeyDownDebugMode(const cKeyboardEvent &event);
+    void tryDebugSwitchToPlayer(int playerIndex);
 
     void centerCameraOnUnits(const std::vector<int>& unitIds);
     void drawTrackingOverlays() const;

--- a/src/gamestates/cGamePlaying.h
+++ b/src/gamestates/cGamePlaying.h
@@ -2,7 +2,9 @@
 
 #include "cGameState.h"
 #include "controls/cKeyboardEvent.h"
+#include "controls/eKeyAction.h"
 #include "sMouseEvent.h"
+#include <optional>
 #include <vector>
 #include <SDL2/SDL.h>
 
@@ -60,4 +62,5 @@ private:
     std::vector<int> m_trackedUnitIds;
     int m_lastGroupKeyPressed = 0;
     Uint32 m_lastGroupKeyPressedTick = 0;
+    std::optional<eKeyAction> m_lastDebugSwitchAction;
 };


### PR DESCRIPTION
## Summary

- Before switching the controlled player via TAB-N in debug mode, check that the target player has been assigned a real house (not \`GENERALHOUSE\`) and is still alive
- If the player is not active, add a notification to the current controlled player's notification queue and keep the current controlled player
- Refactored the four duplicate switch blocks into a shared \`tryDebugSwitchToPlayer(int)\` helper
- Added debounce: \`HOLD\` events fire every ~5ms while keys are held; the fix tracks the last processed switch action and skips re-processing the same combo until the number key is released (no switch action matches while only TAB is held). This prevents the notification and switch from firing on every game tick.

Fixes #1146

## Screenshot
<img width="182" height="116" alt="image" src="https://github.com/user-attachments/assets/5c9b78a1-8732-4793-a85f-d2671107c0cc" />


## Test plan

- [ ] Start a 2-player skirmish in debug mode
- [ ] Press TAB-0 and TAB-1: should switch to those players, fires only once per key press
- [ ] Press TAB-2 and TAB-3: should show "Player X is not active." notification exactly once per press and NOT switch
- [ ] Hold TAB, tap 1, release 1, tap 1 again: should switch/notify twice (not skipped on second press)
- [ ] Verify ornithopter/thopter spawning no longer causes crashes from issue #1143 after this fix