### PR TITLE
Disabled buttons are grayed out regardless of hover state

### DIFF
--- a/src/gui/GuiButton.cpp
+++ b/src/gui/GuiButton.cpp
@@ -89,7 +89,7 @@ void GuiButton::drawText() const
 {
     Color textColor = m_focus ? m_theme.textColorHover : m_theme.textColor;
     if (!m_enabled) {
-        textColor = m_focus ? m_theme.borderDark : m_theme.borderLight;
+        textColor = m_theme.disabled;
     }
 
     switch (m_textAlignHorizontal) {


### PR DESCRIPTION
## Summary

- `GuiButton::drawText()` was using `borderLight` (near-white) as the disabled text color when the button was not hovered, making disabled buttons look identical to enabled ones
- Replaced the hover-dependent disabled color logic with a single `theme.disabled` color (gray: 128, 128, 128), which is already defined in all themes for exactly this purpose
- As a result, the START button on the Skirmish setup screen is visibly grayed out from the moment the screen opens, until a map is selected

## Screenshot

<img width="308" height="169" alt="image" src="https://github.com/user-attachments/assets/11d9c06c-da45-40b4-8633-be9a7a699021" />


## Test plan

- [ ] Open the Skirmish setup screen - START button should appear grayed out immediately
- [ ] Select a map - START button should become white/normal
- [ ] Deselect or check with no map - START button should return to grayed out
- [ ] Verify hovering a disabled button still renders correctly (gray, not red)
- [ ] Verify enabled buttons still highlight red on hover as before

Closes #1102