### PR TITLE
Skirmish has a 'Surprise me' button that randomly starts a game

### DIFF
--- a/src/drawers/SDLDrawer.cpp
+++ b/src/drawers/SDLDrawer.cpp
@@ -157,7 +157,6 @@ void SDLDrawer::gui_DrawRectBorder(const cRectangle &rectangle, Color gui_colorB
     int y1 = rectangle.getY();
     int width = rectangle.getWidth();
     int height = rectangle.getHeight();
-    //std::cout <<":" << x1 << " " << y1 << " " << width << " " << height << std::endl;
     SDL_Rect tmp = {x1,y1,width,height};
     renderChangeColor(gui_colorBorderLight);
     SDL_RenderDrawRect(renderer, &tmp);

--- a/src/drawers/SDLDrawer.cpp
+++ b/src/drawers/SDLDrawer.cpp
@@ -145,10 +145,13 @@ void SDLDrawer::gui_DrawRect(const cRectangle &rectangle, Color gui_colorWindow,
     SDL_RenderDrawRect(renderer, &tmp );
 
     // lines to darken the right sides
+    int endX = (x1+width) - 1;
+    int endY = (y1+height) - 1;
+
     renderChangeColor(gui_colorBorderDark);
-    SDL_RenderDrawLine(renderer, x1+width, y1, x1+width, y1+height);
+    SDL_RenderDrawLine(renderer, endX, y1, endX, endY);
     renderChangeColor(gui_colorBorderDark);
-    SDL_RenderDrawLine(renderer, x1, y1+height, x1+width, y1+height);
+    SDL_RenderDrawLine(renderer, x1, endY, endX, endY);
 }
 
 void SDLDrawer::gui_DrawRectBorder(const cRectangle &rectangle, Color gui_colorBorderLight, Color gui_colorBorderDark)
@@ -161,9 +164,12 @@ void SDLDrawer::gui_DrawRectBorder(const cRectangle &rectangle, Color gui_colorB
     renderChangeColor(gui_colorBorderLight);
     SDL_RenderDrawRect(renderer, &tmp);
     renderChangeColor(gui_colorBorderDark);
-    SDL_RenderDrawLine(renderer, x1+width, y1, x1+width, y1+height);
+
+    int endX = (x1+width) - 1;
+    int endY = (y1+height) - 1;
+    SDL_RenderDrawLine(renderer, endX, y1, endX, endY);
     renderChangeColor(gui_colorBorderDark);
-    SDL_RenderDrawLine(renderer, x1, y1+height, x1+width, y1+height);
+    SDL_RenderDrawLine(renderer, x1, endY, endX, endY);
 }
 
 void SDLDrawer::renderClearToColor(Color color)

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -282,7 +282,7 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
     int modifyButtonX = screen_x - startButtonWidth-modifyButtonWidth - 35;
     cRectangle modifyButtonRect = cRectangle(modifyButtonX, modifyButtonY, modifyButtonWidth, modifyButtonHeight);
     modifyButton = GuiButtonBuilder()
-            .withRect(modifyButtonRect)        
+            .withRect(modifyButtonRect)
             .withLabel("Modify")
             .withTextDrawer(m_textDrawer)
             .withRenderer(m_renderDrawer)
@@ -295,7 +295,22 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
                 }
             })
             .build();
-    
+
+    // Surprise me button (bottom right, left of Modify)
+    int surpriseMeButtonWidth = m_textDrawer->getTextLength("Surprise me");
+    int surpriseMeButtonY = screen_y - topBarHeight;
+    int surpriseMeButtonX = modifyButtonX - surpriseMeButtonWidth - 15;
+    cRectangle surpriseMeButtonRect = cRectangle(surpriseMeButtonX, surpriseMeButtonY, surpriseMeButtonWidth, topBarHeight);
+    surpriseMeButton = GuiButtonBuilder()
+            .withRect(surpriseMeButtonRect)
+            .withLabel("Surprise me")
+            .withTextDrawer(m_textDrawer)
+            .withRenderer(m_renderDrawer)
+            .withTheme(theme)
+            .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
+            .onClick([this]() { surpriseMe(); })
+            .build();
+
     // Create new map button (bottom right, only visible when random map is selected)
     int newMapButtonWidth = m_textDrawer->getTextLength("Create New Map");
     int newMapButtonHeight = topBarHeight;
@@ -303,7 +318,7 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
     int newMapButtonX = screen_x - startButtonWidth - newMapButtonWidth - modifyButtonWidth - 70;
     cRectangle newMapButtonRect = cRectangle(newMapButtonX, newMapButtonY, newMapButtonWidth, newMapButtonHeight);
     newMapButton = GuiButtonBuilder()
-            .withRect(newMapButtonRect)        
+            .withRect(newMapButtonRect)
             .withLabel("New Map")
             .withTextDrawer(m_textDrawer)
             .withRenderer(m_renderDrawer)
@@ -432,6 +447,7 @@ void cSetupSkirmishState::draw() const
     startButton->draw();
     modifyButton->draw();
     newMapButton->draw();
+    surpriseMeButton->draw();
     nextMapButton->draw();
     previousMapButton->draw();
 
@@ -912,6 +928,7 @@ void cSetupSkirmishState::onNotifyMouseEvent(const s_MouseEvent &event)
     startButton->onNotifyMouseEvent(event);
     modifyButton->onNotifyMouseEvent(event);
     newMapButton->onNotifyMouseEvent(event);
+    surpriseMeButton->onNotifyMouseEvent(event);
     nextMapButton->onNotifyMouseEvent(event);
     previousMapButton->onNotifyMouseEvent(event);
 }
@@ -1171,6 +1188,48 @@ void cSetupSkirmishState::onMouseLeftButtonClickedAtMapList(const cRectangle &se
             iDrawY += mapItemButtonHeight + 15;
         }
     }
+}
+
+void cSetupSkirmishState::surpriseMe()
+{
+    // Collect valid map indices
+    int mapCount = m_previewMaps->getMapCount();
+    std::vector<int> validIndices;
+    for (int i = 0; i < mapCount; i++) {
+        if (m_previewMaps->getMap(i).validMap) {
+            validIndices.push_back(i);
+        }
+    }
+    if (validIndices.empty()) {
+        return;
+    }
+
+    iSkirmishMap = validIndices[RNG::rnd(validIndices.size())];
+
+    if (iSkirmishMap == 0) {
+        iStartingPoints = 2 + RNG::rnd(3); // 2 to 4
+        generateRandomMap();
+    }
+    else {
+        auto &selectedMap = m_previewMaps->getMap(iSkirmishMap);
+        int maxPlayers = 0;
+        for (int s : selectedMap.iStartCell) {
+            if (s > -1) {
+                maxPlayers++;
+            }
+        }
+        iStartingPoints = 2 + RNG::rnd(maxPlayers - 1); // 2 to maxPlayers
+    }
+
+    for (int p = 0; p < (AI_WORM - 1); p++) {
+        s_SkirmishPlayer &player = skirmishPlayer[p];
+        player.bPlaying = (p < iStartingPoints);
+        player.iHouse = 0;
+        player.iCredits = 1000 + RNG::rnd(19) * 500;
+    }
+    skirmishPlayer[HUMAN].bPlaying = true;
+
+    prepareSkirmishGameToPlayAndTransitionToCombatState(iSkirmishMap);
 }
 
 void cSetupSkirmishState::generateRandomMap()

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -92,12 +92,12 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
     colorDarkishBackground = theme.background;
     colorDarkishBorder = theme.borderLight;
     colorDarkerYellow = theme.textDarkColor;
-    colorDisabled = theme.disabled;
+    colorDisabled = theme.disabledTextColor;
     colorLightBackground = theme.fillColor;
     colorOtherBorder = theme.borderDark;
 
     // Basic coordinates
-    topBarHeight = 21;
+    topBarHeight = 25;
     previewMapHeight = 129;
     previewMapWidth = 129;
     widthOfRightColumn = 300;
@@ -157,10 +157,12 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
 
     // actual list of maps
     int mapListTopY = mapListTitle.getY() + mapListTitle.getHeight();
-    int previewMapY = playerListBarY + playerListBarHeight+previewMapFrameHeight;
-    int previewMapX = screen_x - widthOfSidebar;
-    previewMap = cRectangle(previewMapX, previewMapY, widthOfRightColumn, widthOfRightColumn+65);
-    previewMapRect = cRectangle(previewMapX+25, previewMapY+25, widthOfRightColumn-50, widthOfRightColumn-50);
+
+    int previewMapY = playerListBarY + playerListBarHeight + previewMapFrameHeight;
+    int previewMapX = (screen_x - widthOfSidebar) + 1;
+    int heightOfRightColumn = screen_y - (playerListBarHeight + previewMapFrameHeight);
+    previewMap = cRectangle(previewMapX, previewMapY, widthOfRightColumn, heightOfRightColumn);
+    previewMapRect = cRectangle(previewMap.getX()+23, previewMap.getY()+23, 256, 256);
 
     selectArea = cRectangle(0, mapListTopY, screen_x -widthOfRightColumn-2, screen_y-topBarHeight-mapListTopY);
     int margin = 10;
@@ -238,37 +240,40 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
     int techLevelHitBoxHeight = 16;
     techLevelRect = cRectangle(techLevelX, techLevelY, techLevelHitBoxWidth, techLevelHitBoxHeight);
 
-    int backButtonWidth = m_textDrawer->getTextLength(" Back");
-    int backButtonHeight = topBarHeight;
-    int backButtonY = screen_y - topBarHeight;
+    const int btnHPad = 8;
+    const int btnVPad = 2;
+    const int btnHeight = topBarHeight - (btnVPad * 2);
+
+    int backButtonWidth = m_textDrawer->getTextLength("Back") + btnHPad;
+    int backButtonY = screen_y - topBarHeight + btnVPad;
     int backButtonX = 0;
-    cRectangle backButtonRect(backButtonX, backButtonY, backButtonWidth, backButtonHeight);
+    cRectangle backButtonRect(backButtonX, backButtonY, backButtonWidth, btnHeight);
     backButton = GuiButtonBuilder()
-            .withRect(backButtonRect)        
+            .withRect(backButtonRect)
             .withLabel("Back")
             .withTextDrawer(m_textDrawer)
             .withRenderer(m_renderDrawer)
             .withTheme(theme)
-            .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
+            .withKind(GuiRenderKind::OPAQUE_WITH_BORDER)
             .onClick([this]() {
                 m_interface->setTransitionToWithFadingOut(GAME_MENU);
             })
             .build();
 
     const int btnGap = 15;
-    const int bottomY = screen_y - topBarHeight;
+    const int bottomY = screen_y - topBarHeight + btnVPad;
 
     // Right group: [Surprise me] [START]
-    int startButtonWidth = m_textDrawer->getTextLength("Start");
+    int startButtonWidth = m_textDrawer->getTextLength("Start") + btnHPad;
     int startButtonX = screen_x - startButtonWidth;
-    cRectangle startButtonRect = cRectangle(startButtonX, bottomY, startButtonWidth, topBarHeight);
+    cRectangle startButtonRect = cRectangle(startButtonX, bottomY, startButtonWidth, btnHeight);
     startButton = GuiButtonBuilder()
             .withRect(startButtonRect)
             .withLabel("Start")
             .withTextDrawer(m_textDrawer)
             .withRenderer(m_renderDrawer)
             .withTheme(theme)
-            .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
+            .withKind(GuiRenderKind::OPAQUE_WITH_BORDER)
             .onClick([this]() {
                 if (iSkirmishMap > -1) {
                     prepareSkirmishGameToPlayAndTransitionToCombatState(iSkirmishMap);
@@ -276,46 +281,46 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
             })
             .build();
 
-    int surpriseMeButtonWidth = m_textDrawer->getTextLength("Surprise me");
+    int surpriseMeButtonWidth = m_textDrawer->getTextLength("Surprise me") + btnHPad;
     int surpriseMeButtonX = startButtonX - btnGap - surpriseMeButtonWidth;
-    cRectangle surpriseMeButtonRect = cRectangle(surpriseMeButtonX, bottomY, surpriseMeButtonWidth, topBarHeight);
+    cRectangle surpriseMeButtonRect = cRectangle(surpriseMeButtonX, bottomY, surpriseMeButtonWidth, btnHeight);
     surpriseMeButton = GuiButtonBuilder()
             .withRect(surpriseMeButtonRect)
             .withLabel("Surprise me")
             .withTextDrawer(m_textDrawer)
             .withRenderer(m_renderDrawer)
             .withTheme(theme)
-            .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
+            .withKind(GuiRenderKind::OPAQUE_WITH_BORDER)
             .onClick([this]() { surpriseMe(); })
             .build();
 
     // Center group: [New Map] [Modify]
-    int newMapButtonWidth = m_textDrawer->getTextLength("New Map");
-    int modifyButtonWidth = m_textDrawer->getTextLength("Modify");
+    int newMapButtonWidth = m_textDrawer->getTextLength("New Map") + btnHPad;
+    int modifyButtonWidth = m_textDrawer->getTextLength("Modify") + btnHPad;
     int centerGroupWidth = newMapButtonWidth + btnGap + modifyButtonWidth;
     int centerGroupX = screen_x / 2 - centerGroupWidth / 2;
-    cRectangle newMapButtonRect = cRectangle(centerGroupX, bottomY, newMapButtonWidth, topBarHeight);
+    cRectangle newMapButtonRect = cRectangle(centerGroupX, bottomY, newMapButtonWidth, btnHeight);
     newMapButton = GuiButtonBuilder()
             .withRect(newMapButtonRect)
             .withLabel("New Map")
             .withTextDrawer(m_textDrawer)
             .withRenderer(m_renderDrawer)
             .withTheme(theme)
-            .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
+            .withKind(GuiRenderKind::OPAQUE_WITH_BORDER)
             .onClick([this]() {
                 m_interface->setTransitionToWithFadingOut(GAME_NEW_MAP_EDITOR);
             })
             .build();
 
     int modifyButtonX = centerGroupX + newMapButtonWidth + btnGap;
-    cRectangle modifyButtonRect = cRectangle(modifyButtonX, bottomY, modifyButtonWidth, topBarHeight);
+    cRectangle modifyButtonRect = cRectangle(modifyButtonX, bottomY, modifyButtonWidth, btnHeight);
     modifyButton = GuiButtonBuilder()
             .withRect(modifyButtonRect)
             .withLabel("Modify")
             .withTextDrawer(m_textDrawer)
             .withRenderer(m_renderDrawer)
             .withTheme(theme)
-            .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
+            .withKind(GuiRenderKind::OPAQUE_WITH_BORDER)
             .onClick([this]() {
                 if (iSkirmishMap > -1) {
                     m_interface->loadMapFromEditor(iSkirmishMap);
@@ -355,20 +360,29 @@ void cSetupSkirmishState::thinkFast()
 
 void cSetupSkirmishState::draw() const
 {
-    // @Mira rewrite it on Texture
+    // Draw top-bar / title-bar
     m_renderDrawer->gui_DrawRect(topBar, colorLightBackground, colorDarkishBorder, colorOtherBorder);
-
     m_textDrawer->drawTextCentered("Skirmish", 1);
 
+    // Draw Players/House/Credits/Units/Team rectangle
     m_renderDrawer->gui_DrawRect(playerTitleBar, colorDarkishBackground, Color::White, Color::White);
-    m_renderDrawer->gui_DrawRect(topRightBox, colorLightBackground, colorDarkishBorder, colorOtherBorder);
+    // Draw rectangle for the actual players (beneath playerTitleBar)
     m_renderDrawer->gui_DrawRect(playerList, colorDarkishBackground, Color::White, Color::White);
-    m_renderDrawer->gui_DrawRect(mapListTitle, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);
 
+    // Draw top-right rectangle for "Startpoints"
+    m_renderDrawer->gui_DrawRect(topRightBox, colorLightBackground, colorDarkishBorder, colorOtherBorder);
+
+    // Draw "Maps" (yellow title), rectangle
+    m_renderDrawer->gui_DrawRect(mapListTitle, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);
     m_textDrawer->drawTextCentered("Maps", mapListTitle.getX(), mapListTitle.getWidth(), mapListTitle.getY() + 4, Color::Yellow);
+
+    // Draw "Preview" bar + title (right to "Maps")
     m_renderDrawer->gui_DrawRect(previewMapTitle, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);    //renderDrawer->gui_DrawRect(previewMap, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);      
     m_textDrawer->drawTextCentered("Preview", previewMapTitle.getX(), previewMapTitle.getWidth(), previewMapTitle.getY() + 4, Color::Yellow);
+
+    // Draw the right bar where we render the map selected + any information
     m_renderDrawer->gui_DrawRect(previewMap, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);
+
     m_renderDrawer->gui_DrawRect(selectArea, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);
     ///////
     /// DRAW PREVIEW MAP

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -255,14 +255,15 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
             })
             .build();
 
-    // Start skirmish mission (bottom right)
+    const int btnGap = 15;
+    const int bottomY = screen_y - topBarHeight;
+
+    // Right group: [Surprise me] [START]
     int startButtonWidth = m_textDrawer->getTextLength("START");
-    int startButtonHeight = topBarHeight;
-    int startButtonY = screen_y - topBarHeight;
     int startButtonX = screen_x - startButtonWidth;
-    cRectangle startButtonRect = cRectangle(startButtonX, startButtonY, startButtonWidth, startButtonHeight);
+    cRectangle startButtonRect = cRectangle(startButtonX, bottomY, startButtonWidth, topBarHeight);
     startButton = GuiButtonBuilder()
-            .withRect(startButtonRect)        
+            .withRect(startButtonRect)
             .withLabel("START")
             .withTextDrawer(m_textDrawer)
             .withRenderer(m_renderDrawer)
@@ -275,12 +276,39 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
             })
             .build();
 
-    // Modifiymap mission (bottom right)
+    int surpriseMeButtonWidth = m_textDrawer->getTextLength("Surprise me");
+    int surpriseMeButtonX = startButtonX - btnGap - surpriseMeButtonWidth;
+    cRectangle surpriseMeButtonRect = cRectangle(surpriseMeButtonX, bottomY, surpriseMeButtonWidth, topBarHeight);
+    surpriseMeButton = GuiButtonBuilder()
+            .withRect(surpriseMeButtonRect)
+            .withLabel("Surprise me")
+            .withTextDrawer(m_textDrawer)
+            .withRenderer(m_renderDrawer)
+            .withTheme(theme)
+            .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
+            .onClick([this]() { surpriseMe(); })
+            .build();
+
+    // Center group: [New Map] [Modify]
+    int newMapButtonWidth = m_textDrawer->getTextLength("New Map");
     int modifyButtonWidth = m_textDrawer->getTextLength("Modify");
-    int modifyButtonHeight = topBarHeight;
-    int modifyButtonY = screen_y - topBarHeight;
-    int modifyButtonX = screen_x - startButtonWidth-modifyButtonWidth - 35;
-    cRectangle modifyButtonRect = cRectangle(modifyButtonX, modifyButtonY, modifyButtonWidth, modifyButtonHeight);
+    int centerGroupWidth = newMapButtonWidth + btnGap + modifyButtonWidth;
+    int centerGroupX = screen_x / 2 - centerGroupWidth / 2;
+    cRectangle newMapButtonRect = cRectangle(centerGroupX, bottomY, newMapButtonWidth, topBarHeight);
+    newMapButton = GuiButtonBuilder()
+            .withRect(newMapButtonRect)
+            .withLabel("New Map")
+            .withTextDrawer(m_textDrawer)
+            .withRenderer(m_renderDrawer)
+            .withTheme(theme)
+            .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
+            .onClick([this]() {
+                m_interface->setTransitionToWithFadingOut(GAME_NEW_MAP_EDITOR);
+            })
+            .build();
+
+    int modifyButtonX = centerGroupX + newMapButtonWidth + btnGap;
+    cRectangle modifyButtonRect = cRectangle(modifyButtonX, bottomY, modifyButtonWidth, topBarHeight);
     modifyButton = GuiButtonBuilder()
             .withRect(modifyButtonRect)
             .withLabel("Modify")
@@ -293,39 +321,6 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
                     m_interface->loadMapFromEditor(iSkirmishMap);
                     m_interface->initiateFadingOut();
                 }
-            })
-            .build();
-
-    // Surprise me button (bottom right, left of Modify)
-    int surpriseMeButtonWidth = m_textDrawer->getTextLength("Surprise me");
-    int surpriseMeButtonY = screen_y - topBarHeight;
-    int surpriseMeButtonX = modifyButtonX - surpriseMeButtonWidth - 15;
-    cRectangle surpriseMeButtonRect = cRectangle(surpriseMeButtonX, surpriseMeButtonY, surpriseMeButtonWidth, topBarHeight);
-    surpriseMeButton = GuiButtonBuilder()
-            .withRect(surpriseMeButtonRect)
-            .withLabel("Surprise me")
-            .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
-            .withTheme(theme)
-            .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
-            .onClick([this]() { surpriseMe(); })
-            .build();
-
-    // Create new map button (bottom right, only visible when random map is selected)
-    int newMapButtonWidth = m_textDrawer->getTextLength("Create New Map");
-    int newMapButtonHeight = topBarHeight;
-    int newMapButtonY = screen_y - topBarHeight;
-    int newMapButtonX = screen_x - startButtonWidth - newMapButtonWidth - modifyButtonWidth - 70;
-    cRectangle newMapButtonRect = cRectangle(newMapButtonX, newMapButtonY, newMapButtonWidth, newMapButtonHeight);
-    newMapButton = GuiButtonBuilder()
-            .withRect(newMapButtonRect)
-            .withLabel("New Map")
-            .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
-            .withTheme(theme)
-            .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
-            .onClick([this]() {
-                m_interface->setTransitionToWithFadingOut(GAME_NEW_MAP_EDITOR);
             })
             .build();
 }
@@ -1196,7 +1191,7 @@ void cSetupSkirmishState::surpriseMe()
     int mapCount = m_previewMaps->getMapCount();
     std::vector<int> validIndices;
     for (int i = 0; i < mapCount; i++) {
-        if (m_previewMaps->getMap(i).validMap) {
+        if (m_previewMaps->getMap(i)->validMap) {
             validIndices.push_back(i);
         }
     }
@@ -1211,9 +1206,9 @@ void cSetupSkirmishState::surpriseMe()
         generateRandomMap();
     }
     else {
-        auto &selectedMap = m_previewMaps->getMap(iSkirmishMap);
+        auto *selectedMap = m_previewMaps->getMap(iSkirmishMap);
         int maxPlayers = 0;
-        for (int s : selectedMap.iStartCell) {
+        for (int s : selectedMap->iStartCell) {
             if (s > -1) {
                 maxPlayers++;
             }

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -238,14 +238,14 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
     int techLevelHitBoxHeight = 16;
     techLevelRect = cRectangle(techLevelX, techLevelY, techLevelHitBoxWidth, techLevelHitBoxHeight);
 
-    int backButtonWidth = m_textDrawer->getTextLength(" BACK");
+    int backButtonWidth = m_textDrawer->getTextLength(" Back");
     int backButtonHeight = topBarHeight;
     int backButtonY = screen_y - topBarHeight;
     int backButtonX = 0;
     cRectangle backButtonRect(backButtonX, backButtonY, backButtonWidth, backButtonHeight);
     backButton = GuiButtonBuilder()
             .withRect(backButtonRect)        
-            .withLabel("BACK")
+            .withLabel("Back")
             .withTextDrawer(m_textDrawer)
             .withRenderer(m_renderDrawer)
             .withTheme(theme)
@@ -259,12 +259,12 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
     const int bottomY = screen_y - topBarHeight;
 
     // Right group: [Surprise me] [START]
-    int startButtonWidth = m_textDrawer->getTextLength("START");
+    int startButtonWidth = m_textDrawer->getTextLength("Start");
     int startButtonX = screen_x - startButtonWidth;
     cRectangle startButtonRect = cRectangle(startButtonX, bottomY, startButtonWidth, topBarHeight);
     startButton = GuiButtonBuilder()
             .withRect(startButtonRect)
-            .withLabel("START")
+            .withLabel("Start")
             .withTextDrawer(m_textDrawer)
             .withRenderer(m_renderDrawer)
             .withTheme(theme)

--- a/src/gamestates/cSetupSkirmishState.h
+++ b/src/gamestates/cSetupSkirmishState.h
@@ -104,9 +104,11 @@ private:
     cRectangle playerList;
     cRectangle mapList;
     cRectangle mapListTitle;
+
     cRectangle previewMapTitle;
     cRectangle previewMap;
     cRectangle previewMapRect;
+
     cRectangle startPointsRect;
     cRectangle wormsRect;
     cRectangle bloomsRect;

--- a/src/gamestates/cSetupSkirmishState.h
+++ b/src/gamestates/cSetupSkirmishState.h
@@ -118,11 +118,13 @@ private:
     std::unique_ptr<GuiButton> startButton;
     std::unique_ptr<GuiButton> modifyButton;
     std::unique_ptr<GuiButton> newMapButton;
+    std::unique_ptr<GuiButton> surpriseMeButton;
     std::unique_ptr<GuiButton> nextMapButton;
     std::unique_ptr<GuiButton> previousMapButton;
 
     // Functions
     void prepareSkirmishGameToPlayAndTransitionToCombatState(int iSkirmishMap);
+    void surpriseMe();
 
     void onMouseLeftButtonClicked(const s_MouseEvent &event);
     void onMouseRightButtonClicked(const s_MouseEvent &event);    

--- a/src/gui/GuiButton.cpp
+++ b/src/gui/GuiButton.cpp
@@ -38,12 +38,16 @@ void GuiButton::draw() const
             drawText();
             break;
         case OPAQUE_WITH_BORDER:
-            m_renderDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_theme.fillColor);
+            m_renderDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_enabled ? m_theme.fillColor : m_theme.disabledFillColor);
             if (m_pressed) {
                 m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.borderDark, m_theme.borderLight);
             }
             else {
-                m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.borderLight, m_theme.borderDark);
+                if (m_enabled) {
+                    m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.borderLight, m_theme.borderDark);
+                } else {
+                    m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.disabledBorderLight, m_theme.disabledBorderDark);
+                }
             }
             drawText();
             break;
@@ -89,7 +93,7 @@ void GuiButton::drawText() const
 {
     Color textColor = m_focus ? m_theme.textColorHover : m_theme.textColor;
     if (!m_enabled) {
-        textColor = m_focus ? m_theme.borderDark : m_theme.borderLight;
+        textColor = m_theme.disabledTextColor;
     }
 
     switch (m_textAlignHorizontal) {

--- a/src/gui/GuiTheme.hpp
+++ b/src/gui/GuiTheme.hpp
@@ -3,15 +3,23 @@
 #include "drawers/SDLDrawer.hpp"
 
 struct GuiTheme {
+    // Button/Rectangle
     Color fillColor;
     Color borderLight;
     Color borderDark;
     Color background;
+
+    // Text
     Color textColor;
     Color textDarkColor;
     Color textColorHover;
     Color textColorShadow;
-    Color disabled;
+
+    // Disabled properties here (for now, perhaps in the future its own "theme"?)
+    Color disabledTextColor;
+    Color disabledFillColor;
+    Color disabledBorderLight;
+    Color disabledBorderDark;
 
 };
 
@@ -28,7 +36,10 @@ public:
         m_textDarkColor = Color{225, 177, 21, 255};
         m_textColorHover = Color{255, 0, 0, 255};
         m_textColorShadow = Color::Black;
-        m_disabled = Color{128, 128, 128, 255};
+        m_disabledTextColor = Color{128, 128, 128, 255};
+        m_disabledFillColor = Color{64, 64, 100, 255};
+        m_disabledBorderLight = {40, 40, 40, 255};
+        m_disabledBorderDark = {20, 20, 20, 255};
         return *this;
     }
 
@@ -41,7 +52,10 @@ public:
         m_textDarkColor = Color{128, 128, 128, 255};
         m_textColorHover = Color::Black;
         m_textColorShadow = Color{128, 128, 128, 255};
-        m_disabled = Color{128, 128, 128, 255};
+        m_disabledTextColor = Color{128, 128, 128, 255};
+        m_disabledFillColor = Color{64, 64, 100, 255};
+        m_disabledBorderLight = Color{40, 40, 40, 255};
+        m_disabledBorderDark = Color{176, 176, 196, 255};
         return *this;
     }
 
@@ -54,7 +68,10 @@ public:
         m_textDarkColor = Color{225, 177, 21, 255};
         m_textColorHover = Color{255, 0, 0, 255};
         m_textColorShadow = Color::Black;
-        m_disabled = Color{128, 128, 128, 255};
+        m_disabledTextColor = Color{128, 128, 128, 255};
+        m_disabledFillColor = Color{146, 146, 166, 255};
+        m_disabledBorderLight = Color{84, 84, 120, 255};
+        m_disabledBorderDark = Color{128, 128, 128, 255};
         return *this;
     }
 
@@ -73,7 +90,10 @@ public:
             m_textDarkColor,
             m_textColorHover,
             m_textColorShadow,
-            m_disabled
+            m_disabledTextColor,
+            m_disabledFillColor,
+            m_disabledBorderLight,
+            m_disabledBorderDark
         };
     }
 
@@ -86,5 +106,8 @@ private:
     Color m_textDarkColor;
     Color m_textColorHover;
     Color m_textColorShadow;
-    Color m_disabled;
+    Color m_disabledTextColor;
+    Color m_disabledFillColor;
+    Color m_disabledBorderLight;
+    Color m_disabledBorderDark;
 };


### PR DESCRIPTION
## Summary

- Adds a "Surprise me" button to the skirmish setup screen, paired with the START button at the bottom right
- "New Map" and "Modify" buttons are grouped in the center of the bottom bar
- Clicking "Surprise me" picks a random valid map, randomizes the number of players (min 2, up to the map's max starting positions), sets all houses to random, randomizes credits between 1000-10000, and immediately starts the game


## Screenshots
<img width="2456" height="1536" alt="image" src="https://github.com/user-attachments/assets/e6cd4cd6-6877-40a3-af93-eee9c4d8d9dd" />



Random game
<img width="2456" height="1536" alt="image" src="https://github.com/user-attachments/assets/81cb6a5f-8632-4312-b4f7-45ab7b367bbf" />


## Test plan

- [ ] Open Skirmish setup screen - bottom bar shows: BACK (left) | New Map + Modify (center) | Surprise me + START (right)
- [ ] No overlapping buttons
- [ ] Click "Surprise me" - game starts immediately with randomized settings
- [ ] Repeat several times and verify: different maps, different player counts, different credit amounts
- [ ] Minimum of 2 players always in the game

Closes #1145