### PR TITLE
Sardaukar can build Carryall; Ornithopter available for all non-Harkonnen houses

### DIFF
--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -172,7 +172,7 @@ void cBuildingListUpdater::onStructureCreatedCampaignMode(int structureType) con
 
     if (structureType == HIGHTECH) {
         listUnits->addUnitToList(CARRYALL, SUBLIST_HIGHTECH);
-        if (house == ATREIDES || house == ORDOS) {
+        if (house != HARKONNEN) {
             listUnits->addUnitToList(ORNITHOPTER, SUBLIST_HIGHTECH);
         }
     }
@@ -187,6 +187,7 @@ void cBuildingListUpdater::onStructureCreatedCampaignMode(int structureType) con
         list->addUnitToList(MCV, 0);
         list->addUnitToList(HARVESTER, 0);
         list->addUnitToList(LAUNCHER, 0);
+		list->addUnitToList(CARRYALL, 0);
 
         if (techLevel > 6) {
             list->addUnitToList(SIEGETANK, 0);


### PR DESCRIPTION
For #1060 

## Summary

- Sardaukar now have access to Carryall in their build tree (Hitech)
- Ornithopter availability changed from explicit Atreides/Ordos check to `house != HARKONNEN`, so any future non-Harkonnen house is covered automatically

## Credits

Thanks to Ripps for reporting and contributing to these build tree fixes.