### PR TITLE
Update cBuildingListUpdater.cpp (Changes to sardauker tech tree)

### DIFF
--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -172,7 +172,7 @@ void cBuildingListUpdater::onStructureCreatedCampaignMode(int structureType) con
 
     if (structureType == HIGHTECH) {
         listUnits->addUnitToList(CARRYALL, SUBLIST_HIGHTECH);
-        if (house == ATREIDES || house == ORDOS) {
+        if (house != HARKONNEN) {
             listUnits->addUnitToList(ORNITHOPTER, SUBLIST_HIGHTECH);
         }
     }
@@ -187,6 +187,7 @@ void cBuildingListUpdater::onStructureCreatedCampaignMode(int structureType) con
         list->addUnitToList(MCV, 0);
         list->addUnitToList(HARVESTER, 0);
         list->addUnitToList(LAUNCHER, 0);
+		list->addUnitToList(CARRYALL, 0);
 
         if (techLevel > 6) {
             list->addUnitToList(SIEGETANK, 0);
@@ -238,7 +239,7 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
         m_player->log("onStructureCreated - added SLAB1 to list");
 
         if (techLevel >= 2) {
-            if (house == ATREIDES || house == ORDOS) {
+            if (house != HARKONNEN) {
                 listConstYard->addStructureToList(BARRACKS, 0);
                 m_player->log("onStructureCreated - added BARRACKS to list");
             }
@@ -247,6 +248,15 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
                 m_player->log("onStructureCreated - added WOR to list");
             }
         }
+		
+		if (structureType == BARRACKS) {
+			if (techLevel >= 3) {
+				if (house == SARDAUKAR) {
+					listConstYard->addStructureToList(WOR, 0);
+					m_player->log("onStructureCreated - added WOR to list");
+				}
+			}
+		
 
         if (techLevel >= 4) {
             //list->addItemToList(new cBuildingListItem(SLAB4, structures[SLAB4])); // only available after upgrading


### PR DESCRIPTION
My first commit.
Changes to sarduaker tech tree, Barracks now available for sarduaker,  Wor now requires barracks & tech level 3

Attempt to fix sardauker [tech tree (Issue#1060)](https://github.com/stefanhendriks/Dune-II---The-Maker/issues/1060)

## **Goal**

Changes to sardauker tech tree requiring them to build a barracks before a wor, making wor only available if tech level higher than 3

### Changes

- Changed line 242 to read `            if (house != HARKONNEN) {`
- Added lines to include `if (structureType == BARRACKS) {
			if (techLevel >= 3) {
				if (house == SARDAUKAR) {
					listConstYard->addStructureToList(WOR, 0);
					m_player->log("onStructureCreated - added WOR to list");
				}
			}`
- So that I could verify A) if i could make these changes) and B) to make sardauker play requires greater skill and effort.


## Testing Steps
Let me do my thing.