### PR TITLE
Update techtree - Changes to sardauker tech tree

### DIFF
--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -239,7 +239,7 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
         m_player->log("onStructureCreated - added SLAB1 to list");
 
         if (techLevel >= 2) {
-            if (house == ATREIDES || house == ORDOS) {
+            if (house != HARKONNEN) {
                 listConstYard->addStructureToList(BARRACKS, 0);
                 m_player->log("onStructureCreated - added BARRACKS to list");
             }
@@ -257,6 +257,15 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
 
         listConstYard->addStructureToList(WINDTRAP, 0);
         m_player->log("onStructureCreated - added WINDTRAP to list");
+    }
+
+	if (structureType == BARRACKS) {
+		if (techLevel >= 3) {
+			if (house == SARDAUKAR) {
+				listConstYard->addStructureToList(WOR, 0);
+				m_player->log("onStructureCreated - added WOR to list");
+			}
+		}
     }
 
     if (structureType == WINDTRAP) {


### PR DESCRIPTION
My first commit.
Changes to sarduaker tech tree, Barracks now available for sarduaker,  Wor now requires barracks & tech level 3

Attempt to fix sardauker [tech tree (Issue#1060)](https://github.com/stefanhendriks/Dune-II---The-Maker/issues/1060)

## **Goal**

Changes to sardauker tech tree requiring them to build a barracks before a wor, making wor only available if tech level higher than 3

### Changes
- Fix `(house != HARKONNEN)`
- Added lines to include `if (structureType == BARRACKS)`

## Testing Steps
Let me do my thing.
So that I could verify
- A) if i could make these changes)
- B) to make sardauker play requires greater skill and effort.