### PR TITLE
Removing quad from sardauker tech tree until research has been done.

### DIFF
--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -355,7 +355,7 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
             listConstYard->addStructureToList(STARPORT, 0);
         }
 
-        if (house == ATREIDES || house == SARDAUKER) {
+        if (house == ATREIDES || house == SARDAUKAR) {
             listUnits->addUnitToList(TRIKE, SUBLIST_LIGHTFCTRY);
         }
         else if (house == ORDOS) {

--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -355,7 +355,7 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
             listConstYard->addStructureToList(STARPORT, 0);
         }
 
-        if (house == ATREIDES) {
+        if (house == ATREIDES || house == SARDAUKER) {
             listUnits->addUnitToList(TRIKE, SUBLIST_LIGHTFCTRY);
         }
         else if (house == ORDOS) {


### PR DESCRIPTION
Attempt to fix Quad being available to sardauker before performing research.

[issue #1069 ](https://github.com/stefanhendriks/Dune-II---The-Maker/issues/1069)

## **Goal**

Make sardauker perform quad research first before making it available to build.

### Changes

Crude hack to prevent the game skipping over sardauker since they are not explicitly mentioned the game falls back to 
`        else {
            listUnits->addUnitToList(TRIKE, SUBLIST_LIGHTFCTRY);
            listUnits->addUnitToList(QUAD, SUBLIST_LIGHTFCTRY);
`
Essentially giving them instant access to both trike and quad.

## Testing Steps
Build a light factory, make sure quad is not available, perform research, make sure quad is available.

## Screenshots (optional)