### PR TITLE
Arrow keys navigate the map cursor in the skirmish setup screen

### DIFF
--- a/keys.md
+++ b/keys.md
@@ -85,4 +85,5 @@
 | ESCAPE | Choose House | Return to main menu |
 | ESCAPE | Setup Skirmish | Return to main menu |
 | ESCAPE | Select Conquest | Return to options |
-| LEFT / RIGHT | Setup Skirmish | Previous / next map page |
+| Arrow keys | Setup Skirmish | Move map cursor (wraps rows, changes page at edges) |
+| ENTER | Setup Skirmish | Start game with selected map |

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -1307,11 +1307,12 @@ void cSetupSkirmishState::drawMapList(const cRectangle &selectMapArea) const
             guiDrawFramePressed(iDrawX, iDrawY, mapItemButtonWidth, mapItemButtonHeight);
         }
 
-        // selected map, always render as pressed
+        // selected map, always render as pressed with a bright border
         if (isRenderingSelectedMap) {
             textColor = bHover ? colorDarkerYellow : Color::Yellow;
             // RENDERS (AGAIN)!
             guiDrawFramePressed(iDrawX, iDrawY, mapItemButtonWidth, mapItemButtonHeight);
+            m_renderDrawer->renderRectColor(iDrawX - 2, iDrawY - 2, mapItemButtonWidth + 4, mapItemButtonHeight + 4, Color::Yellow);
         }
 
         // In case invalid map, render as not-selectable
@@ -1405,6 +1406,33 @@ void cSetupSkirmishState::onMouseMovedTo(const s_MouseEvent &)
 {
 }
 
+void cSetupSkirmishState::moveCursor(int deltaX, int deltaY)
+{
+    int maxIndex = m_previewMaps->getMapCount();
+
+    if (iSkirmishMap == -1) {
+        iSkirmishMap = mapStartingIndexToDisplay;
+    } else {
+        int newIndex = iSkirmishMap + deltaX + deltaY * maxMapsInSelectAreaHorizontally;
+        iSkirmishMap = std::clamp(newIndex, 0, maxIndex);
+    }
+
+    mapStartingIndexToDisplay = (iSkirmishMap / maxMapsInSelectArea) * maxMapsInSelectArea;
+
+    if (iSkirmishMap == 0) return;
+
+    s_PreviewMap* map = m_previewMaps->getMap(iSkirmishMap);
+    if (!map->validMap) return;
+
+    iStartingPoints = 0;
+    for (int s : map->iStartCell) {
+        if (s > -1) iStartingPoints++;
+    }
+    for (int p = iStartingPoints; p < (AI_WORM - 1); p++) {
+        skirmishPlayer[p].bPlaying = false;
+    }
+}
+
 void cSetupSkirmishState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
 {
     if (event.isType(eKeyEventType::PRESSED)) {
@@ -1412,10 +1440,21 @@ void cSetupSkirmishState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
             m_interface->setTransitionToWithFadingOut(GAME_MENU);
         }
         if (event.isAction(eKeyAction::SCROLL_LEFT)) {
-            previousFunction();
+            moveCursor(-1, 0);
         }
         if (event.isAction(eKeyAction::SCROLL_RIGHT)) {
-            nextFunction();
+            moveCursor(1, 0);
+        }
+        if (event.isAction(eKeyAction::SCROLL_UP)) {
+            moveCursor(0, -1);
+        }
+        if (event.isAction(eKeyAction::SCROLL_DOWN)) {
+            moveCursor(0, 1);
+        }
+        if (event.isAction(eKeyAction::MENU_CONFIRM)) {
+            if (iSkirmishMap > -1 && m_previewMaps->getMap(iSkirmishMap)->validMap) {
+                prepareSkirmishGameToPlayAndTransitionToCombatState(iSkirmishMap);
+            }
         }
     }
 }

--- a/src/gamestates/cSetupSkirmishState.h
+++ b/src/gamestates/cSetupSkirmishState.h
@@ -177,4 +177,6 @@ private:
 
     void onMouseLeftButtonClickedAtTechLevel();
     void onMouseRightButtonClickedAtTechLevel();
+
+    void moveCursor(int deltaX, int deltaY);
 };


### PR DESCRIPTION
Closes #1158

## Summary

- Arrow keys move a cursor through the map grid one tile at a time; left/right wrap to the next/previous row, up/down jump a full row
- Reaching the edge of a page automatically turns the page
- Enter starts the game with the currently selected map
- The selected tile shows a bright yellow border so the cursor is clearly visible

## Test plan

- [ ] Open skirmish setup, press arrow keys — cursor appears on the first map and moves through the grid
- [ ] Press right at end of a row — cursor wraps to the first tile of the next row
- [ ] Press right at end of the last tile on a page — page advances to the next one
- [ ] Press left at the start of a row — cursor wraps to the last tile of the previous row
- [ ] Press up/down — cursor jumps a full row; page changes if needed
- [ ] Press Enter with a map selected — game starts
- [ ] Clicking a map with the mouse still works and arrow keys continue from the clicked position