### PR TITLE
Clicking structures/units and hotkeys work when watching a non-human player + pre-select CONSTYARD upon mission start

### DIFF
--- a/src/drawers/cStructureDrawer.cpp
+++ b/src/drawers/cStructureDrawer.cpp
@@ -27,17 +27,19 @@
 #include <SDL2/SDL.h>
 #include "include/cAssert.h"
 
-cStructureDrawer::cStructureDrawer(GameContext *ctx) :
+cStructureDrawer::cStructureDrawer(GameContext *ctx, cPlayer *player) :
     m_renderDrawer(ctx->getSDLDrawer()),
     m_textDrawer(ctx->getTextContext()->getBeneTextDrawer()),
     m_gfxinter(ctx->getGraphicsContext()->gfxinter.get()),
-    m_gfxdata(ctx->getGraphicsContext()->gfxdata.get())
+    m_gfxdata(ctx->getGraphicsContext()->gfxdata.get()),
+    m_player(player)
 {
     d2tm_assert(ctx != nullptr);
     d2tm_assert(m_renderDrawer != nullptr);
     d2tm_assert(m_textDrawer != nullptr);
     d2tm_assert(m_gfxinter != nullptr);
     d2tm_assert(m_gfxdata != nullptr);
+    d2tm_assert(m_player != nullptr);
 }
 
 
@@ -165,11 +167,10 @@ void cStructureDrawer::drawStructureAnimationTurret(cAbstractStructure *structur
 
     // :-/
     if (game.m_gameSettings->isDebugMode()) {
-        cPlayer *humanPlayer = game.m_gameObjectsContext->getPlayer(HUMAN);
-        cAbstractStructure *pStructure = humanPlayer->getSelectedStructure();
+        cAbstractStructure *pStructure = m_player->getSelectedStructure();
         if (pStructure && pStructure == structure) {
             cMouse *pMouse = game.getMouse();
-            cGameControlsContext *pContext = humanPlayer->getGameControlsContext();
+            cGameControlsContext *pContext = m_player->getGameControlsContext();
 
             int x1 = pMouse->getX();
             int y1 = pMouse->getY();
@@ -341,15 +342,13 @@ void cStructureDrawer::drawStructuresForLayer(int layer)
             // draw
             drawStructureForLayer(theStructure, layer);
 
-            cPlayer *player = game.m_gameObjectsContext->getPlayer(HUMAN); // TODO: Pass it as variable? (instead of getting it from here)
-            // regardless if selected, render this so you know from which structure things will come?
-            if (player->isPrimaryStructureForStructureType(theStructure->getType(), i)) {
-                drawRectangleOfStructure(theStructure, player->getPrimaryBuildingFadingColor());
+            if (m_player->isPrimaryStructureForStructureType(theStructure->getType(), i)) {
+                drawRectangleOfStructure(theStructure, m_player->getPrimaryBuildingFadingColor());
                 continue;
             }
 
-            if (i == player->selected_structure) {
-                drawRectangleOfStructure(theStructure, player->getSelectFadingColor());
+            if (i == m_player->selected_structure) {
+                drawRectangleOfStructure(theStructure, m_player->getSelectFadingColor());
             }
         }
     }

--- a/src/drawers/cStructureDrawer.h
+++ b/src/drawers/cStructureDrawer.h
@@ -4,6 +4,7 @@ class GameContext;
 class Graphics;
 class SDLDrawer;
 class cTextDrawer;
+class cPlayer;
 
 #include "gameobjects/structures/cAbstractStructure.h"
 #include "utils/cStructureUtils.h"
@@ -11,8 +12,9 @@ class cTextDrawer;
 
 class cStructureDrawer {
 public:
-    explicit cStructureDrawer(GameContext *ctx);
+    explicit cStructureDrawer(GameContext *ctx, cPlayer *player);
     ~cStructureDrawer() = default;
+    void setPlayer(cPlayer *pPlayer) { m_player = pPlayer; }
     void drawStructuresFirstLayer();
     void drawStructuresSecondLayer();
     void drawStructuresHealthBars();
@@ -35,6 +37,7 @@ private:
     Graphics *m_gfxinter;
     Graphics *m_gfxdata;
     cStructureUtils m_structureUtils;
+    cPlayer *m_player;
 
     void renderIconOfUnitBeingRepaired(cAbstractStructure *structure) const;
     void renderIconThatStructureIsBeingRepaired(cAbstractStructure *structure) const;

--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -1687,6 +1687,10 @@ void cPlayer::onNotifyGameEvent(const s_GameEvent &event)
             if (const auto *commonEvent = std::get_if<CommonEvent>(&event.data)) {
                 if (commonEvent->player == this && commonEvent->entityType == eBuildType::STRUCTURE) {
                     buildingListUpdater->onStructureCreated(commonEvent->entitySpecificType);
+                    if (commonEvent->entitySpecificType == CONSTYARD && selected_structure < 0) {
+                        selected_structure = commonEvent->entityID;
+                        getSideBar()->setSelectedListId(eListType::LIST_CONSTYARD);
+                    }
                 }
             }
             break;

--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -2443,32 +2443,34 @@ std::vector<int> cPlayer::getAttackingUnitsOnMap() const
     return ids;
 }
 
-bool cPlayer::evaluateStillAlive()
-{
-    alive = false;
+bool cPlayer::hasAliveStructure() {
     for (int i = 0; i < MAX_STRUCTURES; i++) {
         cAbstractStructure *abstractStructure = m_objects->getStructures()[i];
         if (!abstractStructure) continue;
         if (!abstractStructure->isValid()) continue;
         if (!abstractStructure->belongsTo(this)) continue;
-        alive = true;
-        break;
+        return true;
     }
+    return false;
+}
 
-    if (!alive) {
-        // check units now
-        for (int i = 0; i < m_objects->getUnitsSize(); i++) {
-            cUnit *pUnit = m_objects->getUnit(i);
-            if (!pUnit->isValid()) continue;
-            if (pUnit->isAirbornUnit()) continue; // do not count airborn units
-            if (pUnit->isDead()) continue; // in case we have some 'half-dead' units that got pass the isValid check...
-            // a better way for this would be to have such units in a separate collection.
-            if (!pUnit->belongsTo(this)) continue;
-            alive = true;
-            break;
-        }
+bool cPlayer::hasAliveUnit() {
+    for (int i = 0; i < m_objects->getUnitsSize(); i++) {
+        cUnit *pUnit = m_objects->getUnit(i);
+        if (!pUnit->isValid()) continue;
+        if (pUnit->isAirbornUnit()) continue; // do not count airborn units
+        if (pUnit->isDead()) continue; // in case we have some 'half-dead' units that got pass the isValid check...
+        // a better way for this would be to have such units in a separate collection.
+        if (!pUnit->belongsTo(this)) continue;
+        return true;
     }
-    return isAlive();
+    return false;
+}
+
+bool cPlayer::evaluateStillAlive()
+{
+    alive = hasAliveStructure() || hasAliveUnit();
+    return alive;
 }
 
 cAbstractStructure *cPlayer::getSelectedStructure() const

--- a/src/gameobjects/players/cPlayer.h
+++ b/src/gameobjects/players/cPlayer.h
@@ -545,6 +545,9 @@ public:
     int getSwapColor() const;
 
 private:
+    bool hasAliveStructure();
+    bool hasAliveUnit();
+
     static int groupIdToIndex(int groupId);
 
     cBuildingListItem *isUpgradeAvailableToGrant(eBuildType providesType, int providesTypeId) const;

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -497,6 +497,8 @@ void cGamePlaying::tryDebugSwitchToPlayer(int playerIndex)
         m_interface->onNotifyGameEvent(newEvent);
         return;
     }
+    m_controlledPlayer->deselectAllUnits();
+    m_controlledPlayer->selected_structure = -1;
     m_controlledPlayer = targetPlayer;
     m_drawManager->setPlayerToDraw(m_controlledPlayer);
     m_interface->setPlayerToInteractFor(m_controlledPlayer);

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -370,11 +370,11 @@ void cGamePlaying::onKeyDownGamePlaying(const cKeyboardEvent &event)
     }
 
     if (event.isAction(eKeyAction::CENTER_ON_HOME)) {
-        m_mapCamera->centerAndJumpViewPortToCell(humanPlayer->getFocusCell());
+        m_mapCamera->centerAndJumpViewPortToCell(m_controlledPlayer->getFocusCell());
     }
 
     if (event.isAction(eKeyAction::CENTER_ON_STRUCTURE)) {
-        cAbstractStructure *selectedStructure = humanPlayer->getSelectedStructure();
+        cAbstractStructure *selectedStructure = m_controlledPlayer->getSelectedStructure();
         if (selectedStructure) {
             m_mapCamera->centerAndJumpViewPortToCell(selectedStructure->getCell());
         }
@@ -451,11 +451,11 @@ void cGamePlaying::onKeyPressedGamePlaying(const cKeyboardEvent &event)
     }
 
     if (event.isAction(eKeyAction::CENTER_ON_HOME)) {
-        m_mapCamera->centerAndJumpViewPortToCell(humanPlayer->getFocusCell());
+        m_mapCamera->centerAndJumpViewPortToCell(m_controlledPlayer->getFocusCell());
     }
 
     if (event.isAction(eKeyAction::CENTER_ON_STRUCTURE)) {
-        cAbstractStructure *selectedStructure = humanPlayer->getSelectedStructure();
+        cAbstractStructure *selectedStructure = m_controlledPlayer->getSelectedStructure();
         if (selectedStructure) {
             m_mapCamera->centerAndJumpViewPortToCell(selectedStructure->getCell());
         }

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -298,6 +298,13 @@ void cGamePlaying::evaluatePlayerStatus()
                     }
                 };
                 m_interface->onNotifyGameEvent(event);
+
+                // player is defeated, if it was the controlling player it is no longer valid to control it
+                if (player == m_controlledPlayer) {
+                    m_controlledPlayer = m_objects->getPlayer(HUMAN);
+                    m_drawManager->setPlayerToDraw(m_controlledPlayer);
+                    m_interface->setPlayerToInteractFor(m_controlledPlayer);
+                }
             }
             // TODO: event : Player joined/became alive, etc?
         }

--- a/src/managers/cDrawManager.cpp
+++ b/src/managers/cDrawManager.cpp
@@ -56,7 +56,7 @@ void cDrawManager::reset()
     m_particleDrawer = std::make_unique<cParticleDrawer>();
     m_messageDrawer = std::make_unique<cMessageDrawer>(m_ctx);
     m_placeitDrawer = std::make_unique<cPlaceItDrawer>(m_ctx,m_player);
-    m_structureDrawer = std::make_unique<cStructureDrawer>(m_ctx);
+    m_structureDrawer = std::make_unique<cStructureDrawer>(m_ctx, m_player);
     m_btnOptions = createPlayerTextureFromIndexedSurfaceWithPalette(
         m_player, m_gfxinter->getSurface(BTN_OPTIONS), TransparentColorIndex
     );
@@ -267,6 +267,7 @@ void cDrawManager::setPlayerToDraw(cPlayer *playerToDraw)
     m_orderDrawer->setPlayer(playerToDraw);
     m_miniMapDrawer->setPlayer(playerToDraw);
     m_mapDrawer->setPlayer(playerToDraw);
+    m_structureDrawer->setPlayer(playerToDraw);
 }
 
 void cDrawManager::drawOptionBar()


### PR DESCRIPTION
Fixes #1149
Also fixes #1143

## What changed

When switching to a non-human player via debug mode, several interactions were broken.

**Structure selection highlight** (`cStructureDrawer`): The drawer hardcoded `getPlayer(HUMAN)` when deciding which structure to highlight and when drawing the debug turret aim line. Added `m_player` to `cStructureDrawer` (constructor + `setPlayer()`), called from `cDrawManager::setPlayerToDraw()` alongside the other sub-drawers.

**CENTER_ON_HOME / CENTER_ON_STRUCTURE hotkeys**: Both keyboard handlers used `humanPlayer` instead of `m_controlledPlayer`, so the camera always jumped to the human player's base/selection. Changed to `m_controlledPlayer`.

**Deselect on player switch**: Switching to another player left the previous player's unit and structure selection intact. `tryDebugSwitchToPlayer` now clears both before switching.

**Auto-select constyard at mission start**: The first constyard placed for a player is now automatically selected and its sidebar list activated, when nothing else is selected yet. This restores the expected starting state without a manual click.

**Ghost thopter fix**: When the currently controlled AI player gets eliminated, `m_controlledPlayer` is now automatically reset to the human player. Previously, pressing F8 (spawn ornithopter) after the watched player died would spawn a unit for a dead/non-active player, resulting in a ghost thopter.

## Test plan

- [ ] Start a mission — constyard is pre-selected and its sidebar list is active
- [ ] Switch to an AI player via debug mode (Tab + 1/2/3) — their structures can be clicked and show a selection rectangle
- [ ] With an AI structure selected, press CENTER_ON_STRUCTURE — camera jumps to it
- [ ] Press CENTER_ON_HOME — camera jumps to the AI player's base
- [ ] Switch back to human player — previous AI player selection is cleared
- [ ] Watch an AI player until they are eliminated — controlled player switches back to human automatically
- [ ] After elimination, press F8 — ornithopter spawns for the human player (no ghost thopter)