### PR TITLE
Attempting to fix carry-all not being available for purchase at starport

### DIFF
--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -282,6 +282,7 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
         list->addUnitToList(MCV, 0);
         list->addUnitToList(HARVESTER, 0);
         list->addUnitToList(LAUNCHER, 0);
+		list->addUnitToList(CARRYALL, 0);
 
         if (techLevel > 6) {
             list->addUnitToList(SIEGETANK, 0);


### PR DESCRIPTION
I thought i had previously made this change, but there is a second list that also needed an update.

[Issue #963](https://github.com/stefanhendriks/Dune-II---The-Maker/issues/963)

## **Goal**

Make Carry-all available for purchase from starport.

### Changes

added missing reference to carry-all.


## Testing Steps

Build a starport, check to see if carry-all is available for purchase.

## Screenshots (optional)