### PR TITLE
Defeated player's air units turn gray and retreat to map edge

### DIFF
--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -3895,6 +3895,12 @@ void cUnit::setAction(eActionType action)
     m_action = action;
 }
 
+void cUnit::retreatToMapEdge()
+{
+    m_transferType = eTransferType::DIE;
+    setGoalCell(iFindCloseBorderCell(position.iCell));
+}
+
 void cUnit::retreatToNearbyBase()
 {
     const std::vector<sEntityForDistance> &result = getPlayer()->getAllMyStructuresOrderClosestToCell(position.iCell);

--- a/src/gameobjects/units/cUnit.h
+++ b/src/gameobjects/units/cUnit.h
@@ -181,6 +181,7 @@ public:
     sRendering rendering;
 
     void retreatToNearbyBase();
+    void retreatToMapEdge();
     void deselect();
     [[nodiscard]] bool isSelected() const;
     void select();

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -275,6 +275,32 @@ void cGamePlaying::onNotifyKeyboardEvent(const cKeyboardEvent &event)
 }
 
 
+void cGamePlaying::onPlayerDefeated(cPlayer *player) {
+    const s_GameEvent event {
+        .eventType = eGameEventType::GAME_EVENT_PLAYER_DEFEATED,
+        .data = CommonEvent {
+            .entityType = eBuildType::SPECIAL,
+            .player = player
+        }
+    };
+    m_interface->onNotifyGameEvent(event);
+
+    // player is defeated, if it was the controlling player it is no longer valid to control it
+    if (player == m_controlledPlayer) {
+        m_controlledPlayer = m_objects->getPlayer(HUMAN);
+        m_drawManager->setPlayerToDraw(m_controlledPlayer);
+        m_interface->setPlayerToInteractFor(m_controlledPlayer);
+    }
+
+    player->setHouse(GENERALHOUSE);
+
+    for (int unitId : player->getAllMyUnits()) {
+        cUnit *pUnit = m_objects->getUnit(unitId);
+        if (!pUnit->isAirbornUnit()) continue;
+        pUnit->retreatToMapEdge();
+    }
+}
+
 void cGamePlaying::evaluatePlayerStatus()
 {
     if (m_TIMER_evaluatePlayerStatus > 0) {
@@ -287,24 +313,10 @@ void cGamePlaying::evaluatePlayerStatus()
             cPlayer* player = m_objects->getPlayer(i);
             bool isAlive = player->isAlive();
             // evaluate all players regardless if they are alive or not (who knows, they became alive?)
-            player->evaluateStillAlive();
+            bool isStillAlive = player->evaluateStillAlive();
 
-            if (isAlive && !player->isAlive()) {
-                const s_GameEvent event {
-                    .eventType = eGameEventType::GAME_EVENT_PLAYER_DEFEATED,
-                    .data = CommonEvent {
-                        .entityType = eBuildType::SPECIAL,
-                        .player = player
-                    }
-                };
-                m_interface->onNotifyGameEvent(event);
-
-                // player is defeated, if it was the controlling player it is no longer valid to control it
-                if (player == m_controlledPlayer) {
-                    m_controlledPlayer = m_objects->getPlayer(HUMAN);
-                    m_drawManager->setPlayerToDraw(m_controlledPlayer);
-                    m_interface->setPlayerToInteractFor(m_controlledPlayer);
-                }
+            if (isAlive && !isStillAlive) {
+                onPlayerDefeated(player);
             }
             // TODO: event : Player joined/became alive, etc?
         }

--- a/src/gamestates/cGamePlaying.h
+++ b/src/gamestates/cGamePlaying.h
@@ -33,6 +33,8 @@ public:
     void onNotifyMouseEvent(const s_MouseEvent &event) override;
     void onNotifyKeyboardEvent(const cKeyboardEvent &event) override;
 
+    void onPlayerDefeated(cPlayer *player);
+
     eGameStateType getType() override;
 
     void missionInit();


### PR DESCRIPTION
Fixes #1175

## What changed

When a player is eliminated, two things now happen:

**Recolor to gray**: The defeated player's house is set to `GENERALHOUSE`. Since unit bitmaps are resolved through the player at draw time, all their units immediately render in gray without needing to touch `iPlayer` on any unit.

**Air units retreat**: Any surviving airborne units (ornithopters, carryalls) have their transfer type set to `DIE` and their goal cell set to the nearest map border. They fly there and die on arrival — reusing the existing `eTransferType::DIE` path already used by carryalls after dropping off reinforcements.

The player-defeat handling was also extracted into `onPlayerDefeated()` for clarity.

## Test plan

- [ ] Start a skirmish with an AI opponent that has ornithopters/carryalls
- [ ] Let or cause the AI player to be eliminated (all structures and ground units destroyed)
- [ ] Verify: surviving air units turn gray
- [ ] Verify: they fly toward the nearest map edge and disappear on arrival
- [ ] Verify: no crash or ghost units remain after they die