### PR TITLE
Attempt to fix Palace being available without house of IX

### DIFF
--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -331,7 +331,9 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
         }
 
         if (techLevel >= 8) {
-            listConstYard->addStructureToList(PALACE, 0);
+			if (structureType == IX) {
+				listConstYard->addStructureToList(PALACE, 0);
+			}
         }
     }
 


### PR DESCRIPTION
In the original game, the palace required the construction of a house of IX first, this is my attempt to restore this behavior.

[Issue #1178](https://github.com/stefanhendriks/Dune-II---The-Maker/issues/1178)

## **Goal**

Forces the construction of House of IX prior to the construction of a palace, making IX a requirement.

### Changes

Added a single additional line of code.


## Testing Steps
Build Radar, Check if you can build palace.
Build House of IX, check if you can build palace, if so = drink beer.

## Screenshots (optional)