### PR TITLE
Palace required the construction of a house of IX

### DIFF
--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -329,11 +329,11 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
         if (techLevel >= 5) {
             listConstYard->addStructureToList(TURRET, 0);
         }
-
-        if (techLevel >= 8) {
-            listConstYard->addStructureToList(PALACE, 0);
-        }
     }
+
+	if (structureType == IX) { //already techlevel 8, but we want to add palace only when IX is built, not when techlevel is 8 (since the player might not have built IX yet)
+				listConstYard->addStructureToList(PALACE, 0);
+	}
 
     if (structureType == STARPORT) {
         // House of IX is available if Starport is built


### PR DESCRIPTION
In the original game, the palace required the construction of a house of IX first, this is my attempt to restore this behavior.

[Issue #1178](https://github.com/stefanhendriks/Dune-II---The-Maker/issues/1178)

## **Goal**

Forces the construction of House of IX prior to the construction of a palace, making IX a requirement.

### Changes

Added a single additional line of code.


## Testing Steps
Build Radar, Check if you can build palace.
Build House of IX, check if you can build palace, if so = drink beer.
