### PR TITLE
Make sure Sardaukar skirmish AI purchases Upgrades

### DIFF
--- a/src/gameobjects/players/brains/cPlayerBrainSkirmish.cpp
+++ b/src/gameobjects/players/brains/cPlayerBrainSkirmish.cpp
@@ -352,6 +352,18 @@ void cPlayerBrainSkirmish::thinkState_Base()
         if (player->startUpgradingForUnitIfPossible(ORNITHOPTER)) {
             return;
         }
+
+        if (player->startUpgradingForUnitIfPossible(SONICTANK)) {
+            return;
+        }
+
+        if (player->startUpgradingForUnitIfPossible(DEVIATOR)) {
+            return;
+        }
+
+        if (player->startUpgradingForUnitIfPossible(DEVASTATOR)) {
+            return;
+        }
     }
 
     if (player->hasAtleastOneStructure(CONSTYARD)) {

--- a/src/gameobjects/players/brains/cPlayerBrainSkirmish.cpp
+++ b/src/gameobjects/players/brains/cPlayerBrainSkirmish.cpp
@@ -322,7 +322,9 @@ void cPlayerBrainSkirmish::thinkState_Base()
 
     // structure placement is done in thinkState_ProcessBuildOrders() !
 
-    if (player->hasEnoughCreditsFor(500) && m_economyState == PLAYERBRAIN_ECONOMY_STATE_NORMAL) {
+    bool economyAllowsUpgrade = m_economyState == PLAYERBRAIN_ECONOMY_STATE_NORMAL
+                                || m_economyState == PLAYERBRAIN_ECONOMY_STATE_GOOD;
+    if (player->hasEnoughCreditsFor(500) && economyAllowsUpgrade) {
         // we have money to do a (unit) upgrade, structure sUpgradeInfo are done via the "thinkAboutNextStructure" thing
         // which will enforce an upgrade via that path
         if (player->startUpgradingForUnitIfPossible(QUAD)) {


### PR DESCRIPTION
Closes #1148

## Summary

- Adds `startUpgradingForUnitIfPossible` calls for SONICTANK, DEVIATOR, and DEVASTATOR to the skirmish AI upgrade block, so the AI will queue those upgrades when IX and Heavy Factory are available
- Allows the upgrade block to run in GOOD economy state (credits > 1050), not only NORMAL; by the time the AI builds IX late in the build order it typically has surplus credits, which previously caused the entire upgrade block to be skipped silently

Other houses are unaffected: Atreides, Harkonnen, and Ordos receive their special heavy units automatically when IX is built, without needing paid upgrades.

## Test plan

- Start a skirmish game against a Sardaukar AI opponent
- Let the AI grow until it builds a Heavy Factory, Starport, and House of IX
- Confirm the Sardaukar AI purchases the Sonic Tank, Deviator, and Devastator upgrades and eventually fields those units