### PR TITLE
Cheat mode toggle shows enabled/disabled notification in green

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1413,8 +1413,9 @@ void cGame::onKeyPressedGame(const cKeyboardEvent &event)
 
     if (event.isAction(eKeyAction::TOGGLE_CHEAT)) {
         m_gameSettings->m_cheatMode = !m_gameSettings->m_cheatMode;
-        cLogger::getInstance()->log(LOG_INFO, COMP_CHEATS, "Cheat mode enabled", "All cheats are now enabled. Have fun!");
-        m_notificationArea->addNotification("Cheat mode toggle !", eNotificationType::NEUTRAL);
+        auto message = std::format("Cheat mode {}", m_gameSettings->m_cheatMode ? "enabled" : "disabled");
+        cLogger::getInstance()->log(LOG_INFO, COMP_CHEATS, "Cheat mode", message);
+        m_notificationArea->addNotification(message, eNotificationType::OTHER);
     }
 }
 

--- a/src/gameobjects/players/cPlayerNotification.cpp
+++ b/src/gameobjects/players/cPlayerNotification.cpp
@@ -51,5 +51,7 @@ Color cPlayerNotification::getColor() const
             return badColor;
         case OTHER:
             return otherColor;
+        default:
+            return neutralColor;
     }
 }

--- a/src/gameobjects/players/cPlayerNotification.cpp
+++ b/src/gameobjects/players/cPlayerNotification.cpp
@@ -12,6 +12,8 @@ std::string eNotificationTypeString(const eNotificationType &type)
             return "PRIORITY";
         case eNotificationType::BAD:
             return "BAD";
+        case eNotificationType::OTHER:
+            return "OTHER";
         default:
             d2tm_assert(false && "Unknown eNotificationType?");
             break;
@@ -36,18 +38,18 @@ const std::string &cPlayerNotification::getMessage() const
 
 Color cPlayerNotification::getColor() const
 {
-    // @Mira regression on color
-    //bool justStarted = (m_initialDuration - m_TIMER) < 500;
-    static const Color neutralColor = Color::White; //Color{255, 255, 255,255}; // white
-    static const Color priorityColor = Color::Yellow; //Color{255, 207, 41,255}; // yellow
-    static const Color badColor = Color::Red; //{255, 0, 0,255}; // red
+    static const Color neutralColor = Color::White;
+    static const Color priorityColor = Color::Yellow;
+    static const Color badColor = Color::Red;
+    static const Color otherColor = Color::Green;
     switch (m_type) {
         case NEUTRAL:
-            return /*justStarted ? game.getColorFadeSelected(neutralColor) :*/ neutralColor;
+            return neutralColor;
         case PRIORITY:
-            return /*justStarted ? game.getColorFadeSelected(priorityColor) :*/ priorityColor;
+            return priorityColor;
         case BAD:
-            return /*justStarted ? game.getColorFadeSelected(badColor) :*/ badColor;
+            return badColor;
+        case OTHER:
+            return otherColor;
     }
-    return neutralColor;
 }

--- a/src/include/eNotificationType.h
+++ b/src/include/eNotificationType.h
@@ -3,5 +3,6 @@
 enum eNotificationType {
     NEUTRAL,    // generic message, in white
     PRIORITY,   // a more important message, yellow
-    BAD         // bad news, in red
+    BAD,        // bad news, in red
+    OTHER       // other kind of messages
 };


### PR DESCRIPTION
## Summary

- Adds `OTHER` notification type (rendered in green) to `eNotificationType`
- Toggles "Cheat mode enabled" / "Cheat mode disabled" message based on actual state, replacing the static "Cheat mode toggle !" text
- Cleans up commented-out color-fade code in `cPlayerNotification::getColor()`