### PR TITLE
Right-click pauses construction, left-click resumes

### DIFF
--- a/src/building/cItemBuilder.cpp
+++ b/src/building/cItemBuilder.cpp
@@ -182,7 +182,7 @@ void cItemBuilder::thinkFast()
         // stop building this item when we are done
         if (item->getTimesToBuild() == 0) {	// no more items to build
             // stop building (set flags)
-            item->stopBuilding();
+            item->cancelBuilding();
 
             // remove this item from the build list (does not delete item, so pointer is still valid)
             removeItemFromList(item);
@@ -282,7 +282,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                     if (special.providesType == UNIT) {
                         deployUnit(item, special.providesTypeId);
                     }
-                    item->stopBuilding();
+                    item->cancelBuilding();
                     removeItemFromList(item);
                 }
                 else if (special.deployFrom == AT_RANDOM_CELL) {
@@ -326,7 +326,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                             iCll = game.m_gameObjectsContext->getMapGeometry()->makeCell(x, y);
                         }
                     }
-                    item->stopBuilding();
+                    item->cancelBuilding();
                     removeItemFromList(item);
                 }
 
@@ -773,7 +773,7 @@ cBuildingListItem *cItemBuilder::getItem(int position)
 void cItemBuilder::startBuilding(cBuildingListItem *item)
 {
     if (item == nullptr) return;
-    item->setIsBuilding(true);
+    item->startBuilding();
     item->setTimerCap(getTimerCap(item));
     item->resetProgressFrameTimer();
     m_buildingListUpdater->onBuildItemStarted(item);

--- a/src/building/cItemBuilder.cpp
+++ b/src/building/cItemBuilder.cpp
@@ -137,6 +137,8 @@ void cItemBuilder::thinkFast()
         }
 
         // ITEM is building
+        if (item->isPaused()) continue;
+
         m_timers[i]++;
 
         // determines how fast an item is built, this is the so called 'delay' before 1 'build time tick' has passed

--- a/src/drawers/cBuildingListDrawer.cpp
+++ b/src/drawers/cBuildingListDrawer.cpp
@@ -181,6 +181,10 @@ void cBuildingListDrawer::drawList(cBuildingList *list, bool shouldDrawStructure
                 // draw the other progress stuff
                 m_renderDrawer->renderSprite(m_gfxinter->getTexture(PROGRESSFIX), iDrawX+2, iDrawY+2,128);
                 m_renderDrawer->renderSprite(m_gfxinter->getTexture(PROGRESS001+iFrame), iDrawX+2, iDrawY+2,128);
+
+                if (item->isPaused()) {
+                    m_smallTextDrawer->drawTextCenteredInBox("Paused", iDrawX, iDrawY, withOfIcon, heightOfIcon, Color::Yellow);
+                }
             }
             else {
                 if (item->shouldPlaceIt()) {

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1253,8 +1253,7 @@ void cGame::onEventSpecialLaunch(const LaunchDeathHandEvent &event) const
 
     itemToDeploy->decreaseTimesToBuild();
     itemToDeploy->setDeployIt(false);
-    itemToDeploy->setIsBuilding(false);
-    itemToDeploy->resetProgress();
+    itemToDeploy->cancelBuilding();
     if (itemToDeploy->getTimesToBuild() < 1) {
         player->getItemBuilder()->removeItemFromList(itemToDeploy);
     }

--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -1602,8 +1602,7 @@ cAbstractStructure *cPlayer::placeItem(int destinationCell, cBuildingListItem *i
     buildingListUpdater->onBuildItemCompleted(itemToPlace);
     itemToPlace->decreaseTimesToBuild();
     itemToPlace->setPlaceIt(false);
-    itemToPlace->setIsBuilding(false);
-    itemToPlace->resetProgress();
+    itemToPlace->cancelBuilding();
     if (itemToPlace->getTimesToBuild() < 1) {
         itemBuilder->removeItemFromList(itemToPlace);
     }

--- a/src/include/enums.h
+++ b/src/include/enums.h
@@ -256,6 +256,7 @@ inline int eListTypeAsInt(eListType value)
 enum eBuildingListItemState {
     AVAILABLE,
     BUILDING,
+    PAUSED,
     PENDING_UPGRADE,    // an upgrade is blocking this item to be built
     PENDING_BUILDING,   // another item being built is blocking this item to be upgraded
     UNAVAILABLE

--- a/src/sidebar/cBuildingListItem.cpp
+++ b/src/sidebar/cBuildingListItem.cpp
@@ -134,11 +134,6 @@ float cBuildingListItem::getRefundAmount()
     return (fProgress * m_creditsPerProgressTime);
 }
 
-void cBuildingListItem::decreaseTimesToBuild()
-{
-    m_timesToBuild--;
-}
-
 void cBuildingListItem::increaseProgress(int byAmount)
 {
     setProgress(getProgress() + byAmount);

--- a/src/sidebar/cBuildingListItem.cpp
+++ b/src/sidebar/cBuildingListItem.cpp
@@ -16,8 +16,6 @@ cBuildingListItem::cBuildingListItem(eBuildType type, int buildId, int cost, int
     m_buildId = buildId;
     m_type = type;
     m_cost = cost;
-    m_building = false;
-    m_paused = false;
     m_state = AVAILABLE;
     m_progress = 0;
     m_buildFrameToDraw = 0;

--- a/src/sidebar/cBuildingListItem.cpp
+++ b/src/sidebar/cBuildingListItem.cpp
@@ -17,6 +17,7 @@ cBuildingListItem::cBuildingListItem(eBuildType type, int buildId, int cost, int
     m_type = type;
     m_cost = cost;
     m_building = false;
+    m_paused = false;
     m_state = AVAILABLE;
     m_progress = 0;
     m_buildFrameToDraw = 0;

--- a/src/sidebar/cBuildingListItem.h
+++ b/src/sidebar/cBuildingListItem.h
@@ -75,6 +75,9 @@ public:
     bool isBuilding() {
         return m_building;
     }
+    bool isPaused() {
+        return m_paused;
+    }
     bool isState(eBuildingListItemState value) {
         return m_state == value;
     }
@@ -144,8 +147,12 @@ public:
     void setIsBuilding(bool value) {
         m_building = value;
     }
+    void setPaused(bool value) {
+        m_paused = value;
+    }
     void stopBuilding() {
         setIsBuilding(false);
+        setPaused(false);
         resetProgress();
     }
     void setStatusPendingUpgrade() {
@@ -267,6 +274,7 @@ private:
     eBuildType m_type;		// .. of this type of thing (ie, UNIT or STRUCTURE)
     int m_cost;				// price
     bool m_building;			// building this item? (default = false)
+    bool m_paused;              // construction paused by player?
     eBuildingListItemState m_state;
     int m_progress;			// progress building this item
     int m_buildFrameToDraw;   // for the progress drawing

--- a/src/sidebar/cBuildingListItem.h
+++ b/src/sidebar/cBuildingListItem.h
@@ -137,13 +137,6 @@ public:
         return m_queuable;
     }
 
-    // setters
-    void setIconId(int value) {
-        m_icon = value;
-    }
-    void setBuildCost(int value) {
-        m_cost = value;
-    }
     void pauseBuilding() {
         m_state = eBuildingListItemState::PAUSED;
     }
@@ -157,6 +150,14 @@ public:
     void startBuilding() {
         m_state = eBuildingListItemState::BUILDING;
     }
+
+    // setters
+    void setIconId(int value) {
+        m_icon = value;
+    }
+    void setBuildCost(int value) {
+        m_cost = value;
+    }
     void setStatusPendingUpgrade() {
         m_state = eBuildingListItemState::PENDING_UPGRADE;
     }
@@ -165,15 +166,6 @@ public:
     }
     void setStatusPendingBuilding() {
         m_state = eBuildingListItemState::PENDING_BUILDING;
-    }
-    void setIsAvailable(bool value) {
-        value ? m_state = eBuildingListItemState::AVAILABLE : eBuildingListItemState::UNAVAILABLE;
-    }
-    void setTimesToBuild(int value) {
-        m_timesToBuild = value;
-    }
-    void setTimesOrdered(int value) {
-        m_timesOrdered = value;
     }
     void increaseTimesToBuild() {
         m_timesToBuild++;
@@ -186,7 +178,9 @@ public:
             m_timesToBuild = 1; // not queueable always means 1
         }
     }
-    void decreaseTimesToBuild();
+    void decreaseTimesToBuild() {
+        m_timesToBuild--;
+    }
     void increaseTimesOrdered() {
         m_timesOrdered++;
     }

--- a/src/sidebar/cBuildingListItem.h
+++ b/src/sidebar/cBuildingListItem.h
@@ -73,10 +73,10 @@ public:
         return m_progress;
     }
     bool isBuilding() {
-        return m_building;
+        return isState(eBuildingListItemState::BUILDING) || isState(eBuildingListItemState::PAUSED);
     }
     bool isPaused() {
-        return m_paused;
+        return isState(eBuildingListItemState::PAUSED);
     }
     bool isState(eBuildingListItemState value) {
         return m_state == value;
@@ -87,7 +87,7 @@ public:
      * @return
      */
     bool isAvailable() {
-        return isState(eBuildingListItemState::AVAILABLE);
+        return isState(eBuildingListItemState::AVAILABLE) || isState(eBuildingListItemState::BUILDING);
     }
 
     /**
@@ -144,16 +144,18 @@ public:
     void setBuildCost(int value) {
         m_cost = value;
     }
-    void setIsBuilding(bool value) {
-        m_building = value;
+    void pauseBuilding() {
+        m_state = eBuildingListItemState::PAUSED;
     }
-    void setPaused(bool value) {
-        m_paused = value;
+    void resumeBuilding() {
+        m_state = eBuildingListItemState::BUILDING;
     }
-    void stopBuilding() {
-        setIsBuilding(false);
-        setPaused(false);
+    void cancelBuilding() {
+        m_state = eBuildingListItemState::AVAILABLE;
         resetProgress();
+    }
+    void startBuilding() {
+        m_state = eBuildingListItemState::BUILDING;
     }
     void setStatusPendingUpgrade() {
         m_state = eBuildingListItemState::PENDING_UPGRADE;
@@ -273,8 +275,6 @@ private:
     int m_buildId;			// the ID to build .. (ie TRIKE, or CONSTYARD)
     eBuildType m_type;		// .. of this type of thing (ie, UNIT or STRUCTURE)
     int m_cost;				// price
-    bool m_building;			// building this item? (default = false)
-    bool m_paused;              // construction paused by player?
     eBuildingListItemState m_state;
     int m_progress;			// progress building this item
     int m_buildFrameToDraw;   // for the progress drawing

--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -607,8 +607,7 @@ void cBuildingListUpdater::evaluateUpgrades()
                         // calculate the amount of money back:
                         m_player->giveCredits(item->getRefundAmount());
                     }
-                    item->setIsBuilding(false);
-                    item->resetProgress();
+                    item->cancelBuilding();
                     cItemBuilder *itemBuilder = m_player->getItemBuilder();
                     itemBuilder->removeItemFromList(item);
                 }

--- a/src/sidebar/cSideBar.cpp
+++ b/src/sidebar/cSideBar.cpp
@@ -209,7 +209,7 @@ void cSideBar::onMouseClickedLeft(const s_MouseEvent &event)
             m_player->setContextMouseState(eMouseState::MOUSESTATE_DEPLOY);
         }
         else if (item->isPaused()) {
-            item->setPaused(false);
+            item->startBuilding();
         }
         else {
             startBuildingItemIfOk(item);
@@ -242,14 +242,15 @@ void cSideBar::onMouseClickedRight(const s_MouseEvent &event)
 
     // anything but the starport can 'build' things
     if (list->getType() != eListType::LIST_STARPORT) {
-        if (item->isBuilding() && !item->isPaused()) {
-            item->setPaused(true);
+        if (!item->isPaused() &&
+            item->isBuilding() &&
+            !item->isTypeUpgrade()) { // cannot pause upgrades
+            item->pauseBuilding();
         }
         else {
             cancelBuildingListItem(item);
         }
-    }
-    else {
+    } else {
         cOrderProcesser *orderProcesser = m_player->getOrderProcesser();
 
         d2tm_assert(orderProcesser);
@@ -277,8 +278,7 @@ void cSideBar::cancelBuildingListItem(cBuildingListItem *item)
                 m_player->giveCredits(item->getRefundAmount());
                 m_player->getBuildingListUpdater()->onBuildItemCancelled(item);
             }
-            item->setIsBuilding(false);
-            item->resetProgress();
+            item->cancelBuilding();
 
             // notify game that the item just has been cancelled, just before the actual removal
             const s_GameEvent event {

--- a/src/sidebar/cSideBar.cpp
+++ b/src/sidebar/cSideBar.cpp
@@ -208,6 +208,9 @@ void cSideBar::onMouseClickedLeft(const s_MouseEvent &event)
         else if (item->shouldDeployIt()) {
             m_player->setContextMouseState(eMouseState::MOUSESTATE_DEPLOY);
         }
+        else if (item->isPaused()) {
+            item->setPaused(false);
+        }
         else {
             startBuildingItemIfOk(item);
         }
@@ -239,7 +242,12 @@ void cSideBar::onMouseClickedRight(const s_MouseEvent &event)
 
     // anything but the starport can 'build' things
     if (list->getType() != eListType::LIST_STARPORT) {
-        cancelBuildingListItem(item);
+        if (item->isBuilding() && !item->isPaused()) {
+            item->setPaused(true);
+        }
+        else {
+            cancelBuildingListItem(item);
+        }
     }
     else {
         cOrderProcesser *orderProcesser = m_player->getOrderProcesser();


### PR DESCRIPTION
Closes #1008

## Summary

- Right-clicking a sidebar item that is actively building **pauses** it instead of cancelling
- The progress bar stays frozen at its current point and a yellow **"Paused"** label appears over the icon
- Left-clicking a paused item **resumes** construction from where it stopped
- Right-clicking a **paused** item **cancels** it with the normal partial credit refund

## How it works

- Added `PAUSED` to `eBuildingListItemState` so `m_state` is the single source of truth for build status (no separate boolean flags)
- `cBuildingListItem` exposes `pauseBuilding()` / `resumeBuilding()` / `startBuilding()` / `cancelBuilding()` instead of bool setters
- `cItemBuilder::thinkFast()` skips the progress/credit tick when `isPaused()`, leaving the item in the queue so the progress bar remains visible
- `cSideBar::onMouseClickedRight()` pauses if actively building; cancels if already paused or un-started
- `cSideBar::onMouseClickedLeft()` calls `resumeBuilding()` on a paused item
- `cBuildingListDrawer` renders "Paused" in yellow over the frozen progress bar

## Test plan

- Start building a unit or structure
- Right-click its portrait → confirm progress bar freezes and "Paused" label appears, credits stop draining
- Left-click the paused item → confirm construction resumes from the same progress point
- Right-click the paused item → confirm it is cancelled and partial credits are refunded
- Right-click an item that has not started building yet → confirm it is removed from the queue (existing behaviour unchanged)