### PR TITLE
Fixed Infantry Soldier, not being able to shoot the correct distance.

### DIFF
--- a/resources/game.ini
+++ b/resources/game.ini
@@ -267,7 +267,7 @@ MoveSpeed=1
 TurnSpeed=1
 AttackFrequency=10
 Sight=2
-Range=1
+Range=2
 
 ; Build properties + Sidebar
 BuildTime=5


### PR DESCRIPTION
Fixed Soldier not being able to shoot a distance of 2 tiles like their squad counterparts and the original game.

Issue [#1197](https://github.com/stefanhendriks/Dune-II---The-Maker/issues/1197)

## **Goal**

Fix Infantry Soldiers Range.

### Changes

Changed Infantry Soldier Range from `1` to `2`


## Testing Steps

Build soldiers, check if you can shoot 2 tiles.
play ordos mission 2, check if you can even win.

## Screenshots (optional)