### PR TITLE
Fix range for rocket troopers to be more like Dune 2

### DIFF
--- a/resources/game.ini
+++ b/resources/game.ini
@@ -301,7 +301,7 @@ MoveSpeed=1
 TurnSpeed=1
 AttackFrequency=15
 Sight=3
-Range=3
+Range=5
 
 ; Build properties + Sidebar
 BuildTime=5
@@ -317,7 +317,7 @@ MoveSpeed=1
 TurnSpeed=1
 AttackFrequency=18
 Sight=4
-Range=4
+Range=5
 
 ; Build properties + Sidebar
 BuildTime=38
@@ -350,7 +350,7 @@ MoveSpeed=1
 TurnSpeed=1
 AttackFrequency=16
 Sight=6
-Range=5
+Range=6
 
 ; Build properties + Sidebar
 ; Buildtime = 1000, equals saboteur
@@ -369,7 +369,7 @@ MoveSpeed=4
 TurnSpeed=2
 AttackFrequency=16
 Sight=6
-Range=5
+Range=6
 
 ; Build properties + Sidebar
 ; Buildtime = 1000, equals saboteur


### PR DESCRIPTION
[Issue #1206](https://github.com/stefanhendriks/Dune-II---The-Maker/issues/1206)

## **Goal**

I've asked Danzemon to test the original game to find out the true ranges for troopers, which is 5 for both squad and single

ours is 3, so I've made this correction to the game.ini

### Changes

- I changed rocket trooper range from 3 - 5
- And I changed rocket trooper squads range from 3 - 5
- So that I could restore the original feel and power of the troopers
- I've also increased the range of Fremen troopers from 5 - 6 to maintain their edge over regular troopers.


## Testing Steps
Play the with the troopers, and check their range = 5
player with the fremen, check their range = 6