### PR TITLE
Updates to game rules (game.ini) in an effort re-balance infantry

### DIFF
--- a/resources/game.ini
+++ b/resources/game.ini
@@ -265,7 +265,7 @@ Cost=125
 HitPoints=40
 MoveSpeed=1
 TurnSpeed=1
-AttackFrequency=10
+AttackFrequency=6
 Sight=2
 Range=2
 
@@ -280,10 +280,10 @@ Cost=60
 ; -----------------
 [UNIT: INFANTRY]
 ; Unit properties
-HitPoints=80
+HitPoints=120
 MoveSpeed=1
 TurnSpeed=1
-AttackFrequency=13
+AttackFrequency=6
 Sight=3
 Range=2
 
@@ -312,10 +312,10 @@ Cost=80
 ; -----------------
 [UNIT: TROOPERS]
 ; Unit properties
-HitPoints=100
+HitPoints=180
 MoveSpeed=1
 TurnSpeed=1
-AttackFrequency=18
+AttackFrequency=15
 Sight=4
 Range=5
 
@@ -348,7 +348,7 @@ BuildTime=5
 HitPoints=150
 MoveSpeed=1
 TurnSpeed=1
-AttackFrequency=16
+AttackFrequency=14
 Sight=6
 Range=6
 
@@ -364,10 +364,10 @@ Unit: Triple fremen (Atreides)
 ; -----------------
 [UNIT: THREEFREMEN]
 ; Unit properties
-HitPoints=250
+HitPoints=450
 MoveSpeed=4
 TurnSpeed=2
-AttackFrequency=16
+AttackFrequency=14
 Sight=6
 Range=6
 


### PR DESCRIPTION
These suggested improvements are based on the fact many infantry had strange stats that didn't reflect what we saw (for example being a squad doesn't have 3x health as you would expect for having 3x units wrapped into one)

[Issue #1209](https://github.com/stefanhendriks/Dune-II---The-Maker/issues/1209)

## **Goal**

Balance changes to infantry to help make them less weak and better reflect what you actually see on the battefield
(a trooper squad should have 3x the health of a single trooper etc.)

### Changes

I made changes to the game.ini
Increased health of squads (3x of the singleton versions)
Increased rate of fire for infantry & squads.
Changed range values to squads and singletons share the same value.


## Testing Steps
Let me do my thing.

## Additional Notes

These changes should be considered experimental and could be reverted or altered further if testing demands it.