### PR TITLE
Notifications shown only for the currently controlled player

### DIFF
--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -261,6 +261,7 @@ private:
     std::unique_ptr<cScreenShake> m_screenShake;
     std::unique_ptr<cNotificationArea> m_notificationArea;
     std::unique_ptr<GuiConsole> m_guiConsole;
+    cPlayer *m_controlledPlayer = nullptr;
 
     void thinkFast_audio();
     void thinkFast_fading();

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1169,7 +1169,9 @@ void cGame::dispatchGameEvent(const s_GameEvent &event)
 
     if (event.eventType == eGameEventType::GAME_EVENT_NOTIFICATION) {
         if (const auto *notifEvent = std::get_if<NotificationEvent>(&event.data)) {
-            addNotification(notifEvent->message, notifEvent->type);
+            if (notifEvent->player == nullptr || notifEvent->player == m_controlledPlayer) {
+                m_notificationArea->addNotification(notifEvent->message, notifEvent->type);
+            }
         }
     }
 

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1148,6 +1148,7 @@ void cGame::thinkFast()
 
 void cGame::setPlayerToInteractFor(cPlayer *pPlayer)
 {
+    m_controlledPlayer = pPlayer;
     m_interactionManager->setPlayerToInteractFor(pPlayer);
 }
 

--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -1707,6 +1707,7 @@ void cPlayer::onNotifyGameEvent(const s_GameEvent &event)
                         .data = NotificationEvent {
                             .message = msg,
                             .type = eNotificationType::PRIORITY,
+                            .player = this,
                         }
                     };
                     m_interface->onNotifyGameEvent(newEvent);

--- a/src/include/sGameEvent.h
+++ b/src/include/sGameEvent.h
@@ -80,6 +80,7 @@ struct CommonEvent {
 struct NotificationEvent {
     std::string message;
     eNotificationType type = eNotificationType::NEUTRAL;
+    cPlayer *player = nullptr;
 };
 
 struct s_GameEvent {


### PR DESCRIPTION
Fixes #1221.

## What was happening

Notifications (e.g. "Upgrade: X completed.") were shown for every player, not just the one currently being controlled. `NotificationEvent` carried no player reference, so `cGame::onNotifyGameEvent()` added every notification to the global area unconditionally.

## Changes

- Added `cPlayer *player = nullptr` to `NotificationEvent` (`sGameEvent.h`)
- Populated `.player = this` when building the upgrade-completed notification in `cPlayer::onNotifyGameEvent()`
- Added `m_controlledPlayer` to `cGame`, updated in `setPlayerToInteractFor()` 
- Filter in `cGame::onNotifyGameEvent()`: only add the notification when `player == nullptr` (global/system messages) or `player == m_controlledPlayer`

## How to test

1. Start a skirmish with at least one AI opponent
2. Wait for an AI upgrade to complete — no notification should appear for you
3. Build and complete an upgrade yourself — notification should appear