### PR TITLE
Feature Copy Paste on mapEditor 

### DIFF
--- a/src/controls/cKeyBindings.cpp
+++ b/src/controls/cKeyBindings.cpp
@@ -72,6 +72,8 @@ void cKeyBindings::loadDefaults()
     bind(eKeyAction::EDITOR_DISPLAY_AXES, {SDL_SCANCODE_A});
     bind(eKeyAction::EDITOR_UNDO,     {SDL_SCANCODE_Z}, true, false, false);
     bind(eKeyAction::EDITOR_REDO,     {SDL_SCANCODE_Y}, true, false, false);
+    bind(eKeyAction::EDITOR_COPY,     {SDL_SCANCODE_C}, true, false, false);
+    bind(eKeyAction::EDITOR_PASTE,    {SDL_SCANCODE_V}, true, false, false);
 
     // UI / menus
     bind(eKeyAction::MENU_BACK,    {SDL_SCANCODE_ESCAPE});
@@ -150,6 +152,8 @@ const std::vector<std::pair<std::string, eKeyAction>>& cKeyBindings::getActionTa
         {"EDITOR_DISPLAY_AXES",       eKeyAction::EDITOR_DISPLAY_AXES},
         {"EDITOR_UNDO",               eKeyAction::EDITOR_UNDO},
         {"EDITOR_REDO",               eKeyAction::EDITOR_REDO},
+        {"EDITOR_COPY",               eKeyAction::EDITOR_COPY},
+        {"EDITOR_PASTE",              eKeyAction::EDITOR_PASTE},
         {"MENU_BACK",                 eKeyAction::MENU_BACK},
         {"MENU_CONFIRM",              eKeyAction::MENU_CONFIRM},
         {"MENU_CANCEL",               eKeyAction::MENU_CANCEL},

--- a/src/controls/eKeyAction.h
+++ b/src/controls/eKeyAction.h
@@ -59,6 +59,8 @@ enum class eKeyAction {
     EDITOR_DISPLAY_AXES,
     EDITOR_UNDO,
     EDITOR_REDO,
+    EDITOR_COPY,
+    EDITOR_PASTE,
     // UI / menus
     MENU_BACK,
     MENU_CONFIRM,

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -478,6 +478,10 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
                 m_hasChanged = true;
             }
         }
+        if (event.isAction(eKeyAction::EDITOR_COPY)) {
+            //std::cout << "Action : Copy selection to clipboard" << std::endl;
+            copySelectionToClipboard();
+        }
     }
 
     if (event.isType(eKeyEventType::HOLD)) {
@@ -752,6 +756,26 @@ void cEditorState::updateSelectionFromTiles(int startTileX, int startTileY, int 
     m_selectionEndTileX = std::max(startTileX, endTileX);
     m_selectionEndTileY = std::max(startTileY, endTileY);
     m_hasSelection = true;
+}
+
+void cEditorState::copySelectionToClipboard()
+{
+    if (m_mapData == nullptr || !m_hasSelection) {
+        return;
+    }
+    const int width = m_selectionEndTileX - m_selectionStartTileX + 1;
+    const int height = m_selectionEndTileY - m_selectionStartTileY + 1;
+    if (width <= 0 || height <= 0 || (width * height) < 2) {
+        return;
+    }
+
+    m_clipboardTiles.assign(height, std::vector<int>(width, TERRAIN_SAND));
+    for (int y = 0; y < height; y++) {
+        for (int x = 0; x < width; x++) {
+            m_clipboardTiles[y][x] = (*m_mapData)[m_selectionStartTileY + y][m_selectionStartTileX + x];
+        }
+    }
+    m_hasSelection = false;
 }
 
 

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -35,6 +35,8 @@ const Color editorHoveredCellFillColor = Color{255, 230, 64, 96};
 const Color editorHoveredCellBorderColor = Color{255, 230, 64, 220};
 const Color editorSelectionFillColor = Color{255, 255, 255, 40};
 const Color editorSelectionBorderColor = Color{255, 255, 255, 255};
+const Color editorPasteGhostFillColor = Color{64, 208, 255, 60};
+const Color editorPasteGhostBorderColor = Color{64, 208, 255, 220};
 
 
 cEditorState::cEditorState(sGameServices* services) 
@@ -348,6 +350,8 @@ void cEditorState::draw() const
     drawMap();
     drawHoveredCellHighlight();
     drawSelectionRectangle();
+    if (m_displaySelection)
+        drawPastePreviewGhost();
     if (m_displayGrid)
         drawGrid();
     if (m_displayAxes)
@@ -479,12 +483,15 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
             }
         }
         if (event.isAction(eKeyAction::EDITOR_COPY)) {
-            //std::cout << "Action : Copy selection to clipboard" << std::endl;
+            std::cout << "Action : Copy selection to clipboard" << std::endl;
             copySelectionToClipboard();
         }
         if (event.isAction(eKeyAction::EDITOR_PASTE)) {
-            //std::cout << "Action : Paste selection to clipboard" << std::endl;
+            std::cout << "Action : Paste selection to clipboard" << std::endl;
             pasteClipboardAtMouseCursor();
+        }
+        if (!event.isShiftPressed()) {
+            m_displaySelection = false;
         }
     }
 
@@ -508,10 +515,15 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
         if (event.isShiftPressed() && event.isAction(eKeyAction::SCROLL_UP)) {
             m_editorCam->zoomAtMapPosition(mapSizeArea.getWidth()/2, mapSizeArea.getHeight()/2, cEditorCam::ZoomDirection::zoomIn, *m_mapData);
             m_editorCam->updateVisibleTiles(*m_mapData);
+            return;
         }
         if (event.isShiftPressed() && event.isAction(eKeyAction::SCROLL_DOWN)) {
             m_editorCam->zoomAtMapPosition(mapSizeArea.getWidth()/2, mapSizeArea.getHeight()/2, cEditorCam::ZoomDirection::zoomOut, *m_mapData);
             m_editorCam->updateVisibleTiles(*m_mapData);
+            return;
+        }
+        if (event.isShiftPressed()) {
+            m_displaySelection = true;
         }
         //to test : updateVisibleTiles();
     }
@@ -539,6 +551,7 @@ void cEditorState::loadMap(int mapIndex)
     normalizeModifications();
     m_displayGrid = false;
     m_displayAxes = false;
+    m_displaySelection = false;
     m_hasChanged = false;
     m_hasSelection = false;
     m_isDraggingSelection = false;
@@ -713,6 +726,39 @@ void cEditorState::drawSelectionRectangle() const
     cRectangle selectionRect(cellScreenX, cellScreenY, highlightWidth, highlightHeight);
     m_renderDrawer->renderRectFillColor(selectionRect, editorSelectionFillColor, editorSelectionFillColor.a);
     m_renderDrawer->renderRectColor(selectionRect, editorSelectionBorderColor, editorSelectionBorderColor.a);
+}
+
+void cEditorState::drawPastePreviewGhost() const
+{
+    if (m_mapData == nullptr || m_clipboardTiles.empty() || m_clipboardTiles.front().empty()) {
+        return;
+    }
+
+    cMouse *mouse = m_interface->getMouse();
+    int anchorTileX = 0;
+    int anchorTileY = 0;
+    if (!tryGetTileFromMouseCoords(mouse->getMouseCoords(), anchorTileX, anchorTileY)) {
+        return;
+    }
+
+    const int widthInTiles = static_cast<int>(m_clipboardTiles.front().size());
+    const int heightInTiles = static_cast<int>(m_clipboardTiles.size());
+    if (widthInTiles <= 0 || heightInTiles <= 0) {
+        return;
+    }
+
+    const int cameraX = m_editorCam->getCameraX();
+    const int cameraY = m_editorCam->getCameraY();
+    const int tileLenSize = m_editorCam->getTileSize();
+
+    const int cellScreenX = anchorTileX * tileLenSize - cameraX;
+    const int cellScreenY = heightBarSize + anchorTileY * tileLenSize - cameraY;
+    const int ghostWidth = widthInTiles * tileLenSize;
+    const int ghostHeight = heightInTiles * tileLenSize;
+
+    cRectangle ghostRect(cellScreenX, cellScreenY, ghostWidth, ghostHeight);
+    m_renderDrawer->renderRectFillColor(ghostRect, editorPasteGhostFillColor, editorPasteGhostFillColor.a);
+    m_renderDrawer->renderRectColor(ghostRect, editorPasteGhostBorderColor, editorPasteGhostBorderColor.a);
 }
 
 bool cEditorState::tryGetTileFromMouseCoords(const cPoint &coords, int &tileX, int &tileY) const

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -490,7 +490,7 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
             std::cout << "Action : Paste selection to clipboard" << std::endl;
             pasteClipboardAtMouseCursor();
         }
-        if (!event.isShiftPressed()) {
+        if (!event.isCtrlPressed()) {
             m_displaySelection = false;
         }
     }
@@ -522,7 +522,7 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
             m_editorCam->updateVisibleTiles(*m_mapData);
             return;
         }
-        if (event.isShiftPressed()) {
+        if (event.isCtrlPressed()) {
             m_displaySelection = true;
         }
         //to test : updateVisibleTiles();

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -482,6 +482,10 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
             //std::cout << "Action : Copy selection to clipboard" << std::endl;
             copySelectionToClipboard();
         }
+        if (event.isAction(eKeyAction::EDITOR_PASTE)) {
+            //std::cout << "Action : Paste selection to clipboard" << std::endl;
+            pasteClipboardAtMouseCursor();
+        }
     }
 
     if (event.isType(eKeyEventType::HOLD)) {
@@ -778,6 +782,50 @@ void cEditorState::copySelectionToClipboard()
     m_hasSelection = false;
 }
 
+void cEditorState::pasteClipboardAtMouseCursor()
+{
+    if (m_mapData == nullptr || m_clipboardTiles.empty() || m_clipboardTiles.front().empty()) {
+        return;
+    }
+
+    cMouse *mouse = m_interface->getMouse();
+    int anchorTileX = 0;
+    int anchorTileY = 0;
+    if (!tryGetTileFromMouseCoords(mouse->getMouseCoords(), anchorTileX, anchorTileY)) {
+        return;
+    }
+
+    bool hasRecordedGroup = false;
+    const int height = static_cast<int>(m_clipboardTiles.size());
+    const int width = static_cast<int>(m_clipboardTiles.front().size());
+    for (int y = 0; y < height; y++) {
+        for (int x = 0; x < width; x++) {
+            const int destTileX = anchorTileX + x;
+            const int destTileY = anchorTileY + y;
+            if (!isEditableTile(destTileX, destTileY)) {
+                continue;
+            }
+
+            const int newTileID = m_clipboardTiles[y][x];
+            const int oldTileID = (*m_mapData)[destTileY][destTileX];
+            if (oldTileID == newTileID) {
+                continue;
+            }
+
+            if (!hasRecordedGroup) {
+                m_undoRedo->beginRecordGroup();
+                hasRecordedGroup = true;
+            }
+
+            m_undoRedo->recordTileChange(destTileX, destTileY, oldTileID, newTileID);
+            (*m_mapData)[destTileY][destTileX] = newTileID;
+        }
+    }
+
+    if (hasRecordedGroup) {
+        m_hasChanged = true;
+    }
+}
 
 int cEditorState::getNormalizedCursorSize() const
 {

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -33,6 +33,8 @@ const Color editorGridColor = Color{128, 128, 128, 180};
 const Color editorCenterLineColor = Color{32, 176, 32, 220};
 const Color editorHoveredCellFillColor = Color{255, 230, 64, 96};
 const Color editorHoveredCellBorderColor = Color{255, 230, 64, 220};
+const Color editorSelectionFillColor = Color{255, 255, 255, 40};
+const Color editorSelectionBorderColor = Color{255, 255, 255, 255};
 
 
 cEditorState::cEditorState(sGameServices* services) 
@@ -345,6 +347,7 @@ void cEditorState::draw() const
 {
     drawMap();
     drawHoveredCellHighlight();
+    drawSelectionRectangle();
     if (m_displayGrid)
         drawGrid();
     if (m_displayAxes)
@@ -361,6 +364,18 @@ void cEditorState::onNotifyMouseEvent(const s_MouseEvent &event)
     if (m_mapData == nullptr) {
         return;
     }
+
+    if (event.eventType == MOUSE_RIGHT_BUTTON_CLICKED) {
+        if (m_hasSelection) {
+            const int selectionWidth = m_selectionEndTileX - m_selectionStartTileX + 1;
+            const int selectionHeight = m_selectionEndTileY - m_selectionStartTileY + 1;
+            if (selectionWidth * selectionHeight < 2) {
+                m_hasSelection = false;
+            }
+        }
+        m_isDraggingSelection = false;
+    }
+
     if (event.coords.isWithinRectangle(&mapSizeArea)) {
         // Zoom centered on the cursor
         int mouseX = event.coords.x;
@@ -371,6 +386,24 @@ void cEditorState::onNotifyMouseEvent(const s_MouseEvent &event)
         } else if (event.eventType == MOUSE_SCROLLED_UP) {
             m_editorCam->zoomAtMapPosition(mouseX, mouseY, cEditorCam::ZoomDirection::zoomIn, *m_mapData);
             m_editorCam->updateVisibleTiles(*m_mapData);
+        } else if (event.eventType == MOUSE_RIGHT_BUTTON_PRESSED) {
+            int tileX = 0;
+            int tileY = 0;
+            if (tryGetTileFromMouseCoords(event.coords, tileX, tileY) && isEditableTile(tileX, tileY)) {
+                if (!m_isDraggingSelection) {
+                    m_selectionAnchorTileX = tileX;
+                    m_selectionAnchorTileY = tileY;
+                    m_isDraggingSelection = true;
+                    m_hasSelection = true;
+                }
+                updateSelectionFromTiles(m_selectionAnchorTileX, m_selectionAnchorTileY, tileX, tileY);
+            }
+        } else if (event.eventType == MOUSE_MOVED_TO && m_isDraggingSelection) {
+            int tileX = 0;
+            int tileY = 0;
+            if (tryGetTileFromMouseCoords(event.coords, tileX, tileY)) {
+                updateSelectionFromTiles(m_selectionAnchorTileX, m_selectionAnchorTileY, tileX, tileY);
+            }
         } else if (event.eventType == MOUSE_LEFT_BUTTON_PRESSED && m_currentBar == m_topologyBar.get()) {
             modifyTile(mouseX, mouseY, idTerrainToMapModif);
         }else if (event.eventType == MOUSE_LEFT_BUTTON_PRESSED && m_currentBar == m_startCellBar.get()) {
@@ -499,6 +532,8 @@ void cEditorState::loadMap(int mapIndex)
     m_displayGrid = false;
     m_displayAxes = false;
     m_hasChanged = false;
+    m_hasSelection = false;
+    m_isDraggingSelection = false;
     m_undoRedo->clear();
 }
 
@@ -652,6 +687,73 @@ void cEditorState::drawHoveredCellHighlight() const
     m_renderDrawer->renderRectFillColor(cellRect, editorHoveredCellFillColor, editorHoveredCellFillColor.a);
     m_renderDrawer->renderRectColor(cellRect, editorHoveredCellBorderColor, editorHoveredCellBorderColor.a);
 }
+
+void cEditorState::drawSelectionRectangle() const
+{
+    if (m_mapData == nullptr || !m_hasSelection) {
+        return;
+    }
+    const int cameraX = m_editorCam->getCameraX();
+    const int cameraY = m_editorCam->getCameraY();
+    const int tileLenSize = m_editorCam->getTileSize();
+
+    const int cellScreenX = m_selectionStartTileX * tileLenSize - cameraX;
+    const int cellScreenY = heightBarSize + m_selectionStartTileY * tileLenSize - cameraY;
+    const int highlightWidth = (m_selectionEndTileX - m_selectionStartTileX + 1) * tileLenSize;
+    const int highlightHeight = (m_selectionEndTileY - m_selectionStartTileY + 1) * tileLenSize;
+
+    cRectangle selectionRect(cellScreenX, cellScreenY, highlightWidth, highlightHeight);
+    m_renderDrawer->renderRectFillColor(selectionRect, editorSelectionFillColor, editorSelectionFillColor.a);
+    m_renderDrawer->renderRectColor(selectionRect, editorSelectionBorderColor, editorSelectionBorderColor.a);
+}
+
+bool cEditorState::tryGetTileFromMouseCoords(const cPoint &coords, int &tileX, int &tileY) const
+{
+    if (!coords.isWithinRectangle(&mapSizeArea)) {
+        return false;
+    }
+
+    tileX = m_editorCam->screenToTileX(coords.x);
+    tileY = m_editorCam->screenToTileY(coords.y - mapSizeArea.getY());
+    if (tileX < 0 || tileY < 0 || tileX >= static_cast<int>(m_mapData->getCols()) || tileY >= static_cast<int>(m_mapData->getRows())) {
+        return false;
+    }
+
+    return true;
+}
+
+bool cEditorState::isEditableTile(int tileX, int tileY) const
+{
+    if (m_mapData == nullptr) {
+        return false;
+    }
+
+    return tileX >= 1 && tileY >= 1 && tileX < static_cast<int>(m_mapData->getCols()) - 1 && tileY < static_cast<int>(m_mapData->getRows()) - 1;
+}
+
+void cEditorState::updateSelectionFromTiles(int startTileX, int startTileY, int endTileX, int endTileY)
+{
+    if (m_mapData == nullptr) {
+        return;
+    }
+
+    const int minX = 1;
+    const int minY = 1;
+    const int maxX = static_cast<int>(m_mapData->getCols()) - 2;
+    const int maxY = static_cast<int>(m_mapData->getRows()) - 2;
+
+    startTileX = std::clamp(startTileX, minX, maxX);
+    startTileY = std::clamp(startTileY, minY, maxY);
+    endTileX = std::clamp(endTileX, minX, maxX);
+    endTileY = std::clamp(endTileY, minY, maxY);
+
+    m_selectionStartTileX = std::min(startTileX, endTileX);
+    m_selectionStartTileY = std::min(startTileY, endTileY);
+    m_selectionEndTileX = std::max(startTileX, endTileX);
+    m_selectionEndTileY = std::max(startTileY, endTileY);
+    m_hasSelection = true;
+}
+
 
 int cEditorState::getNormalizedCursorSize() const
 {

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -737,7 +737,7 @@ void cEditorState::drawPastePreviewGhost() const
     cMouse *mouse = m_interface->getMouse();
     int anchorTileX = 0;
     int anchorTileY = 0;
-    if (!tryGetTileFromMouseCoords(mouse->getMouseCoords(), anchorTileX, anchorTileY)) {
+    if (!tryGetEditableTileFromMouseCoords(mouse->getMouseCoords(), anchorTileX, anchorTileY)) {
         return;
     }
 
@@ -773,6 +773,25 @@ bool cEditorState::tryGetTileFromMouseCoords(const cPoint &coords, int &tileX, i
         return false;
     }
 
+    return true;
+}
+
+bool cEditorState::tryGetEditableTileFromMouseCoords(const cPoint &coords, int &tileX, int &tileY) const
+{
+    if (m_mapData == nullptr || !tryGetTileFromMouseCoords(coords, tileX, tileY)) {
+        return false;
+    }
+
+    const int minX = 1;
+    const int minY = 1;
+    const int maxX = static_cast<int>(m_mapData->getCols()) - 2;
+    const int maxY = static_cast<int>(m_mapData->getRows()) - 2;
+    if (maxX < minX || maxY < minY) {
+        return false;
+    }
+
+    tileX = std::clamp(tileX, minX, maxX);
+    tileY = std::clamp(tileY, minY, maxY);
     return true;
 }
 
@@ -837,7 +856,7 @@ void cEditorState::pasteClipboardAtMouseCursor()
     cMouse *mouse = m_interface->getMouse();
     int anchorTileX = 0;
     int anchorTileY = 0;
-    if (!tryGetTileFromMouseCoords(mouse->getMouseCoords(), anchorTileX, anchorTileY)) {
+    if (!tryGetEditableTileFromMouseCoords(mouse->getMouseCoords(), anchorTileX, anchorTileY)) {
         return;
     }
 

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -483,11 +483,11 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
             }
         }
         if (event.isAction(eKeyAction::EDITOR_COPY)) {
-            std::cout << "Action : Copy selection to clipboard" << std::endl;
+            //std::cout << "Action : Copy selection to clipboard" << std::endl;
             copySelectionToClipboard();
         }
         if (event.isAction(eKeyAction::EDITOR_PASTE)) {
-            std::cout << "Action : Paste selection to clipboard" << std::endl;
+            //std::cout << "Action : Paste selection to clipboard" << std::endl;
             pasteClipboardAtMouseCursor();
         }
         if (!event.isCtrlPressed()) {

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -350,7 +350,7 @@ void cEditorState::draw() const
     drawMap();
     drawHoveredCellHighlight();
     drawSelectionRectangle();
-    if (m_displaySelection)
+    if (m_displayPastPreview)
         drawPastePreviewGhost();
     if (m_displayGrid)
         drawGrid();
@@ -491,7 +491,7 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
             pasteClipboardAtMouseCursor();
         }
         if (!event.isCtrlPressed()) {
-            m_displaySelection = false;
+            m_displayPastPreview = false;
         }
     }
 
@@ -523,7 +523,7 @@ void cEditorState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
             return;
         }
         if (event.isCtrlPressed()) {
-            m_displaySelection = true;
+            m_displayPastPreview = true;
         }
         //to test : updateVisibleTiles();
     }
@@ -551,7 +551,7 @@ void cEditorState::loadMap(int mapIndex)
     normalizeModifications();
     m_displayGrid = false;
     m_displayAxes = false;
-    m_displaySelection = false;
+    m_displayPastPreview = false;
     m_hasChanged = false;
     m_hasSelection = false;
     m_isDraggingSelection = false;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -70,6 +70,7 @@ private:
     bool isEditableTile(int tileX, int tileY) const;
     void updateSelectionFromTiles(int startTileX, int startTileY, int endTileX, int endTileY);
     void copySelectionToClipboard();
+    void pasteClipboardAtMouseCursor();
 
     void saveMap(bool backup = false) const;
     std::unique_ptr<GuiBar> m_selectBar;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <array>
 #include <string>
+#include <vector>
 
 class Texture;
 class Graphics;
@@ -55,6 +56,7 @@ private:
 
     void drawMap() const;
     void drawHoveredCellHighlight() const;
+    void drawSelectionRectangle() const;
     void drawStartCells() const;
     void drawGrid() const;
     void drawAxes() const;
@@ -64,6 +66,9 @@ private:
     void modifyTile(int posX, int posY, int tileID);
     void modifyStartCell(int posX, int posY, int startCellID);
     void normalizeModifications();
+    bool tryGetTileFromMouseCoords(const cPoint &coords, int &tileX, int &tileY) const;
+    bool isEditableTile(int tileX, int tileY) const;
+    void updateSelectionFromTiles(int startTileX, int startTileY, int endTileX, int endTileY);
 
     void saveMap(bool backup = false) const;
     std::unique_ptr<GuiBar> m_selectBar;
@@ -90,6 +95,17 @@ private:
     bool m_displayGrid = false;
     bool m_displayAxes = false;
     bool m_hasChanged = false;
+
+    bool m_hasSelection = false;
+    bool m_isDraggingSelection = false;
+    int m_selectionStartTileX = 1;
+    int m_selectionStartTileY = 1;
+    int m_selectionEndTileX = 1;
+    int m_selectionEndTileY = 1;
+    int m_selectionAnchorTileX = 1;
+    int m_selectionAnchorTileY = 1;
+
+    std::vector<std::vector<int>> m_clipboardTiles;
 
     // startCell positions 
     std::array<cPoint,5> startCells;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -98,7 +98,7 @@ private:
     bool m_displayGrid = false;
     bool m_displayAxes = false;
     bool m_hasChanged = false;
-    bool m_displaySelection = false;
+    bool m_displayPastPreview = false;
 
     bool m_hasSelection = false;
     bool m_isDraggingSelection = false;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -57,6 +57,7 @@ private:
     void drawMap() const;
     void drawHoveredCellHighlight() const;
     void drawSelectionRectangle() const;
+    void drawPastePreviewGhost() const;
     void drawStartCells() const;
     void drawGrid() const;
     void drawAxes() const;
@@ -97,6 +98,7 @@ private:
     bool m_displayGrid = false;
     bool m_displayAxes = false;
     bool m_hasChanged = false;
+    bool m_displaySelection = false;
 
     bool m_hasSelection = false;
     bool m_isDraggingSelection = false;

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -68,6 +68,7 @@ private:
     void modifyStartCell(int posX, int posY, int startCellID);
     void normalizeModifications();
     bool tryGetTileFromMouseCoords(const cPoint &coords, int &tileX, int &tileY) const;
+    bool tryGetEditableTileFromMouseCoords(const cPoint &coords, int &tileX, int &tileY) const;
     bool isEditableTile(int tileX, int tileY) const;
     void updateSelectionFromTiles(int startTileX, int startTileY, int endTileX, int endTileY);
     void copySelectionToClipboard();

--- a/src/gamestates/cEditorState.h
+++ b/src/gamestates/cEditorState.h
@@ -69,6 +69,7 @@ private:
     bool tryGetTileFromMouseCoords(const cPoint &coords, int &tileX, int &tileY) const;
     bool isEditableTile(int tileX, int tileY) const;
     void updateSelectionFromTiles(int startTileX, int startTileY, int endTileX, int endTileY);
+    void copySelectionToClipboard();
 
     void saveMap(bool backup = false) const;
     std::unique_ptr<GuiBar> m_selectBar;


### PR DESCRIPTION
For #800 

## **Goal**

Add possibility to COPY PAST an area selected with right mouse bottom 

### New behavior
- select copy area with right mouse bottom
- CTRL+C will COPY the selected area (We cannot copy an area of size 1x1)
- CTRL+V will PAST the copied area
- Press SHIFT will display a preview of PAST area

## Screenshots

<img width="1051" height="820" alt="Capture d’écran du 2026-05-24 01-10-29" src="https://github.com/user-attachments/assets/5fcbb93e-5288-424d-8cd1-c5e46a68f68e" />

<img width="1008" height="705" alt="Capture d’écran du 2026-05-24 01-10-56" src="https://github.com/user-attachments/assets/ba7e0063-2191-429f-9282-08d6f212b4c9" />


