### PR TITLE
Unmodified key bindings no longer fire when modifier keys are held

### DIFF
--- a/src/controls/cKeyBindings.cpp
+++ b/src/controls/cKeyBindings.cpp
@@ -240,6 +240,18 @@ bool cKeyBindings::matches(const std::set<SDL_Scancode> &keys, const s_KeysCombo
     if (binding.requireAlt   && !combo.altPressed)   return false;
     if (binding.requireShift && !combo.shiftPressed)  return false;
 
+    // A binding that doesn't require a modifier must not fire when that modifier is active,
+    // unless the modifier key itself is one of the binding's keys (e.g. ATTACK_MODE uses LCTRL as its key).
+    auto keysContain = [&](SDL_Scancode sc1, SDL_Scancode sc2) {
+        for (SDL_Scancode sc : binding.keys) {
+            if (sc == sc1 || sc == sc2) return true;
+        }
+        return false;
+    };
+    if (!binding.requireCtrl  && combo.ctrlPressed  && !keysContain(SDL_SCANCODE_LCTRL,  SDL_SCANCODE_RCTRL))  return false;
+    if (!binding.requireAlt   && combo.altPressed   && !keysContain(SDL_SCANCODE_LALT,   SDL_SCANCODE_RALT))   return false;
+    if (!binding.requireShift && combo.shiftPressed && !keysContain(SDL_SCANCODE_LSHIFT, SDL_SCANCODE_RSHIFT)) return false;
+
     for (SDL_Scancode sc : binding.keys) {
         if (keys.count(sc) > 0) return true;
     }


### PR DESCRIPTION
## Summary

- Fixes a bug where pressing CTRL+Z would trigger both `SELECT_SAME_TYPE_ON_MAP` (intended) and `ZOOM_RESET` (not intended)
- The same class of bug affects any unmodified binding sharing a key with a modifier-required binding (e.g. SHIFT+Z / SELECT_SAME_TYPE_ON_SCREEN also redundantly triggered ZOOM_RESET)

## Root cause

`cKeyBindings::matches()` checked "if a required modifier is missing, reject" but never "if an unrequired modifier is present, reject". So a plain-Z binding matched regardless of whether CTRL was held.

## Fix

After the existing require-checks, added inverse checks in `matches()`: if the binding does not require a modifier but that modifier is active, return false — unless the modifier key itself is one of the binding's listed keys. That carve-out keeps `ATTACK_MODE` (bound to `{LCTRL, RCTRL}` without `requireCtrl`) working correctly.

## Test plan

- [ ] Press Z alone: zoom resets
- [ ] Press CTRL+Z: selects same unit type on map, zoom does NOT reset
- [ ] Press SHIFT+Z: selects same unit type on screen, zoom does NOT reset
- [ ] Hold CTRL and click to attack (attack mode cursor): still works