### PR TITLE
Turret sight, range, and fire rate configurable via game.ini

### DIFF
--- a/resources/game.ini
+++ b/resources/game.ini
@@ -625,6 +625,9 @@ FixPoints=2
 BuildTime=5
 PowerDrain=10
 PowerGive=0
+Sight=7
+Range=7
+FireRate=275
 
 ; ---------------------
 ; Structure: Rocket Turret
@@ -636,6 +639,9 @@ FixPoints=3
 BuildTime=5
 PowerDrain=20
 PowerGive=0
+Sight=10
+Range=7
+FireRate=350
 
 
 ; ==================================================

--- a/src/context/cInfoContextCreator.cpp
+++ b/src/context/cInfoContextCreator.cpp
@@ -1639,6 +1639,7 @@ void cInfoContextCreator::initStructures(cStructureInfos& structureInfos)
     structureInfos[TURRET].fadecol = -1;
     structureInfos[TURRET].icon = ICON_STR_TURRET;
     structureInfos[TURRET].sight = 7;
+    structureInfos[TURRET].range = 7;
     structureInfos[TURRET].configured = true;
     structureInfos[TURRET].canAttackGroundUnits = true;
     structureInfos[TURRET].fireRate = 275;
@@ -1653,6 +1654,7 @@ void cInfoContextCreator::initStructures(cStructureInfos& structureInfos)
     structureInfos[RTURRET].fadecol = -1;
     structureInfos[RTURRET].icon = ICON_STR_RTURRET;
     structureInfos[RTURRET].sight = 10;
+    structureInfos[RTURRET].range = 7;
     structureInfos[RTURRET].configured = true;
     structureInfos[RTURRET].canAttackAirUnits = true;
     structureInfos[RTURRET].canAttackGroundUnits = true;

--- a/src/gameobjects/structures/cAbstractStructure.cpp
+++ b/src/gameobjects/structures/cAbstractStructure.cpp
@@ -161,7 +161,7 @@ int cAbstractStructure::getSight()
 int cAbstractStructure::getRange()
 {
     int type = getType();
-    return game.m_infoContext->getStructureInfo(type).sight;
+    return game.m_infoContext->getStructureInfo(type).range;
 }
 
 

--- a/src/gameobjects/structures/cGunTurret.cpp
+++ b/src/gameobjects/structures/cGunTurret.cpp
@@ -149,9 +149,8 @@ void cGunTurret::think_fire()
 
         int iDistance = game.m_gameObjectsContext->getMapGeometry()->distance(getCell(), unitTarget->getCell());
 
-        if (iDistance > getSight()) {
+        if (iDistance > getRange()) {
             iTargetID = -1;
-            // went out of sight, unfortunately
             return;
         }
 
@@ -231,9 +230,9 @@ void cGunTurret::think_guard()
 
         iTargetID=-1;       // no target
 
-        int distanceForAttacking = getSight();
+        int distanceForAttacking = getRange();
         if (lowPower && getType() == RTURRET) {
-            distanceForAttacking = game.m_infoContext->getStructureInfo(TURRET).sight; // HACK HACK: way to reduce distance for rturret on low power
+            distanceForAttacking = game.m_infoContext->getStructureInfo(TURRET).range;
         }
 
         // scan area for units

--- a/src/gameobjects/structures/cStructureInfo.h
+++ b/src/gameobjects/structures/cStructureInfo.h
@@ -46,6 +46,7 @@ struct s_StructureInfo {
     int power_give;        // the power that this building gives...
 
     int sight;
+    int range;
 
     int fadecol;         // Fading color (if needed), -1 is none, > -1 means starting color
     int fademax;         // Max fading color (assuming fadecol < fademax)

--- a/src/utils/ini.cpp
+++ b/src/utils/ini.cpp
@@ -303,7 +303,10 @@ int INI_WordType(const std::string& word, int section)
         if (word.length() > 1) {
             if (cIniUtils::caseInsCompare(word, "PreBuild"))      return WORD_PREBUILD;
             if (cIniUtils::caseInsCompare(word, "Description"))   return WORD_DESCRIPTION;
-            if (cIniUtils::caseInsCompare(word, "Power"))         return WORD_POWER;        // What power it takes
+            if (cIniUtils::caseInsCompare(word, "Power"))         return WORD_POWER;
+            if (cIniUtils::caseInsCompare(word, "Sight"))         return WORD_SIGHT;
+            if (cIniUtils::caseInsCompare(word, "Range"))         return WORD_RANGE;
+            if (cIniUtils::caseInsCompare(word, "FireRate"))      return WORD_FIRERATE;
         }
         else
             return WORD_NONE;
@@ -1566,6 +1569,9 @@ void cIni::installGame(std::string filename)
                 if (wordtype == WORD_BUILDTIME) m_infos->getStructureInfo(id).buildTime = ToInt(word_right);
                 if (wordtype == WORD_CANATTACKAIRUNITS) m_infos->getStructureInfo(id).canAttackAirUnits = ToBool(word_right);
                 if (wordtype == WORD_CANATTACKUNITS) m_infos->getStructureInfo(id).canAttackGroundUnits = ToBool(word_right);
+                if (wordtype == WORD_SIGHT) m_infos->getStructureInfo(id).sight = ToInt(word_right);
+                if (wordtype == WORD_RANGE) m_infos->getStructureInfo(id).range = ToInt(word_right);
+                if (wordtype == WORD_FIRERATE) m_infos->getStructureInfo(id).fireRate = ToInt(word_right);
                 if (wordtype == WORD_UPON_DESTRUCTION_SPAWN_UNIT_AMOUNT_MIN) m_infos->getStructureInfo(id).uponDestructionSpawnUnitAmountMin = ToInt(word_right);
                 if (wordtype == WORD_UPON_DESTRUCTION_SPAWN_UNIT_AMOUNT_MAX) m_infos->getStructureInfo(id).uponDestructionSpawnUnitAmountMax = ToInt(word_right);
                 if (wordtype == WORD_UPON_DESTRUCTION_SPAWN_UNIT_TYPE) m_infos->getStructureInfo(id).uponDestructionSpawnUnitType = cIniUtils::getUnitTypeFromString(word_right);


### PR DESCRIPTION
Closes #1229

## Summary

- Added a `range` field to `s_StructureInfo`, separate from the existing `sight` field
- `cAbstractStructure::getRange()` now returns `range` instead of `sight`
- `INI_STRUCTURES` parsing now recognises `Sight`, `Range`, and `FireRate` keys
- Both `[STRUCTURE: TURRET]` and `[STRUCTURE: ROCKETTURRET]` in `game.ini` expose these three values
- Removed the hardcoded HACK in `cGunTurret::think_guard()` that reached into `TURRET.sight` to cap the rocket turret's low-power range; it now uses the `range` field consistently

## Default values

| Turret | Sight | Range | FireRate |
|--------|-------|-------|----------|
| Gun Turret | 7 | 7 | 275 |
| Rocket Turret | 10 | 7 | 350 |

Rocket turret range (7) is kept below the rocket launcher unit's range (8), preserving the classic strategy of using launchers to outrange turrets.

## Test plan

- [ ] Gun turret stops targeting units that move beyond range 7
- [ ] Rocket turret stops targeting units that move beyond range 7
- [ ] Changing `Range` in `game.ini` takes effect in-game
- [ ] Rocket turret on low power falls back to gun turret range correctly
- [ ] Rocket launcher can outrange a rocket turret