### PR TITLE
Upgrades can be paused like units and structures

### DIFF
--- a/src/sidebar/cSideBar.cpp
+++ b/src/sidebar/cSideBar.cpp
@@ -243,8 +243,7 @@ void cSideBar::onMouseClickedRight(const s_MouseEvent &event)
     // anything but the starport can 'build' things
     if (list->getType() != eListType::LIST_STARPORT) {
         if (!item->isPaused() &&
-            item->isBuilding() &&
-            !item->isTypeUpgrade()) { // cannot pause upgrades
+            item->isBuilding()) {
             item->pauseBuilding();
         }
         else {


### PR DESCRIPTION
## Summary

- Removes the explicit `!item->isTypeUpgrade()` guard in `cSideBar::onMouseClickedRight` that prevented right-clicking an in-progress upgrade from pausing it
- Right-click on a building upgrade now pauses it (shows "Paused" text, stops credit drain)
- Left-click resumes; right-click on a paused upgrade cancels it — consistent with unit/structure behavior
- All other items remain locked while an upgrade is in progress or paused (no change to that behavior)

All pause/resume infrastructure (`pauseBuilding()`, `cItemBuilder` skip-logic, "Paused" text rendering) already handled upgrades correctly; only the sidebar guard was blocking them.

Closes #1228

Follow-up for building other items while upgrade is paused: #1238

## Test plan

- [ ] Build a Barracks, start an upgrade, right-click the upgrade icon → shows "Paused", does not cancel
- [ ] Left-click the paused upgrade → resumes building
- [ ] Right-click the paused upgrade → cancels and refunds credits
- [ ] Other build items remain locked during a paused upgrade