### PR TITLE
Migrate to SDL3

### DIFF
--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           msystem: MINGW64 # D2TM is built within a MinGW64 bit environment
           update: true
-          install: git gzip zip unzip mingw-w64-x86_64-toolchain mingw64/mingw-w64-x86_64-SDL2 mingw64/mingw-w64-x86_64-SDL2_mixer mingw64/mingw-w64-x86_64-SDL2_image mingw64/mingw-w64-x86_64-SDL2_ttf mingw64/mingw-w64-x86_64-cmake mingw-w64-x86_64-catch
+          install: git gzip zip unzip mingw-w64-x86_64-toolchain mingw-w64-x86_64-sdl3 mingw-w64-x86_64-sdl3-mixer mingw-w64-x86_64-sdl3-image mingw-w64-x86_64-sdl3-ttf mingw64/mingw-w64-x86_64-cmake mingw-w64-x86_64-catch
       - name: configure Pagefile
         uses: al-cheb/configure-pagefile-action@v1.5
         with:

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           msystem: MINGW64 # D2TM is built within a MinGW64 bit environment
           update: true
-          install: git gzip zip unzip mingw-w64-x86_64-toolchain mingw64/mingw-w64-x86_64-SDL2 mingw64/mingw-w64-x86_64-SDL2_mixer mingw64/mingw-w64-x86_64-SDL2_image mingw64/mingw-w64-x86_64-SDL2_ttf mingw64/mingw-w64-x86_64-cmake mingw-w64-x86_64-catch
+          install: git gzip zip unzip mingw-w64-x86_64-toolchain mingw-w64-x86_64-sdl3 mingw-w64-x86_64-sdl3-mixer mingw-w64-x86_64-sdl3-image mingw-w64-x86_64-sdl3-ttf mingw64/mingw-w64-x86_64-cmake mingw-w64-x86_64-catch
       - name: configure Pagefile
         uses: al-cheb/configure-pagefile-action@v1.5
         with:

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           msystem: MINGW64 # D2TM is built within a MinGW64 bit environment
           update: true
-          install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc mingw64/mingw-w64-x86_64-SDL2 mingw64/mingw-w64-x86_64-SDL2_mixer mingw64/mingw-w64-x86_64-SDL2_image mingw64/mingw-w64-x86_64-SDL2_ttf mingw64/mingw-w64-x86_64-cmake mingw-w64-x86_64-catch
+          install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-gcc mingw-w64-x86_64-sdl3 mingw-w64-x86_64-sdl3-mixer mingw-w64-x86_64-sdl3-image mingw-w64-x86_64-sdl3-ttf mingw64/mingw-w64-x86_64-cmake mingw-w64-x86_64-catch
       - name: configure Pagefile
         uses: al-cheb/configure-pagefile-action@v1.5
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,3 +192,17 @@ From comments in `cGame.h`:
 - produce small PR's (a very limited set of changes)
 - branch names are usually: `<prefix>/<ticket-githubnr here>/<short-description-of-feature>`
   - prefixes can be `feature` (new feature), `bugfix` or `improv` (for technical improvements usually)
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (`stefanhendriks/Dune-II---The-Maker`). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default canonical label vocabulary (needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,9 @@ if(APPLE)
     find_package(PkgConfig REQUIRED)
 
     pkg_check_modules(SDL3 REQUIRED sdl3)
-    pkg_check_modules(SDL3_IMAGE REQUIRED SDL3_image)
-    pkg_check_modules(SDL3_TTF REQUIRED SDL3_ttf)
-    pkg_check_modules(SDL3_MIXER REQUIRED SDL3_mixer)
+    pkg_check_modules(SDL3_IMAGE REQUIRED sdl3-image)
+    pkg_check_modules(SDL3_TTF REQUIRED sdl3-ttf)
+    pkg_check_modules(SDL3_MIXER REQUIRED sdl3-mixer)
 
     if(EXISTS "/opt/homebrew/bin/brew")
         set(HOMEBREW_PREFIX "/opt/homebrew")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,14 +32,14 @@ CONFIGURE_FILE (
 add_library(cpp_stacktrace INTERFACE)
 
 if(APPLE)
-    message(STATUS "Using pkg-config to locate SDL2 libraries on macOS")
+    message(STATUS "Using pkg-config to locate SDL3 libraries on macOS")
 
     find_package(PkgConfig REQUIRED)
 
-    pkg_check_modules(SDL2 REQUIRED sdl2)
-    pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
-    pkg_check_modules(SDL2_TTF REQUIRED SDL2_ttf)
-    pkg_check_modules(SDL2_MIXER REQUIRED SDL2_mixer)
+    pkg_check_modules(SDL3 REQUIRED sdl3)
+    pkg_check_modules(SDL3_IMAGE REQUIRED SDL3_image)
+    pkg_check_modules(SDL3_TTF REQUIRED SDL3_ttf)
+    pkg_check_modules(SDL3_MIXER REQUIRED SDL3_mixer)
 
     if(EXISTS "/opt/homebrew/bin/brew")
         set(HOMEBREW_PREFIX "/opt/homebrew")
@@ -56,28 +56,28 @@ if(APPLE)
     )
 
     include_directories(
-      ${SDL2_INCLUDE_DIRS}
-      ${SDL2_IMAGE_INCLUDE_DIRS}
-      ${SDL2_TTF_INCLUDE_DIRS}
-      ${SDL2_MIXER_INCLUDE_DIRS}
+      ${SDL3_INCLUDE_DIRS}
+      ${SDL3_IMAGE_INCLUDE_DIRS}
+      ${SDL3_TTF_INCLUDE_DIRS}
+      ${SDL3_MIXER_INCLUDE_DIRS}
     )
 
     link_directories(
-      ${SDL2_LIBRARY_DIRS}
-      ${SDL2_IMAGE_LIBRARY_DIRS}
-      ${SDL2_TTF_LIBRARY_DIRS}
-      ${SDL2_MIXER_LIBRARY_DIRS}
+      ${SDL3_LIBRARY_DIRS}
+      ${SDL3_IMAGE_LIBRARY_DIRS}
+      ${SDL3_TTF_LIBRARY_DIRS}
+      ${SDL3_MIXER_LIBRARY_DIRS}
     )
 
 else()
-    message(STATUS "Using CMake's find_package to locate SDL2 libraries")
+    message(STATUS "Using CMake's find_package to locate SDL3 libraries")
 
-    find_package(SDL2 REQUIRED)
-    find_package(SDL2_ttf REQUIRED)
-    find_package(SDL2_image REQUIRED)
-    find_package(SDL2_mixer REQUIRED)
+    find_package(SDL3 REQUIRED)
+    find_package(SDL3_ttf REQUIRED)
+    find_package(SDL3_image REQUIRED)
+    find_package(SDL3_mixer REQUIRED)
 
-    link_libraries(SDL2 SDL2_ttf SDL2_mixer SDL2_image)
+    link_libraries(SDL3 SDL3_ttf SDL3_mixer SDL3_image)
 endif()
 
 add_subdirectory(src)
@@ -91,7 +91,6 @@ target_include_directories(${PROJECT_NAME}
 	PRIVATE
     	${CMAKE_CURRENT_SOURCE_DIR}/src
     	${CMAKE_CURRENT_SOURCE_DIR}/src/include
-        /usr/local/include/SDL2
         /usr/local/include
 )
 
@@ -99,7 +98,7 @@ if (APPLE)
 
     target_compile_definitions(${PROJECT_NAME} PRIVATE D2TM_CLANG=1)
 
-    set(ALL_SDL_LIBS ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES} ${SDL2_TTF_LIBRARIES} ${SDL2_MIXER_LIBRARIES})
+    set(ALL_SDL_LIBS ${SDL3_LIBRARIES} ${SDL3_IMAGE_LIBRARIES} ${SDL3_TTF_LIBRARIES} ${SDL3_MIXER_LIBRARIES})
     list(REMOVE_DUPLICATES ALL_SDL_LIBS)
     target_link_libraries(${PROJECT_NAME}
         PRIVATE
@@ -155,8 +154,7 @@ else()
     -static-libgcc
     -static-libstdc++
     -lmingw32
-    -lSDL2main
-    -lSDL2
+    -lSDL3
     -mwindows
   )
     target_link_options(cpp_stacktrace INTERFACE $<$<CONFIG:Debug>:/DEBUG>)

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-example-decision.md
+│   └── 0002-example-decision.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (example decision) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/install_dependencies_macosx.sh
+++ b/install_dependencies_macosx.sh
@@ -9,4 +9,4 @@ echo  ---  Installing dependencies  ---
 echo  ---                           ---
 echo  ---------------------------------
 
-brew install --quiet cmake ninja pkg-config sdl2 sdl2_ttf sdl2_image sdl2_mixer catch2
+brew install --quiet cmake ninja pkg-config sdl3 sdl3_ttf sdl3_image sdl3_mixer catch2

--- a/install_dependencies_ubuntu.sh
+++ b/install_dependencies_ubuntu.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+set -e
 
-# Install for kubuntu
+# Install for Ubuntu / Debian
+# SDL3 is not in Ubuntu 24.04 standard repos, so we build it from source.
 
 echo  ---------------------------------
 echo  ---                           ---
@@ -8,7 +10,56 @@ echo  ---  Installing dependencies  ---
 echo  ---                           ---
 echo  ---------------------------------
 
+sudo apt-get update -qq
 
-sudo apt-get install g++
-sudo apt-get install make cmake
-sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev catch2
+# Build tools
+sudo apt-get install -y --no-install-recommends \
+  g++ cmake ninja-build pkg-config git \
+  catch2
+
+# SDL3 platform dependencies
+sudo apt-get install -y --no-install-recommends \
+  libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev libxss-dev libxtst-dev \
+  libwayland-dev libxkbcommon-dev libegl1-mesa-dev libgl1-mesa-dev \
+  libasound2-dev libpulse-dev
+
+# SDL3_image dependencies
+sudo apt-get install -y --no-install-recommends \
+  libpng-dev libjpeg-dev libwebp-dev
+
+# SDL3_ttf dependencies
+sudo apt-get install -y --no-install-recommends \
+  libfreetype-dev
+
+# SDL3_mixer dependencies
+sudo apt-get install -y --no-install-recommends \
+  libmpg123-dev libvorbis-dev libopus-dev libflac-dev
+
+BUILD_DIR=$(mktemp -d)
+CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -GNinja"
+
+# SDL3
+git clone --depth 1 --branch release-3.4.10 https://github.com/libsdl-org/SDL.git "$BUILD_DIR/SDL3"
+cmake -S "$BUILD_DIR/SDL3" -B "$BUILD_DIR/SDL3/build" $CMAKE_FLAGS \
+  -DSDL_TEST_LIBRARY=OFF
+sudo cmake --build "$BUILD_DIR/SDL3/build" --target install -j4
+
+# SDL3_image
+git clone --depth 1 --branch release-3.4.4 https://github.com/libsdl-org/SDL_image.git "$BUILD_DIR/SDL3_image"
+cmake -S "$BUILD_DIR/SDL3_image" -B "$BUILD_DIR/SDL3_image/build" $CMAKE_FLAGS \
+  -DSDLIMAGE_SAMPLES=OFF
+sudo cmake --build "$BUILD_DIR/SDL3_image/build" --target install -j4
+
+# SDL3_ttf
+git clone --depth 1 --branch release-3.2.2 https://github.com/libsdl-org/SDL_ttf.git "$BUILD_DIR/SDL3_ttf"
+cmake -S "$BUILD_DIR/SDL3_ttf" -B "$BUILD_DIR/SDL3_ttf/build" $CMAKE_FLAGS \
+  -DSDLTTF_SAMPLES=OFF
+sudo cmake --build "$BUILD_DIR/SDL3_ttf/build" --target install -j4
+
+# SDL3_mixer
+git clone --depth 1 --branch release-3.2.2 https://github.com/libsdl-org/SDL_mixer.git "$BUILD_DIR/SDL3_mixer"
+cmake -S "$BUILD_DIR/SDL3_mixer" -B "$BUILD_DIR/SDL3_mixer/build" $CMAKE_FLAGS \
+  -DSDLMIXER_SAMPLES=OFF
+sudo cmake --build "$BUILD_DIR/SDL3_mixer/build" --target install -j4
+
+sudo ldconfig

--- a/rebuildmacos.sh
+++ b/rebuildmacos.sh
@@ -5,4 +5,4 @@ cmake ..
 cmake --build . --target all -- -j 6
 ctest --output-on-failure
 cd ..
-
+cp build/d2tm bin

--- a/src/context/ContextCreator.hpp
+++ b/src/context/ContextCreator.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_ttf.h>
+#include <SDL3/SDL.h>
+#include <SDL3_ttf/SDL_ttf.h>
 #include <memory>
 
 class cFileValidator;

--- a/src/controls/cKeyBindings.cpp
+++ b/src/controls/cKeyBindings.cpp
@@ -235,7 +235,7 @@ void cKeyBindings::checkForClashes() const
     }
 }
 
-bool cKeyBindings::matches(const std::bitset<SDL_NUM_SCANCODES> &keys, const s_KeysCombo &combo, eKeyAction action) const
+bool cKeyBindings::matches(const std::bitset<SDL_SCANCODE_COUNT> &keys, const s_KeysCombo &combo, eKeyAction action) const
 {
     auto it = m_bindings.find(action);
     if (it == m_bindings.end()) return false;
@@ -259,7 +259,7 @@ bool cKeyBindings::matches(const std::bitset<SDL_NUM_SCANCODES> &keys, const s_K
     if (!binding.requireShift && combo.shiftPressed && !keysContain(SDL_SCANCODE_LSHIFT, SDL_SCANCODE_RSHIFT)) return false;
 
     for (SDL_Scancode sc : binding.keys) {
-        if (sc >= 0 && sc < SDL_NUM_SCANCODES && keys.test(static_cast<size_t>(sc))) {
+        if (sc >= 0 && sc < SDL_SCANCODE_COUNT && keys.test(static_cast<size_t>(sc))) {
             return true;
         }
     }

--- a/src/controls/cKeyBindings.h
+++ b/src/controls/cKeyBindings.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <string>
 #include <initializer_list>
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 #include "controls/eKeyAction.h"
 #include "controls/eKeyboardEnum.h"

--- a/src/controls/cKeyBindings.h
+++ b/src/controls/cKeyBindings.h
@@ -27,7 +27,7 @@ public:
      * Returns true when the given key set and modifier combo match the binding for the given action.
      * Called internally by cKeyboardEvent::isAction().
      */
-    bool matches(const std::bitset<SDL_NUM_SCANCODES> &keys, const s_KeysCombo &combo, eKeyAction action) const;
+    bool matches(const std::bitset<SDL_SCANCODE_COUNT> &keys, const s_KeysCombo &combo, eKeyAction action) const;
 
 private:
     std::map<eKeyAction, s_KeyBinding> m_bindings;

--- a/src/controls/cKeyboard.cpp
+++ b/src/controls/cKeyboard.cpp
@@ -43,22 +43,22 @@ void cKeyboard::loadKeyBindings(const cSection *section)
 
 void cKeyboard::handleEvent(const SDL_Event &event)
 {
-    if (event.type == SDL_TEXTINPUT) {
+    if (event.type == SDL_EVENT_TEXT_INPUT) {
         if (event.text.text[0] != '\0') {
             m_textInputs.emplace_back(event.text.text);
         }
         return;
     }
 
-    SDL_Scancode scancode = event.key.keysym.scancode;
+    SDL_Scancode scancode = event.key.scancode;
     if (!isValidScancode(scancode)) return;
 
     const size_t index = toScancodeIndex(scancode);
-    if (event.type == SDL_KEYDOWN && !event.key.repeat) {
+    if (event.type == SDL_EVENT_KEY_DOWN && !event.key.repeat) {
         m_keysPressed.set(index);
         m_keysReleased.reset(index);
     }
-    else if (event.type == SDL_KEYUP) {
+    else if (event.type == SDL_EVENT_KEY_UP) {
         m_keysPressed.reset(index);
         m_keysReleased.set(index);
     }

--- a/src/controls/cKeyboard.cpp
+++ b/src/controls/cKeyboard.cpp
@@ -7,7 +7,7 @@ namespace {
 
 bool isValidScancode(SDL_Scancode scancode)
 {
-    return scancode >= 0 && scancode < SDL_NUM_SCANCODES;
+    return scancode >= 0 && scancode < SDL_SCANCODE_COUNT;
 }
 
 size_t toScancodeIndex(SDL_Scancode scancode)
@@ -15,7 +15,7 @@ size_t toScancodeIndex(SDL_Scancode scancode)
     return static_cast<size_t>(scancode);
 }
 
-bool isPressed(const std::bitset<SDL_NUM_SCANCODES> &keys, SDL_Scancode scancode)
+bool isPressed(const std::bitset<SDL_SCANCODE_COUNT> &keys, SDL_Scancode scancode)
 {
     return isValidScancode(scancode) && keys.test(toScancodeIndex(scancode));
 }
@@ -70,7 +70,7 @@ void cKeyboard::handleEvent(const SDL_Event &event)
 
 void cKeyboard::updateState()
 {
-    static const std::bitset<SDL_NUM_SCANCODES> noKeys;
+    static const std::bitset<SDL_SCANCODE_COUNT> noKeys;
 
     for (const auto &textInput : m_textInputs) {
         m_keyboardObserver->onNotifyKeyboardEvent(cKeyboardEvent(eKeyEventType::PRESSED, noKeys, m_currentCombo, m_keyBindings.get(), textInput));

--- a/src/controls/cKeyboard.h
+++ b/src/controls/cKeyboard.h
@@ -2,7 +2,7 @@
 
 #include "controls/eKeyboardEnum.h"
 #include "observers/cInputObserver.h"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <bitset>
 #include <memory>
 #include <vector>

--- a/src/controls/cKeyboard.h
+++ b/src/controls/cKeyboard.h
@@ -30,8 +30,8 @@ public:
 private:
     cInputObserver *m_keyboardObserver;
     std::unique_ptr<cKeyBindings> m_keyBindings;
-    std::bitset<SDL_NUM_SCANCODES> m_keysPressed;
-    std::bitset<SDL_NUM_SCANCODES> m_keysReleased;
+    std::bitset<SDL_SCANCODE_COUNT> m_keysPressed;
+    std::bitset<SDL_SCANCODE_COUNT> m_keysReleased;
     std::vector<std::string> m_textInputs;
     s_KeysCombo m_currentCombo;
 };

--- a/src/controls/cKeyboardEvent.cpp
+++ b/src/controls/cKeyboardEvent.cpp
@@ -21,7 +21,7 @@ const char *toStringKeyboardEventType(const eKeyEventType type)
 
 }
 
-cKeyboardEvent::cKeyboardEvent(eKeyEventType eventType, const std::bitset<SDL_NUM_SCANCODES> &keys,
+cKeyboardEvent::cKeyboardEvent(eKeyEventType eventType, const std::bitset<SDL_SCANCODE_COUNT> &keys,
                                const s_KeysCombo &combo, const cKeyBindings *keyBindings, std::string textInput) :
     m_eventType(eventType),
     m_keys(keys),
@@ -35,7 +35,7 @@ const std::string cKeyboardEvent::toString() const
 {
     std::string str = std::format("cKeyboardEvent [type={}], keys: ", toStringKeyboardEventType(m_eventType));
     str.append("[");
-    for (int sc = 0; sc < SDL_NUM_SCANCODES; ++sc) {
+    for (int sc = 0; sc < SDL_SCANCODE_COUNT; ++sc) {
         if (!m_keys.test(static_cast<size_t>(sc))) continue;
         str.append(SDL_GetScancodeName(static_cast<SDL_Scancode>(sc)));
     }
@@ -87,7 +87,7 @@ int cKeyboardEvent::getAssignGroupNumber() const
 
 bool cKeyboardEvent::hasKey(SDL_Scancode scanCode) const
 {
-    if (scanCode < 0 || scanCode >= SDL_NUM_SCANCODES) return false;
+    if (scanCode < 0 || scanCode >= SDL_SCANCODE_COUNT) return false;
     return m_keys.test(static_cast<size_t>(scanCode));
 }
 

--- a/src/controls/cKeyboardEvent.h
+++ b/src/controls/cKeyboardEvent.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <bitset>
 #include <string>
 
@@ -12,7 +12,7 @@ class cKeyBindings;
 class cKeyboardEvent {
 
 public:
-    cKeyboardEvent(eKeyEventType eventType, const std::bitset<SDL_NUM_SCANCODES> &keys, const s_KeysCombo &combo,
+    cKeyboardEvent(eKeyEventType eventType, const std::bitset<SDL_SCANCODE_COUNT> &keys, const s_KeysCombo &combo,
                 const cKeyBindings *keyBindings, std::string textInput = "");
 
     const std::string toString() const;
@@ -53,7 +53,7 @@ public:
 
 private:
     eKeyEventType m_eventType = eKeyEventType::NONE;
-    const std::bitset<SDL_NUM_SCANCODES> &m_keys;
+    const std::bitset<SDL_SCANCODE_COUNT> &m_keys;
     const s_KeysCombo &m_combo;
     const cKeyBindings *m_keyBindings;
     std::string m_textInput;

--- a/src/controls/cMouse.cpp
+++ b/src/controls/cMouse.cpp
@@ -60,44 +60,44 @@ void cMouse::init()
 void cMouse::handleEvent(const SDL_Event &event)
 {
     switch (event.type) {
-        case SDL_MOUSEBUTTONDOWN:
+        case SDL_EVENT_MOUSE_BUTTON_DOWN:
             if (event.button.button == SDL_BUTTON_LEFT) {
                 m_leftButtonPressed = true;
-                m_coordsOnClick.x = event.motion.x;
-                m_coordsOnClick.y = event.motion.y;
+                m_coordsOnClick.x = (int)event.button.x;
+                m_coordsOnClick.y = (int)event.button.y;
             }
             if (event.button.button == SDL_BUTTON_RIGHT) {
                 m_rightButtonPressed = true;
-                m_coordsOnClick.x = event.motion.x;
-                m_coordsOnClick.y = event.motion.y;
+                m_coordsOnClick.x = (int)event.button.x;
+                m_coordsOnClick.y = (int)event.button.y;
             }
             break;
-        case SDL_MOUSEBUTTONUP:
+        case SDL_EVENT_MOUSE_BUTTON_UP:
             if (event.button.button == SDL_BUTTON_LEFT) {
                 m_leftButtonPressed = false;
                 m_leftButtonReleased = true;
-                int dist = (m_coordsOnClick.x - event.motion.x)*(m_coordsOnClick.x - event.motion.x) + (m_coordsOnClick.y - event.motion.y)*(m_coordsOnClick.y - event.motion.y);
-                if (dist < 16) {
-                    // std::cout << "left click" << std::endl;
+                int dx = m_coordsOnClick.x - (int)event.button.x;
+                int dy = m_coordsOnClick.y - (int)event.button.y;
+                if (dx*dx + dy*dy < 16) {
                     m_leftButtonClicked = true;
                 }
             }
             if (event.button.button == SDL_BUTTON_RIGHT) {
                 m_rightButtonPressed = false;
                 m_rightButtonReleased = true;
-                int dist = (m_coordsOnClick.x - event.motion.x)*(m_coordsOnClick.x - event.motion.x) + (m_coordsOnClick.y - event.motion.y)*(m_coordsOnClick.y - event.motion.y);
-                if (dist < 16) {
-                    // std::cout << "right click" << std::endl;
+                int dx = m_coordsOnClick.x - (int)event.button.x;
+                int dy = m_coordsOnClick.y - (int)event.button.y;
+                if (dx*dx + dy*dy < 16) {
                     m_rightButtonClicked = true;
                 }
             }
             break;
-        case SDL_MOUSEMOTION:
-            m_coords.x = event.motion.x;
-            m_coords.y = event.motion.y;
+        case SDL_EVENT_MOUSE_MOTION:
+            m_coords.x = (int)event.motion.x;
+            m_coords.y = (int)event.motion.y;
             m_didMouseMove = true;
             break;
-        case SDL_MOUSEWHEEL:
+        case SDL_EVENT_MOUSE_WHEEL:
             if (event.wheel.y > 0) m_mouseScrolledUp = true;
             if (event.wheel.y < 0) m_mouseScrolledDown = true;
             break;

--- a/src/controls/cMouse.cpp
+++ b/src/controls/cMouse.cpp
@@ -13,7 +13,7 @@
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
 #include "utils/common.h"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <iostream>
 #include "include/cAssert.h"
 

--- a/src/controls/cMouse.cpp
+++ b/src/controls/cMouse.cpp
@@ -59,25 +59,31 @@ void cMouse::init()
 
 void cMouse::handleEvent(const SDL_Event &event)
 {
+    SDL_Renderer *renderer = m_renderDrawer->getRenderer();
     switch (event.type) {
-        case SDL_EVENT_MOUSE_BUTTON_DOWN:
+        case SDL_EVENT_MOUSE_BUTTON_DOWN: {
+            float px, py;
+            SDL_RenderCoordinatesFromWindow(renderer, event.button.x, event.button.y, &px, &py);
             if (event.button.button == SDL_BUTTON_LEFT) {
                 m_leftButtonPressed = true;
-                m_coordsOnClick.x = (int)event.button.x;
-                m_coordsOnClick.y = (int)event.button.y;
+                m_coordsOnClick.x = (int)px;
+                m_coordsOnClick.y = (int)py;
             }
             if (event.button.button == SDL_BUTTON_RIGHT) {
                 m_rightButtonPressed = true;
-                m_coordsOnClick.x = (int)event.button.x;
-                m_coordsOnClick.y = (int)event.button.y;
+                m_coordsOnClick.x = (int)px;
+                m_coordsOnClick.y = (int)py;
             }
             break;
-        case SDL_EVENT_MOUSE_BUTTON_UP:
+        }
+        case SDL_EVENT_MOUSE_BUTTON_UP: {
+            float px, py;
+            SDL_RenderCoordinatesFromWindow(renderer, event.button.x, event.button.y, &px, &py);
             if (event.button.button == SDL_BUTTON_LEFT) {
                 m_leftButtonPressed = false;
                 m_leftButtonReleased = true;
-                int dx = m_coordsOnClick.x - (int)event.button.x;
-                int dy = m_coordsOnClick.y - (int)event.button.y;
+                int dx = m_coordsOnClick.x - (int)px;
+                int dy = m_coordsOnClick.y - (int)py;
                 if (dx*dx + dy*dy < 16) {
                     m_leftButtonClicked = true;
                 }
@@ -85,18 +91,22 @@ void cMouse::handleEvent(const SDL_Event &event)
             if (event.button.button == SDL_BUTTON_RIGHT) {
                 m_rightButtonPressed = false;
                 m_rightButtonReleased = true;
-                int dx = m_coordsOnClick.x - (int)event.button.x;
-                int dy = m_coordsOnClick.y - (int)event.button.y;
+                int dx = m_coordsOnClick.x - (int)px;
+                int dy = m_coordsOnClick.y - (int)py;
                 if (dx*dx + dy*dy < 16) {
                     m_rightButtonClicked = true;
                 }
             }
             break;
-        case SDL_EVENT_MOUSE_MOTION:
-            m_coords.x = (int)event.motion.x;
-            m_coords.y = (int)event.motion.y;
+        }
+        case SDL_EVENT_MOUSE_MOTION: {
+            float px, py;
+            SDL_RenderCoordinatesFromWindow(renderer, event.motion.x, event.motion.y, &px, &py);
+            m_coords.x = (int)px;
+            m_coords.y = (int)py;
             m_didMouseMove = true;
             break;
+        }
         case SDL_EVENT_MOUSE_WHEEL:
             if (event.wheel.y > 0) m_mouseScrolledUp = true;
             if (event.wheel.y < 0) m_mouseScrolledDown = true;
@@ -174,7 +184,9 @@ void cMouse::updateState()
 
 void cMouse::setCursorPosition(SDL_Window *_windows, int x, int y)
 {
-    SDL_WarpMouseInWindow(_windows, x, y); // allegro function
+    float wx, wy;
+    SDL_RenderCoordinatesToWindow(m_renderDrawer->getRenderer(), (float)x, (float)y, &wx, &wy);
+    SDL_WarpMouseInWindow(_windows, wx, wy);
     if (m_mouseObserver) {
         s_MouseEvent event {
             eMouseEventType::MOUSE_MOVED_TO,

--- a/src/controls/cMouse.h
+++ b/src/controls/cMouse.h
@@ -2,7 +2,7 @@
 
 #include "utils/cPoint.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <string>
 
 class cRectangle;

--- a/src/drawers/CreditsDrawer.cpp
+++ b/src/drawers/CreditsDrawer.cpp
@@ -13,7 +13,7 @@
 #include "context/GraphicsContext.hpp"
 #include "data/gfxaudio.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include "include/cAssert.h"
 
 CreditsDrawer::CreditsDrawer(GameContext* ctx, cPlayer *player) :

--- a/src/drawers/SDLDrawer.cpp
+++ b/src/drawers/SDLDrawer.cpp
@@ -350,23 +350,26 @@ Texture *SDLDrawer::createTextureFromIndexedSurfaceWithPalette(SDL_Surface *refe
 
     // copy palette
     SDL_Palette *refPalette = SDL_GetSurfacePalette(referenceSurface);
-    if (refPalette && refPalette->ncolors > 0) {
-        SDL_SetPaletteColors(SDL_GetSurfacePalette(modifiableSurface),
-                             refPalette->colors,
-                             0,
-                             refPalette->ncolors);
-    }
-    else {
+    if (!refPalette || refPalette->ncolors <= 0) {
         SDL_Log("No palette in the original image!");
         SDL_DestroySurface(modifiableSurface);
         return nullptr;
     }
 
+    // SDL3 does not guarantee an auto-created palette on surfaces made via
+    // SDL_CreateSurface on all platforms. Create one explicitly and attach it.
+    SDL_Palette *palette = SDL_CreatePalette(refPalette->ncolors);
+    if (!palette) {
+        SDL_Log("Failed to create palette: %s", SDL_GetError());
+        SDL_DestroySurface(modifiableSurface);
+        return nullptr;
+    }
+    SDL_SetPaletteColors(palette, refPalette->colors, 0, refPalette->ncolors);
+
     // Apply optional palette swap if requested (caller decides swap start)
     if (paletteSwapStart > -1) {
         int start = paletteSwapStart;
         int s = 144; // original position (harkonnen)
-        SDL_Palette *palette = SDL_GetSurfacePalette(modifiableSurface);
         for (int j = start; j < (start + 7) && s < palette->ncolors; j++) {
             palette->colors[s].r = palette->colors[j].r;
             palette->colors[s].g = palette->colors[j].g;
@@ -374,13 +377,10 @@ Texture *SDLDrawer::createTextureFromIndexedSurfaceWithPalette(SDL_Surface *refe
             palette->colors[s].a = palette->colors[j].a;
             s++;
         }
-        const SDL_Color *colors = palette->colors;
-        if (!SDL_SetPaletteColors(SDL_GetSurfacePalette(modifiableSurface), colors, 0, palette->ncolors)) {
-            SDL_Log("Error setting palette colors : %s", SDL_GetError());
-            SDL_DestroySurface(modifiableSurface);
-            return nullptr;
-        }
     }
+
+    SDL_SetSurfacePalette(modifiableSurface, palette);
+    SDL_DestroyPalette(palette); // surface now holds the reference
 
     // Step 3: Set the transparency index
     if (!SDL_SetSurfaceColorKey(modifiableSurface, true, paletteIndexForTransparency)) {

--- a/src/drawers/SDLDrawer.cpp
+++ b/src/drawers/SDLDrawer.cpp
@@ -50,6 +50,7 @@ void SDLDrawer::renderFromSurface(SDL_Surface *src, int x, int y,Uint8 opacity)
         std::cerr << "error drawSprite : " << SDL_GetError();
         return;
     }
+    SDL_SetTextureScaleMode(texture, SDL_SCALEMODE_NEAREST);
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
     SDL_SetTextureAlphaMod(texture, opacity);
     SDL_RenderTexture(renderer, texture, NULL, &tmp);
@@ -294,6 +295,7 @@ Texture* SDLDrawer::createRenderTargetTexture(int width, int height)
     if (!texture) {
         throw std::runtime_error("Error creating render texture: " + std::string(SDL_GetError()));
     }
+    SDL_SetTextureScaleMode(texture, SDL_SCALEMODE_NEAREST);
     return new Texture(texture, width, height, true);
 }
 
@@ -404,6 +406,7 @@ Texture *SDLDrawer::createTextureFromIndexedSurfaceWithPalette(SDL_Surface *refe
         SDL_DestroySurface(rgbaSurface);
         return nullptr;
     }
+    SDL_SetTextureScaleMode(texture, SDL_SCALEMODE_NEAREST);
 
     auto *newTexture = new Texture(texture, rgbaSurface->w, rgbaSurface->h);
     SDL_DestroySurface(rgbaSurface);

--- a/src/drawers/SDLDrawer.cpp
+++ b/src/drawers/SDLDrawer.cpp
@@ -22,7 +22,7 @@ void SDLDrawer::renderSprite(Texture *src,int x, int y,Uint8 opacity)
     SDL_FRect tmp = {(float)x, (float)y, (float)src->w, (float)src->h};
     SDL_SetTextureBlendMode(src->tex.get(), SDL_BLENDMODE_BLEND);
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-    if (SDL_SetTextureAlphaMod(src->tex.get(), opacity)<0) {
+    if (!SDL_SetTextureAlphaMod(src->tex.get(), opacity)) {
         std::cerr << "no alpha mod "<< SDL_GetError() << std::endl;
     }
     SDL_RenderTexture(renderer, src->tex.get(), NULL, &tmp);
@@ -34,7 +34,7 @@ void SDLDrawer::renderTexture(SDL_Texture *tex, int x, int y, int w, int h, Uint
     SDL_FRect tmp = {(float)x, (float)y, (float)w, (float)h};
     SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND);
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-    if (SDL_SetTextureAlphaMod(tex, opacity)<0) {
+    if (!SDL_SetTextureAlphaMod(tex, opacity)) {
         std::cerr << "no alpha mod "<< SDL_GetError() << std::endl;
     }
     SDL_RenderTexture(renderer, tex, NULL, &tmp);
@@ -44,7 +44,7 @@ void SDLDrawer::renderFromSurface(SDL_Surface *src, int x, int y,Uint8 opacity)
 {
     SDL_FRect tmp = {(float)x, (float)y, (float)src->w, (float)src->h};
     transparentColorKey = SDL_MapRGB(SDL_GetPixelFormatDetails(src->format), SDL_GetSurfacePalette(src), 255, 0, 255);
-    SDL_SetColorKey(src, SDL_TRUE, transparentColorKey);
+    SDL_SetSurfaceColorKey(src, true, transparentColorKey);
     SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, src);
     if (!texture) {
         std::cerr << "error drawSprite : " << SDL_GetError();
@@ -58,7 +58,7 @@ void SDLDrawer::renderFromSurface(SDL_Surface *src, int x, int y,Uint8 opacity)
 
 void SDLDrawer::renderStrechSprite(Texture *src, cRectangle src_pos, cRectangle dest_pos, Uint8 opacity)
 {
-    if (SDL_SetTextureBlendMode(src->tex.get(), SDL_BLENDMODE_BLEND) < 0) {
+    if (!SDL_SetTextureBlendMode(src->tex.get(), SDL_BLENDMODE_BLEND)) {
         std::cerr << "Error SDL_SetTextureBlendMode : " << SDL_GetError() << std::endl;
     }
     SDL_SetTextureAlphaMod(src->tex.get(), opacity);
@@ -69,7 +69,7 @@ void SDLDrawer::renderStrechSprite(Texture *src, cRectangle src_pos, cRectangle 
 
 void SDLDrawer::renderStrechFullSprite(Texture *src, cRectangle dest_pos, Uint8 opacity)
 {
-    if (SDL_SetTextureBlendMode(src->tex.get(), SDL_BLENDMODE_BLEND) < 0) {
+    if (!SDL_SetTextureBlendMode(src->tex.get(), SDL_BLENDMODE_BLEND)) {
         std::cerr << "Error SDL_SetTextureBlendMode : " << SDL_GetError() << std::endl;
     }
     SDL_SetTextureAlphaMod(src->tex.get(), opacity);
@@ -256,8 +256,8 @@ void SDLDrawer::FillWithColor(SDL_Surface *src, Color color)
                                      color.g,
                                      color.b,
                                      color.a);
-    int result = SDL_FillRect(src, NULL, mappedColor);
-    if (result < 0) {
+    bool result = SDL_FillSurfaceRect(src, NULL, mappedColor);
+    if (!result) {
         SDL_Log("SDL_FillRect failed to clear surface: %s", SDL_GetError());
     }
 }
@@ -269,7 +269,7 @@ void SDLDrawer::setPixel(SDL_Surface *bmp, int x, int y, Color color)
                                      SDL_GetSurfacePalette(bmp),
                                      color.r, color.g, color.b, color.a);
 
-    if (SDL_LockSurface(bmp) < 0) {
+    if (!SDL_LockSurface(bmp)) {
         fprintf(stderr, "Error locking surface: %s\n", SDL_GetError());
         return;
     }
@@ -305,7 +305,7 @@ void SDLDrawer::beginDrawingToTexture(Texture* targetTexture)
     SDL_Texture* currentTarget = SDL_GetRenderTarget(renderer);
     renderTargetStack.push(currentTarget);
 
-    if (SDL_SetRenderTarget(renderer, targetTexture->tex.get()) < 0) {
+    if (!SDL_SetRenderTarget(renderer, targetTexture->tex.get())) {
         renderTargetStack.pop();
         throw std::runtime_error("Error changing render target: " + std::string(SDL_GetError()));
     }
@@ -318,7 +318,7 @@ void SDLDrawer::endDrawingToTexture()
     }
     SDL_Texture* previousTarget = renderTargetStack.top();
     renderTargetStack.pop();
-    if (SDL_SetRenderTarget(renderer, previousTarget) < 0) {
+    if (!SDL_SetRenderTarget(renderer, previousTarget)) {
         throw std::runtime_error("Error restoring default render target: " + std::string(SDL_GetError()));
     }
 }
@@ -375,7 +375,7 @@ Texture *SDLDrawer::createTextureFromIndexedSurfaceWithPalette(SDL_Surface *refe
             s++;
         }
         const SDL_Color *colors = palette->colors;
-        if (SDL_SetPaletteColors(SDL_GetSurfacePalette(modifiableSurface), colors, 0, palette->ncolors) != 0) {
+        if (!SDL_SetPaletteColors(SDL_GetSurfacePalette(modifiableSurface), colors, 0, palette->ncolors)) {
             SDL_Log("Error setting palette colors : %s", SDL_GetError());
             SDL_DestroySurface(modifiableSurface);
             return nullptr;
@@ -383,7 +383,7 @@ Texture *SDLDrawer::createTextureFromIndexedSurfaceWithPalette(SDL_Surface *refe
     }
 
     // Step 3: Set the transparency index
-    if (SDL_SetColorKey(modifiableSurface, SDL_TRUE, paletteIndexForTransparency) != 0) {
+    if (!SDL_SetSurfaceColorKey(modifiableSurface, true, paletteIndexForTransparency)) {
         SDL_Log("SDL_SetColorKey error : %s", SDL_GetError());
         SDL_DestroySurface(modifiableSurface);
         return nullptr;

--- a/src/drawers/SDLDrawer.cpp
+++ b/src/drawers/SDLDrawer.cpp
@@ -19,31 +19,31 @@ SDLDrawer::~SDLDrawer()
 void SDLDrawer::renderSprite(Texture *src,int x, int y,Uint8 opacity)
 {
     if (src == nullptr) return;
-    SDL_Rect tmp = {x,y, src->w, src->h };
+    SDL_FRect tmp = {(float)x, (float)y, (float)src->w, (float)src->h};
     SDL_SetTextureBlendMode(src->tex.get(), SDL_BLENDMODE_BLEND);
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
     if (SDL_SetTextureAlphaMod(src->tex.get(), opacity)<0) {
         std::cerr << "no alpha mod "<< SDL_GetError() << std::endl;
     }
-    SDL_RenderCopy(renderer, src->tex.get(), NULL, &tmp);
+    SDL_RenderTexture(renderer, src->tex.get(), NULL, &tmp);
 }
 
 void SDLDrawer::renderTexture(SDL_Texture *tex, int x, int y, int w, int h, Uint8 opacity)
 {
     if (tex == nullptr) return;
-    SDL_Rect tmp = SDL_Rect{x,y,w,h};
+    SDL_FRect tmp = {(float)x, (float)y, (float)w, (float)h};
     SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND);
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
     if (SDL_SetTextureAlphaMod(tex, opacity)<0) {
         std::cerr << "no alpha mod "<< SDL_GetError() << std::endl;
     }
-    SDL_RenderCopy(renderer, tex, NULL, &tmp);
+    SDL_RenderTexture(renderer, tex, NULL, &tmp);
 }
 
 void SDLDrawer::renderFromSurface(SDL_Surface *src, int x, int y,Uint8 opacity)
 {
-    SDL_Rect tmp = {x,y,src->w, src->h};
-    transparentColorKey = SDL_MapRGB(src->format, 255, 0, 255);
+    SDL_FRect tmp = {(float)x, (float)y, (float)src->w, (float)src->h};
+    transparentColorKey = SDL_MapRGB(SDL_GetPixelFormatDetails(src->format), SDL_GetSurfacePalette(src), 255, 0, 255);
     SDL_SetColorKey(src, SDL_TRUE, transparentColorKey);
     SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, src);
     if (!texture) {
@@ -52,7 +52,7 @@ void SDLDrawer::renderFromSurface(SDL_Surface *src, int x, int y,Uint8 opacity)
     }
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
     SDL_SetTextureAlphaMod(texture, opacity);
-    SDL_RenderCopy(renderer, texture, NULL, &tmp);
+    SDL_RenderTexture(renderer, texture, NULL, &tmp);
     SDL_DestroyTexture(texture);
 }
 
@@ -62,9 +62,9 @@ void SDLDrawer::renderStrechSprite(Texture *src, cRectangle src_pos, cRectangle 
         std::cerr << "Error SDL_SetTextureBlendMode : " << SDL_GetError() << std::endl;
     }
     SDL_SetTextureAlphaMod(src->tex.get(), opacity);
-    SDL_Rect srcRect = src_pos.toSDL();
-    SDL_Rect destRect = dest_pos.toSDL();
-    SDL_RenderCopy(renderer, src->tex.get(), &srcRect, &destRect);
+    SDL_FRect srcRect = src_pos.toSDLF();
+    SDL_FRect destRect = dest_pos.toSDLF();
+    SDL_RenderTexture(renderer, src->tex.get(), &srcRect, &destRect);
 }
 
 void SDLDrawer::renderStrechFullSprite(Texture *src, cRectangle dest_pos, Uint8 opacity)
@@ -73,15 +73,15 @@ void SDLDrawer::renderStrechFullSprite(Texture *src, cRectangle dest_pos, Uint8 
         std::cerr << "Error SDL_SetTextureBlendMode : " << SDL_GetError() << std::endl;
     }
     SDL_SetTextureAlphaMod(src->tex.get(), opacity);
-    SDL_Rect destRect = dest_pos.toSDL();
-    SDL_RenderCopy(renderer, src->tex.get(), nullptr, &destRect);
+    SDL_FRect destRect = dest_pos.toSDLF();
+    SDL_RenderTexture(renderer, src->tex.get(), nullptr, &destRect);
 }
 
 void SDLDrawer::renderRectFillColor(int x, int y, int width, int height, Uint8 r, Uint8 g, Uint8 b, Uint8 opacity)
 {
     SDL_SetRenderDrawColor(renderer, r,g,b, opacity);
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-    SDL_Rect carre = {x, y, width, height};
+    SDL_FRect carre = {(float)x, (float)y, (float)width, (float)height};
     SDL_RenderFillRect(renderer, &carre);
 }
 
@@ -94,8 +94,8 @@ void SDLDrawer::renderRectColor(int x, int y, int width, int height, Uint8 r, Ui
 {
     SDL_SetRenderDrawColor(renderer, r,g,b, opacity);
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-    SDL_Rect carre = {x, y, width, height};
-    SDL_RenderDrawRect(renderer, &carre);
+    SDL_FRect carre = {(float)x, (float)y, (float)width, (float)height};
+    SDL_RenderRect(renderer, &carre);
 }
 
 void SDLDrawer::renderRectFillColor(const cRectangle &rect, Color color, Uint8 opacity)
@@ -122,13 +122,13 @@ void SDLDrawer::renderRectColor(const cRectangle &rect, Color color, unsigned ch
 
 void SDLDrawer::resetClippingFor()
 {
-    SDL_RenderSetClipRect(renderer, nullptr);
+    SDL_SetRenderClipRect(renderer, nullptr);
 }
 
 void SDLDrawer::setClippingFor(int topLeftX, int topLeftY, int bottomRightX, int bottomRightY)
 {
     auto tmp = SDL_Rect{topLeftX,topLeftY, bottomRightX-topLeftX, bottomRightY - topLeftY};
-    SDL_RenderSetClipRect(renderer, &tmp);
+    SDL_SetRenderClipRect(renderer, &tmp);
 }
 
 void SDLDrawer::gui_DrawRect(const cRectangle &rectangle, Color gui_colorWindow, Color gui_colorBorderLight, Color gui_colorBorderDark)
@@ -137,11 +137,11 @@ void SDLDrawer::gui_DrawRect(const cRectangle &rectangle, Color gui_colorWindow,
     int y1 = rectangle.getY();
     int width = rectangle.getWidth();
     int height = rectangle.getHeight();
-    SDL_Rect tmp = {x1, y1, width, height};
+    SDL_FRect tmp = {(float)x1, (float)y1, (float)width, (float)height};
     renderChangeColor(gui_colorWindow);
     SDL_RenderFillRect(renderer, &tmp);
     renderChangeColor(gui_colorBorderLight);
-    SDL_RenderDrawRect(renderer, &tmp);
+    SDL_RenderRect(renderer, &tmp);
 
     // lines to darken the right sides
     renderChangeColor(gui_colorBorderDark);
@@ -150,9 +150,9 @@ void SDLDrawer::gui_DrawRect(const cRectangle &rectangle, Color gui_colorWindow,
     int endX = (x1 + width) - 1;
     int endY = (y1 + height) - 1;
 
-    SDL_RenderDrawLine(renderer, endX, y1, endX, endY);
+    SDL_RenderLine(renderer, (float)endX, (float)y1, (float)endX, (float)endY);
     renderChangeColor(gui_colorBorderDark);
-    SDL_RenderDrawLine(renderer, x1, endY, endX, endY);
+    SDL_RenderLine(renderer, (float)x1, (float)endY, (float)endX, (float)endY);
 }
 
 void SDLDrawer::gui_DrawRectBorder(const cRectangle &rectangle, Color gui_colorBorderLight, Color gui_colorBorderDark)
@@ -161,18 +161,18 @@ void SDLDrawer::gui_DrawRectBorder(const cRectangle &rectangle, Color gui_colorB
     int y1 = rectangle.getY();
     int width = rectangle.getWidth();
     int height = rectangle.getHeight();
-    SDL_Rect tmp = {x1,y1,width,height};
+    SDL_FRect tmp = {(float)x1, (float)y1, (float)width, (float)height};
     renderChangeColor(gui_colorBorderLight);
-    SDL_RenderDrawRect(renderer, &tmp);
+    SDL_RenderRect(renderer, &tmp);
     renderChangeColor(gui_colorBorderDark);
 
     // SDL Lines are drawn *including* end coordinate, so need to subtract 1 to make it match
     // with the SDL_RenderFillRect and DrawRect functions.
     int endX = (x1 + width) - 1;
     int endY = (y1 + height) - 1;
-    SDL_RenderDrawLine(renderer, endX, y1, endX, endY);
+    SDL_RenderLine(renderer, (float)endX, (float)y1, (float)endX, (float)endY);
     renderChangeColor(gui_colorBorderDark);
-    SDL_RenderDrawLine(renderer, x1, endY, endX, endY);
+    SDL_RenderLine(renderer, (float)x1, (float)endY, (float)endX, (float)endY);
 }
 
 void SDLDrawer::renderClearToColor(Color color)
@@ -184,7 +184,7 @@ void SDLDrawer::renderClearToColor(Color color)
 void SDLDrawer::renderLine(int x1, int y1, int x2, int y2, Color color)
 {
     renderChangeColor(color);
-    SDL_RenderDrawLine(renderer,x1, y1, x2, y2);
+    SDL_RenderLine(renderer, (float)x1, (float)y1, (float)x2, (float)y2);
 }
 
 void SDLDrawer::renderDot(int x, int y, Color color, int size)
@@ -192,7 +192,7 @@ void SDLDrawer::renderDot(int x, int y, Color color, int size)
     if (size < 1) return;
     renderChangeColor(color);
     if (size == 1) {
-        SDL_RenderDrawPoint(renderer,x, y);
+        SDL_RenderPoint(renderer, (float)x, (float)y);
         return;
     }
 
@@ -200,7 +200,7 @@ void SDLDrawer::renderDot(int x, int y, Color color, int size)
     int endY = y + size;
     for (int sx = x; sx < endX; sx++) {
         for (int sy = y; sy < endY; sy++) {
-            SDL_RenderDrawPoint(renderer,sx, sy);
+            SDL_RenderPoint(renderer, (float)sx, (float)sy);
         }
     }
 }
@@ -210,33 +210,27 @@ bool SDLDrawer::isSurface8BitPaletted(SDL_Surface *bmp)
     if (bmp == nullptr) {
         return false;
     }
-    return bmp->format->BitsPerPixel == 8 && bmp->format->palette != nullptr;
+    return SDL_BITSPERPIXEL(bmp->format) == 8 && SDL_GetSurfacePalette(bmp) != nullptr;
 }
 
-// Fonction utilitaire pour dessiner un pixel sur une SDL_Surface
-// Assurez-vous que la surface est verrouillée avant d'appeler cette fonction !
+// Utility to draw a pixel on a SDL_Surface — surface must be locked before calling!
 void SDLDrawer::set_pixel(SDL_Surface *surface, int x, int y, Uint32 pixel_color)
 {
     if (x < 0 || x >= surface->w || y < 0 || y >= surface->h) {
-        return; // Hors des limites de la surface
+        return;
     }
 
-    int bpp = surface->format->BytesPerPixel;
-    // Pointeur vers le début de la ligne y
+    int bpp = SDL_BYTESPERPIXEL(surface->format);
     Uint8 *p = (Uint8 *)surface->pixels + y * surface->pitch;
 
-    // Déplacer le pointeur jusqu'au pixel x
-    // On convertit Uint32 en la taille appropriée (1, 2, 3 ou 4 octets)
     switch (bpp) {
-        case 1: // 8 bits par pixel
+        case 1:
             *((Uint8 *)p + x) = (Uint8)pixel_color;
             break;
-        case 2: // 16 bits par pixel
+        case 2:
             *((Uint16 *)p + x) = (Uint16)pixel_color;
             break;
-        case 3: // 24 bits par pixel
-            // C'est un peu plus complexe car 3 octets ne s'alignent pas directement avec les types C
-            // Il faut copier octet par octet
+        case 3:
             if (SDL_BYTEORDER == SDL_BIG_ENDIAN) {
                 *((Uint8 *)p + x * bpp + 0) = (pixel_color >> 16) & 0xFF;
                 *((Uint8 *)p + x * bpp + 1) = (pixel_color >> 8) & 0xFF;
@@ -248,7 +242,7 @@ void SDLDrawer::set_pixel(SDL_Surface *surface, int x, int y, Uint32 pixel_color
                 *((Uint8 *)p + x * bpp + 2) = (pixel_color >> 16) & 0xFF;
             }
             break;
-        case 4: // 32 bits par pixel
+        case 4:
             *((Uint32 *)p + x) = pixel_color;
             break;
     }
@@ -256,7 +250,8 @@ void SDLDrawer::set_pixel(SDL_Surface *surface, int x, int y, Uint32 pixel_color
 
 void SDLDrawer::FillWithColor(SDL_Surface *src, Color color)
 {
-    Uint32 mappedColor = SDL_MapRGBA(src->format,
+    Uint32 mappedColor = SDL_MapRGBA(SDL_GetPixelFormatDetails(src->format),
+                                     SDL_GetSurfacePalette(src),
                                      color.r,
                                      color.g,
                                      color.b,
@@ -270,10 +265,10 @@ void SDLDrawer::FillWithColor(SDL_Surface *src, Color color)
 
 void SDLDrawer::setPixel(SDL_Surface *bmp, int x, int y, Color color)
 {
-    Uint32 mappedColor = SDL_MapRGBA(bmp->format,
+    Uint32 mappedColor = SDL_MapRGBA(SDL_GetPixelFormatDetails(bmp->format),
+                                     SDL_GetSurfacePalette(bmp),
                                      color.r, color.g, color.b, color.a);
 
-    // Vérrouiller la surface avant de modifier les pixels
     if (SDL_LockSurface(bmp) < 0) {
         fprintf(stderr, "Error locking surface: %s\n", SDL_GetError());
         return;
@@ -333,7 +328,7 @@ Texture *SDLDrawer::createTextureFromIndexedSurfaceWithPalette(SDL_Surface *refe
     d2tm_assert(referenceSurface && "referenceSurface must be given");
 
     // Step 1: Create a copy of the surface (same INDEX8 format)
-    SDL_Surface *modifiableSurface = SDL_CreateRGBSurfaceWithFormat(0, referenceSurface->w, referenceSurface->h, 8, SDL_PIXELFORMAT_INDEX8);
+    SDL_Surface *modifiableSurface = SDL_CreateSurface(referenceSurface->w, referenceSurface->h, SDL_PIXELFORMAT_INDEX8);
     if (!modifiableSurface) {
         SDL_Log("Error copying surface : %s", SDL_GetError());
         return nullptr;
@@ -342,29 +337,28 @@ Texture *SDLDrawer::createTextureFromIndexedSurfaceWithPalette(SDL_Surface *refe
     // Copy pixels
     SDL_LockSurface(referenceSurface);
     SDL_LockSurface(modifiableSurface);
-//    memcpy(modifiableSurface->pixels, referenceSurface->pixels, referenceSurface->h * referenceSurface->pitch);
     Uint8* src = (Uint8*)referenceSurface->pixels;
     Uint8* dst = (Uint8*)modifiableSurface->pixels;
 
     for (int y = 0; y < referenceSurface->h; y++) {
         memcpy(dst + y * modifiableSurface->pitch,
                src + y * referenceSurface->pitch,
-            referenceSurface->w); // 8 bits = 1 byte par pixel
+            referenceSurface->w); // 8 bits = 1 byte per pixel
     }
     SDL_UnlockSurface(referenceSurface);
     SDL_UnlockSurface(modifiableSurface);
 
     // copy palette
-    if (referenceSurface->format->palette &&
-        referenceSurface->format->palette->ncolors > 0) {
-        SDL_SetPaletteColors(modifiableSurface->format->palette,
-                             referenceSurface->format->palette->colors,
+    SDL_Palette *refPalette = SDL_GetSurfacePalette(referenceSurface);
+    if (refPalette && refPalette->ncolors > 0) {
+        SDL_SetPaletteColors(SDL_GetSurfacePalette(modifiableSurface),
+                             refPalette->colors,
                              0,
-                             referenceSurface->format->palette->ncolors);
+                             refPalette->ncolors);
     }
     else {
         SDL_Log("No palette in the original image!");
-        SDL_FreeSurface(modifiableSurface);
+        SDL_DestroySurface(modifiableSurface);
         return nullptr;
     }
 
@@ -372,7 +366,7 @@ Texture *SDLDrawer::createTextureFromIndexedSurfaceWithPalette(SDL_Surface *refe
     if (paletteSwapStart > -1) {
         int start = paletteSwapStart;
         int s = 144; // original position (harkonnen)
-        SDL_Palette *palette = modifiableSurface->format->palette;
+        SDL_Palette *palette = SDL_GetSurfacePalette(modifiableSurface);
         for (int j = start; j < (start + 7) && s < palette->ncolors; j++) {
             palette->colors[s].r = palette->colors[j].r;
             palette->colors[s].g = palette->colors[j].g;
@@ -381,9 +375,9 @@ Texture *SDLDrawer::createTextureFromIndexedSurfaceWithPalette(SDL_Surface *refe
             s++;
         }
         const SDL_Color *colors = palette->colors;
-        if (SDL_SetPaletteColors(modifiableSurface->format->palette, colors, 0, palette->ncolors) != 0) {
+        if (SDL_SetPaletteColors(SDL_GetSurfacePalette(modifiableSurface), colors, 0, palette->ncolors) != 0) {
             SDL_Log("Error setting palette colors : %s", SDL_GetError());
-            SDL_FreeSurface(modifiableSurface);
+            SDL_DestroySurface(modifiableSurface);
             return nullptr;
         }
     }
@@ -391,15 +385,15 @@ Texture *SDLDrawer::createTextureFromIndexedSurfaceWithPalette(SDL_Surface *refe
     // Step 3: Set the transparency index
     if (SDL_SetColorKey(modifiableSurface, SDL_TRUE, paletteIndexForTransparency) != 0) {
         SDL_Log("SDL_SetColorKey error : %s", SDL_GetError());
-        SDL_FreeSurface(modifiableSurface);
+        SDL_DestroySurface(modifiableSurface);
         return nullptr;
     }
 
     // Step 4: Convert to RGBA8888 to create the texture with alpha
-    SDL_Surface *rgbaSurface = SDL_ConvertSurfaceFormat(modifiableSurface, SDL_PIXELFORMAT_RGBA8888, 0);
-    SDL_FreeSurface(modifiableSurface);
+    SDL_Surface *rgbaSurface = SDL_ConvertSurface(modifiableSurface, SDL_PIXELFORMAT_RGBA8888);
+    SDL_DestroySurface(modifiableSurface);
     if (!rgbaSurface) {
-        SDL_Log("SDL_ConvertSurfaceFormat error : %s", SDL_GetError());
+        SDL_Log("SDL_ConvertSurface error : %s", SDL_GetError());
         return nullptr;
     }
 
@@ -407,11 +401,11 @@ Texture *SDLDrawer::createTextureFromIndexedSurfaceWithPalette(SDL_Surface *refe
     SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, rgbaSurface);
     if (!texture) {
         SDL_Log("SDL_CreateTextureFromSurface error : %s", SDL_GetError());
-        SDL_FreeSurface(rgbaSurface);
+        SDL_DestroySurface(rgbaSurface);
         return nullptr;
     }
 
     auto *newTexture = new Texture(texture, rgbaSurface->w, rgbaSurface->h);
-    SDL_FreeSurface(rgbaSurface);
+    SDL_DestroySurface(rgbaSurface);
     return newTexture;
 }

--- a/src/drawers/SDLDrawer.hpp
+++ b/src/drawers/SDLDrawer.hpp
@@ -5,7 +5,7 @@
 
 #include <map>
 #include <memory>
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <stack>
 
 class Texture;

--- a/src/drawers/cBuildingListDrawer.cpp
+++ b/src/drawers/cBuildingListDrawer.cpp
@@ -13,7 +13,7 @@
 #include "context/cGameObjectContext.h"
 #include "utils/common.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <format>
 #include "include/cAssert.h"
 

--- a/src/drawers/cMapDrawer.cpp
+++ b/src/drawers/cMapDrawer.cpp
@@ -111,7 +111,7 @@ void cMapDrawer::drawTerrain()
     // cache for invalid terran
     auto invalidTile = SDL_CreateSurface(32, 32, SDL_PIXELFORMAT_ARGB8888);
     Uint32 mappedColor = SDL_MapRGBA(SDL_GetPixelFormatDetails(invalidTile->format), SDL_GetSurfacePalette(invalidTile), 245, 245, 245, 255);
-    SDL_FillRect(invalidTile, nullptr, mappedColor);
+    SDL_FillSurfaceRect(invalidTile, nullptr, mappedColor);
 
     // draw vertical rows..
     for (int viewportX = m_camera->getViewportStartX(); viewportX < m_camera->getViewportEndX() + 32; viewportX += 32) {

--- a/src/drawers/cMapDrawer.cpp
+++ b/src/drawers/cMapDrawer.cpp
@@ -109,8 +109,8 @@ void cMapDrawer::drawTerrain()
     int mouseCell = m_player->getGameControlsContext()->getMouseCell();
 
     // cache for invalid terran
-    auto invalidTile = SDL_CreateRGBSurfaceWithFormat(0, 32, 32, 32, SDL_PIXELFORMAT_ARGB8888);
-    Uint32 mappedColor = SDL_MapRGBA(invalidTile->format, 245, 245, 245, 255);
+    auto invalidTile = SDL_CreateSurface(32, 32, SDL_PIXELFORMAT_ARGB8888);
+    Uint32 mappedColor = SDL_MapRGBA(SDL_GetPixelFormatDetails(invalidTile->format), SDL_GetSurfacePalette(invalidTile), 245, 245, 245, 255);
     SDL_FillRect(invalidTile, nullptr, mappedColor);
 
     // draw vertical rows..

--- a/src/drawers/cMapDrawer.cpp
+++ b/src/drawers/cMapDrawer.cpp
@@ -13,7 +13,7 @@
 #include "gameobjects/map/cMapCamera.h"
 #include "gameobjects/map/MapGeometry.hpp"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <cmath>
 #include "include/cAssert.h"
 

--- a/src/drawers/cMessageDrawer.cpp
+++ b/src/drawers/cMessageDrawer.cpp
@@ -99,7 +99,7 @@ void cMessageDrawer::destroy()
     m_alpha = -1;
     m_TIMER_message = 0;
     if (m_bmpBar != nullptr) {
-        SDL_FreeSurface(m_bmpBar);
+        SDL_DestroySurface(m_bmpBar);
     }
 }
 
@@ -156,11 +156,11 @@ void cMessageDrawer::setMessage(const std::string &msg, bool keepMessage)
 void cMessageDrawer::createMessageBarBmp(int desiredWidth)
 {
     if (m_bmpBar) {
-        SDL_FreeSurface(m_bmpBar);
+        SDL_DestroySurface(m_bmpBar);
     }
 
-    m_bmpBar = SDL_CreateRGBSurface(0,desiredWidth, 30,32,0,0,0,255);
-    auto color = SDL_MapRGBA(m_bmpBar->format,255,0,255,255);
+    m_bmpBar = SDL_CreateSurface(desiredWidth, 30, SDL_PIXELFORMAT_RGBA32);
+    auto color = SDL_MapRGBA(SDL_GetPixelFormatDetails(m_bmpBar->format), SDL_GetSurfacePalette(m_bmpBar), 255, 0, 255, 255);
     SDL_FillRect(m_bmpBar, nullptr, color);
     SDL_BlitSurface(m_gfxinter->getSurface(MESSAGE_LEFT), nullptr, m_bmpBar, nullptr);
 

--- a/src/drawers/cMessageDrawer.cpp
+++ b/src/drawers/cMessageDrawer.cpp
@@ -9,7 +9,7 @@
 #include "context/GraphicsContext.hpp"
 #include "game/cGameSettings.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include "include/cAssert.h"
 
 // Game Playing State and SelectYourNextConquestState have their own version

--- a/src/drawers/cMessageDrawer.cpp
+++ b/src/drawers/cMessageDrawer.cpp
@@ -161,7 +161,7 @@ void cMessageDrawer::createMessageBarBmp(int desiredWidth)
 
     m_bmpBar = SDL_CreateSurface(desiredWidth, 30, SDL_PIXELFORMAT_RGBA32);
     auto color = SDL_MapRGBA(SDL_GetPixelFormatDetails(m_bmpBar->format), SDL_GetSurfacePalette(m_bmpBar), 255, 0, 255, 255);
-    SDL_FillRect(m_bmpBar, nullptr, color);
+    SDL_FillSurfaceRect(m_bmpBar, nullptr, color);
     SDL_BlitSurface(m_gfxinter->getSurface(MESSAGE_LEFT), nullptr, m_bmpBar, nullptr);
 
     for (int drawX = 11; drawX < m_bmpBar->w; drawX+= 55) {

--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -13,7 +13,7 @@
 #include "sidebar/cSideBar.h"
 #include "utils/cSoundPlayer.h"
 #include "utils/Graphics.hpp"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include "gameobjects/map/MapGeometry.hpp"
 #include "context/GameContext.hpp"
 #include "context/GraphicsContext.hpp"

--- a/src/drawers/cMouseDrawer.cpp
+++ b/src/drawers/cMouseDrawer.cpp
@@ -10,7 +10,7 @@
 #include "gui/cTextWriter.h"
 #include "gameobjects/players/cPlayer.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <algorithm>
 #include "include/cAssert.h"
 

--- a/src/drawers/cOrderDrawer.cpp
+++ b/src/drawers/cOrderDrawer.cpp
@@ -11,7 +11,7 @@
 #include "utils/texture_utils.h"
 #include "context/GameContext.hpp"
 #include "context/GraphicsContext.hpp"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include "include/cAssert.h"
 
 cOrderDrawer::cOrderDrawer(GameContext *ctx, cPlayer *player) :

--- a/src/drawers/cPlaceItDrawer.cpp
+++ b/src/drawers/cPlaceItDrawer.cpp
@@ -14,7 +14,7 @@
 #include "gameobjects/units/cUnits.h"
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 #include "include/cAssert.h"
 

--- a/src/drawers/cSideBarDrawer.cpp
+++ b/src/drawers/cSideBarDrawer.cpp
@@ -13,7 +13,7 @@
 #include "context/GraphicsContext.hpp"
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <algorithm>
 #include "include/cAssert.h"
 

--- a/src/drawers/cStructureDrawer.cpp
+++ b/src/drawers/cStructureDrawer.cpp
@@ -24,7 +24,7 @@
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
 #include "utils/d2tm_math.h"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include "include/cAssert.h"
 
 cStructureDrawer::cStructureDrawer(GameContext *ctx, cPlayer *player) :

--- a/src/drawers/cTextDrawer.cpp
+++ b/src/drawers/cTextDrawer.cpp
@@ -51,7 +51,7 @@ void cTextDrawer::drawTextCentered(const std::string &msg, int y, Color color) c
 {
     if (msg.empty()) return;
     int w,h;
-    TTF_SizeUTF8(m_font, msg.c_str(), &w, &h);
+    TTF_GetStringSize(m_font, msg.c_str(), 0, &w, &h);
     int half = w / 2;
     int xPos = (game.m_gameSettings->getScreenW() / 2) - half;
     drawText(xPos, y, color, msg);
@@ -61,7 +61,7 @@ void cTextDrawer::drawTextCenteredInBox(const std::string &msg, int x, int y, in
 {
     if (msg.empty()) return;
     int w,h;
-    TTF_SizeUTF8(m_font, msg.c_str(), &w, &h);
+    TTF_GetStringSize(m_font, msg.c_str(), 0, &w, &h);
     int lenghtInPixels = w;
     int heightInPixels = h;
 
@@ -86,7 +86,7 @@ void cTextDrawer::drawTextCentered(const std::string &msg, int x, int width, int
 {
     if (msg.empty()) return;
     int w,h;
-    TTF_SizeUTF8(m_font, msg.c_str(), &w, &h);
+    TTF_GetStringSize(m_font, msg.c_str(), 0, &w, &h);
     int lenghtInPixels = w;
     int half = lenghtInPixels / 2;
     int xPos = x + ((width / 2) - half);
@@ -107,7 +107,7 @@ void cTextDrawer::drawTextBottomRight(Color color, const std::string &msg, int m
 {
     if (msg.empty()) return;
     int w,h;
-    TTF_SizeUTF8(m_font, msg.c_str(), &w, &h);
+    TTF_GetStringSize(m_font, msg.c_str(), 0, &w, &h);
     int lenghtInPixels = w;
     int x = game.m_gameSettings->getScreenW() - lenghtInPixels-margin;
     int y = game.m_gameSettings->getScreenH() - getFontHeight()-20-margin;
@@ -116,14 +116,14 @@ void cTextDrawer::drawTextBottomRight(Color color, const std::string &msg, int m
 
 int cTextDrawer::getFontHeight() const
 {
-    return TTF_FontHeight(m_font);
+    return TTF_GetFontHeight(m_font);
 }
 
 void cTextDrawer::drawTextBottomLeft(Color color, const std::string &msg, int margin) const
 {
     if (msg.empty()) return;
     int w,h;
-    TTF_SizeUTF8(m_font, msg.c_str(), &w, &h);
+    TTF_GetStringSize(m_font, msg.c_str(), 0, &w, &h);
     int y = game.m_gameSettings->getScreenH() - h-20-margin;
     drawText(margin, y, color, msg);
 }
@@ -131,7 +131,7 @@ void cTextDrawer::drawTextBottomLeft(Color color, const std::string &msg, int ma
 int cTextDrawer::getTextLength(const std::string &msg) const
 {
     int w,h;
-    TTF_SizeUTF8(m_font, msg.c_str(), &w, &h);
+    TTF_GetStringSize(m_font, msg.c_str(), 0, &w, &h);
     return w;
 }
 

--- a/src/drawers/cTextDrawer.h
+++ b/src/drawers/cTextDrawer.h
@@ -2,7 +2,7 @@
 
 #include "utils/cRectangle.h"
 #include "utils/Color.hpp"
-#include <SDL2/SDL_ttf.h>
+#include <SDL3_ttf/SDL_ttf.h>
 #include <string>
 #include <memory>
 

--- a/src/drawers/cTextTextureCache.cpp
+++ b/src/drawers/cTextTextureCache.cpp
@@ -27,17 +27,17 @@ cTextTextureCache::~cTextTextureCache()
 std::unique_ptr<textCacheEntry> cTextTextureCache::createCacheEntry(Color color, const std::string &msg) const
 {
     auto newCacheEntry = std::make_unique<textCacheEntry>();
-    SDL_Surface *textSurface = TTF_RenderUTF8_Blended(m_font, msg.c_str(), Color::Black.toSDL());
+    SDL_Surface *textSurface = TTF_RenderText_Blended(m_font, msg.c_str(), 0, Color::Black.toSDL());
     if (!textSurface) {
-        cLogger::getInstance()->log(LOG_ERROR, COMP_ALFONT, "cTextTextureCache", std::format("Failed to create shadow surface for text '{}': {}", msg, TTF_GetError()));
+        cLogger::getInstance()->log(LOG_ERROR, COMP_ALFONT, "cTextTextureCache", std::format("Failed to create shadow surface for text '{}': {}", msg, SDL_GetError()));
         return nullptr;
     }
     newCacheEntry->shadowsTexture = SDL_CreateTextureFromSurface(global_renderDrawer->getRenderer(), textSurface);
     SDL_DestroySurface(textSurface);
 
-    textSurface = TTF_RenderUTF8_Blended(m_font, msg.c_str(), color.toSDL());
+    textSurface = TTF_RenderText_Blended(m_font, msg.c_str(), 0, color.toSDL());
     if (!textSurface) {
-        cLogger::getInstance()->log(LOG_ERROR, COMP_ALFONT, "cTextTextureCache", std::format("Failed to create surface for text '{}': {}", msg, TTF_GetError()));
+        cLogger::getInstance()->log(LOG_ERROR, COMP_ALFONT, "cTextTextureCache", std::format("Failed to create surface for text '{}': {}", msg, SDL_GetError()));
         return nullptr;
     }
     newCacheEntry->texture = SDL_CreateTextureFromSurface(global_renderDrawer->getRenderer(), textSurface);

--- a/src/drawers/cTextTextureCache.cpp
+++ b/src/drawers/cTextTextureCache.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<textCacheEntry> cTextTextureCache::createCacheEntry(Color color,
         return nullptr;
     }
     newCacheEntry->shadowsTexture = SDL_CreateTextureFromSurface(global_renderDrawer->getRenderer(), textSurface);
-    SDL_FreeSurface(textSurface);
+    SDL_DestroySurface(textSurface);
 
     textSurface = TTF_RenderUTF8_Blended(m_font, msg.c_str(), color.toSDL());
     if (!textSurface) {
@@ -44,7 +44,7 @@ std::unique_ptr<textCacheEntry> cTextTextureCache::createCacheEntry(Color color,
     newCacheEntry->width = textSurface->w;
     newCacheEntry->height = textSurface->h;
     newCacheEntry->lifeCounter = 10;
-    SDL_FreeSurface(textSurface);
+    SDL_DestroySurface(textSurface);
 
     return newCacheEntry;
 }

--- a/src/drawers/cTextTextureCache.cpp
+++ b/src/drawers/cTextTextureCache.cpp
@@ -33,6 +33,7 @@ std::unique_ptr<textCacheEntry> cTextTextureCache::createCacheEntry(Color color,
         return nullptr;
     }
     newCacheEntry->shadowsTexture = SDL_CreateTextureFromSurface(global_renderDrawer->getRenderer(), textSurface);
+    SDL_SetTextureScaleMode(newCacheEntry->shadowsTexture, SDL_SCALEMODE_NEAREST);
     SDL_DestroySurface(textSurface);
 
     textSurface = TTF_RenderText_Blended(m_font, msg.c_str(), 0, color.toSDL());
@@ -41,6 +42,7 @@ std::unique_ptr<textCacheEntry> cTextTextureCache::createCacheEntry(Color color,
         return nullptr;
     }
     newCacheEntry->texture = SDL_CreateTextureFromSurface(global_renderDrawer->getRenderer(), textSurface);
+    SDL_SetTextureScaleMode(newCacheEntry->texture, SDL_SCALEMODE_NEAREST);
     newCacheEntry->width = textSurface->w;
     newCacheEntry->height = textSurface->h;
     newCacheEntry->lifeCounter = 10;

--- a/src/drawers/cTextTextureCache.cpp
+++ b/src/drawers/cTextTextureCache.cpp
@@ -27,7 +27,11 @@ cTextTextureCache::~cTextTextureCache()
 std::unique_ptr<textCacheEntry> cTextTextureCache::createCacheEntry(Color color, const std::string &msg) const
 {
     auto newCacheEntry = std::make_unique<textCacheEntry>();
-    SDL_Surface *textSurface = TTF_RenderText_Blended(m_font, msg.c_str(), 0, Color::Black.toSDL());
+    // TTF_RenderText_Solid produces a crisp, non-anti-aliased 8-bit palette surface
+    // (fully transparent background, fully opaque foreground). This scales cleanly
+    // with nearest-neighbour upscaling, whereas Blended's partial-alpha edges produce
+    // a visible haze on light backgrounds and look inconsistent at non-integer scales.
+    SDL_Surface *textSurface = TTF_RenderText_Solid(m_font, msg.c_str(), 0, Color::Black.toSDL());
     if (!textSurface) {
         cLogger::getInstance()->log(LOG_ERROR, COMP_ALFONT, "cTextTextureCache", std::format("Failed to create shadow surface for text '{}': {}", msg, SDL_GetError()));
         return nullptr;
@@ -36,7 +40,7 @@ std::unique_ptr<textCacheEntry> cTextTextureCache::createCacheEntry(Color color,
     SDL_SetTextureScaleMode(newCacheEntry->shadowsTexture, SDL_SCALEMODE_NEAREST);
     SDL_DestroySurface(textSurface);
 
-    textSurface = TTF_RenderText_Blended(m_font, msg.c_str(), 0, color.toSDL());
+    textSurface = TTF_RenderText_Solid(m_font, msg.c_str(), 0, color.toSDL());
     if (!textSurface) {
         cLogger::getInstance()->log(LOG_ERROR, COMP_ALFONT, "cTextTextureCache", std::format("Failed to create surface for text '{}': {}", msg, SDL_GetError()));
         return nullptr;

--- a/src/drawers/cTextTextureCache.h
+++ b/src/drawers/cTextTextureCache.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "utils/Color.hpp"
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_ttf.h>
+#include <SDL3/SDL.h>
+#include <SDL3_ttf/SDL_ttf.h>
 #include <string>
 #include <unordered_map>
 #include <memory>

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -22,8 +22,8 @@
 
 #include <memory>
 #include <string>
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_mixer.h>
+#include <SDL3/SDL.h>
+#include <SDL3_mixer/SDL_mixer.h>
 
 class cGameControlsContext;
 class cGameObjectContext;

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -478,6 +478,9 @@ void cGame::run()
                 case SDL_EVENT_WINDOW_RESTORED:
                     m_focusManager->onWindowFocusGained();
                     break;
+                case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+                    m_Screen->onPixelSizeChanged();
+                    break;
                 case SDL_EVENT_KEY_DOWN:
                 case SDL_EVENT_KEY_UP:
                 case SDL_EVENT_TEXT_INPUT:
@@ -574,6 +577,14 @@ void cGame::shutdown()
 
     delete m_mouse;
     delete m_keyboard;
+
+    // Release all Graphics/Texture objects now, while the renderer is still valid.
+    // ~cPlatformLayerInit() calls SDL_Quit() later (when cGame itself is destroyed),
+    // but some Graphics shared_ptrs may still be alive at that point and their
+    // ~Graphics() would call SDL_DestroyTexture with an already-dead renderer.
+    ctx.reset();
+    context.reset();
+    gfxdata.reset();
 
     logbook("Allegro FONT library shut down.");
 }
@@ -1299,7 +1310,14 @@ void cGame::setNextStateToTransitionTo(int newState)
 
 void cGame::saveBmpScreenToDisk()
 {
-    if (cScreenShotSaver::saveScreen(renderer, m_gameSettings->m_screenW, m_gameSettings->m_screenH)) {
+    // Screenshot key fires during updateMouseAndKeyboardState(), before
+    // beginDrawingToTexture(actualRenderer). The default render target is
+    // SDL3's logical presentation texture which has been cleared to black.
+    // Read from actualRenderer directly — it holds the last complete frame.
+    SDL_SetRenderTarget(renderer, actualRenderer->tex.get());
+    bool saved = cScreenShotSaver::saveScreen(renderer, m_gameSettings->m_screenW, m_gameSettings->m_screenH);
+    SDL_SetRenderTarget(renderer, nullptr);
+    if (saved) {
         m_notificationArea->addNotification("Screenshot saved.", eNotificationType::NEUTRAL);
     }
 }

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -509,6 +509,7 @@ void cGame::run()
         shakeScreenAndBlitBuffer();
 
         m_renderDrawer->endDrawingToTexture();
+        m_renderDrawer->renderClearToColor();  // SDL3 persists its intermediate texture between frames; clear before composite
         m_renderDrawer->renderSprite(actualRenderer, m_screenShake->getX(), m_screenShake->getY());
         SDL_RenderPresent(renderer);
         m_timeManager->waitForCPU(); // wait for CPU to catch up, so we don't run too fast
@@ -831,12 +832,18 @@ void cGame::setState(int newState)
 
         if (newState == GAME_PLAYING) {
             // make sure to delete options menu now
+            if (m_currentState == m_states[GAME_OPTIONS]) {
+                m_currentState = nullptr;
+            }
             delete m_states[GAME_OPTIONS];
             m_states[GAME_OPTIONS] = nullptr;
         }
 
         if (newState == GAME_REGION) {
             // make sure to delete options menu now
+            if (m_currentState == m_states[GAME_OPTIONS]) {
+                m_currentState = nullptr;
+            }
             delete m_states[GAME_OPTIONS];
             m_states[GAME_OPTIONS] = nullptr;
         }

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -125,9 +125,9 @@ bool cGame::shouldCaptureTextInput() const
 void cGame::syncTextInputState() const
 {
     if (shouldCaptureTextInput()) {
-        SDL_StartTextInput();
+        SDL_StartTextInput(window);
     } else {
-        SDL_StopTextInput();
+        SDL_StopTextInput(window);
     }
 }
 
@@ -467,22 +467,27 @@ void cGame::run()
         }
         while (SDL_PollEvent(&event)) {
             switch (event.type) {
-                case SDL_QUIT:
+                case SDL_EVENT_QUIT:
                     m_gameSettings->m_playing = false;
                     break;
-                case SDL_WINDOWEVENT:
-                    m_focusManager->onWindowsFocus(event.window);
+                case SDL_EVENT_WINDOW_FOCUS_LOST:
+                case SDL_EVENT_WINDOW_MINIMIZED:
+                    m_focusManager->onWindowFocusLost();
                     break;
-                case SDL_KEYDOWN:
-                case SDL_KEYUP:
-                case SDL_TEXTINPUT:
+                case SDL_EVENT_WINDOW_FOCUS_GAINED:
+                case SDL_EVENT_WINDOW_RESTORED:
+                    m_focusManager->onWindowFocusGained();
+                    break;
+                case SDL_EVENT_KEY_DOWN:
+                case SDL_EVENT_KEY_UP:
+                case SDL_EVENT_TEXT_INPUT:
                     m_keyboard->handleEvent(event);
                     break;
 
-                case SDL_MOUSEBUTTONDOWN:
-                case SDL_MOUSEBUTTONUP:
-                case SDL_MOUSEMOTION:
-                case SDL_MOUSEWHEEL:
+                case SDL_EVENT_MOUSE_BUTTON_DOWN:
+                case SDL_EVENT_MOUSE_BUTTON_UP:
+                case SDL_EVENT_MOUSE_MOTION:
+                case SDL_EVENT_MOUSE_WHEEL:
                     m_mouse->handleEvent(event);
                 default:
                     break;
@@ -765,7 +770,7 @@ bool cGame::setupGame()
     m_gameObjectsContext->serviceInit(m_services.get());
 
     // all has installed well. Let's rock and roll.
-    SDL_ShowCursor(false);
+    SDL_HideCursor();
     return true;
 }
 
@@ -1600,14 +1605,14 @@ void cGame::initiateFadingOut()
     m_cScreenFader->startFadeOut();
 
     m_renderDrawer->beginDrawingToTexture(screenTexture);
-    SDL_RenderCopy(renderer, actualRenderer->tex.get(),nullptr, nullptr);
+    SDL_RenderTexture(renderer, actualRenderer->tex.get(), nullptr, nullptr);
     m_renderDrawer->endDrawingToTexture();
 }
 
 void cGame::takeBackGroundScreen()
 {
     m_renderDrawer->beginDrawingToTexture(screenTexture);
-    SDL_RenderCopy(renderer, actualRenderer->tex.get(),nullptr, nullptr);
+    SDL_RenderTexture(renderer, actualRenderer->tex.get(), nullptr, nullptr);
     m_renderDrawer->endDrawingToTexture();
 }
 

--- a/src/game/cPlatformLayerInit.cpp
+++ b/src/game/cPlatformLayerInit.cpp
@@ -14,27 +14,27 @@ cPlatformLayerInit::cPlatformLayerInit()
     cLogger *logger = cLogger::getInstance();
     logger->logHeader("SDL");
 
-    if (SDL_Init(SDL_INIT_EVERYTHING)< 0) {
-        logger->log(LOG_FATAL, COMP_SDL2, "SDL2 init", SDL_GetError(), OUTC_FAILED);
+    if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_EVENTS)) {
+        logger->log(LOG_FATAL, COMP_SDL2, "SDL init", SDL_GetError(), OUTC_FAILED);
         throw std::runtime_error(SDL_GetError());
     }
     else {
-        logger->log(LOG_INFO, COMP_SDL2, "SDL2 init", "Initialized successfully", OUTC_SUCCESS);
+        logger->log(LOG_INFO, COMP_SDL2, "SDL init", "Initialized successfully", OUTC_SUCCESS);
     }
 
-    if(Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, MIX_DEFAULT_CHANNELS, 1024) == -1) { //Initialisation de l'API Mixer
-        logger->log(LOG_FATAL, COMP_SDL2, "SDL2 mixer", Mix_GetError(), OUTC_FAILED);
+    if (!Mix_OpenAudio(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, nullptr)) {
+        logger->log(LOG_FATAL, COMP_SDL2, "SDL mixer", Mix_GetError(), OUTC_FAILED);
         throw std::runtime_error(Mix_GetError());
     }
     else {
-        logger->log(LOG_INFO, COMP_SDL2, "SDL2_mixer", "Initialized successfully", OUTC_SUCCESS);
+        logger->log(LOG_INFO, COMP_SDL2, "SDL_mixer", "Initialized successfully", OUTC_SUCCESS);
     }
 
-    if (TTF_Init() < 0) {
-        logger->log(LOG_FATAL, COMP_SDL2, "SDL2 ttf", TTF_GetError(), OUTC_FAILED);
+    if (!TTF_Init()) {
+        logger->log(LOG_FATAL, COMP_SDL2, "SDL ttf", TTF_GetError(), OUTC_FAILED);
     }
     else {
-        logger->log(LOG_INFO, COMP_SDL2, "SDL2_ttf", "Initialized successfully", OUTC_SUCCESS);
+        logger->log(LOG_INFO, COMP_SDL2, "SDL_ttf", "Initialized successfully", OUTC_SUCCESS);
     }
 }
 
@@ -44,7 +44,7 @@ cPlatformLayerInit::~cPlatformLayerInit()
     logger->log(LOG_INFO, COMP_SDL2, "SDL shutdown", "Shutting down...");
     TTF_Quit();
     Mix_CloseAudio();
-    logger->log(LOG_INFO, COMP_SDL2, "SDL2_mixer shutdown", "Thanks for playing!", OUTC_SUCCESS);
+    logger->log(LOG_INFO, COMP_SDL2, "SDL_mixer shutdown", "Thanks for playing!", OUTC_SUCCESS);
     SDL_Quit();
-    logger->log(LOG_INFO, COMP_SDL2, "SDL2 shutdown", "Thanks for playing!", OUTC_SUCCESS);
+    logger->log(LOG_INFO, COMP_SDL2, "SDL shutdown", "Thanks for playing!", OUTC_SUCCESS);
 }

--- a/src/game/cPlatformLayerInit.cpp
+++ b/src/game/cPlatformLayerInit.cpp
@@ -45,6 +45,11 @@ cPlatformLayerInit::~cPlatformLayerInit()
     TTF_Quit();
     MIX_Quit();
     logger->log(LOG_INFO, COMP_SDL2, "SDL_mixer shutdown", "Thanks for playing!", OUTC_SUCCESS);
-    SDL_Quit();
+    // On Linux, SDL3 registers its own atexit() handler that calls SDL_Quit() before
+    // C++ global destructors run. Calling it again here causes a double-free crash.
+    // Guard so we only call SDL_Quit() if SDL is still initialised.
+    if (SDL_WasInit(0)) {
+        SDL_Quit();
+    }
     logger->log(LOG_INFO, COMP_SDL2, "SDL shutdown", "Thanks for playing!", OUTC_SUCCESS);
 }

--- a/src/game/cPlatformLayerInit.cpp
+++ b/src/game/cPlatformLayerInit.cpp
@@ -2,9 +2,9 @@
 
 #include "utils/cLog.h"
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_mixer.h>
-#include <SDL2/SDL_ttf.h>
+#include <SDL3/SDL.h>
+#include <SDL3_mixer/SDL_mixer.h>
+#include <SDL3_ttf/SDL_ttf.h>
 
 #include <cstring>
 #include <stdexcept>

--- a/src/game/cPlatformLayerInit.cpp
+++ b/src/game/cPlatformLayerInit.cpp
@@ -22,16 +22,16 @@ cPlatformLayerInit::cPlatformLayerInit()
         logger->log(LOG_INFO, COMP_SDL2, "SDL init", "Initialized successfully", OUTC_SUCCESS);
     }
 
-    if (!Mix_OpenAudio(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, nullptr)) {
-        logger->log(LOG_FATAL, COMP_SDL2, "SDL mixer", Mix_GetError(), OUTC_FAILED);
-        throw std::runtime_error(Mix_GetError());
+    if (!MIX_Init()) {
+        logger->log(LOG_FATAL, COMP_SDL2, "SDL mixer", SDL_GetError(), OUTC_FAILED);
+        throw std::runtime_error(SDL_GetError());
     }
     else {
         logger->log(LOG_INFO, COMP_SDL2, "SDL_mixer", "Initialized successfully", OUTC_SUCCESS);
     }
 
     if (!TTF_Init()) {
-        logger->log(LOG_FATAL, COMP_SDL2, "SDL ttf", TTF_GetError(), OUTC_FAILED);
+        logger->log(LOG_FATAL, COMP_SDL2, "SDL ttf", SDL_GetError(), OUTC_FAILED);
     }
     else {
         logger->log(LOG_INFO, COMP_SDL2, "SDL_ttf", "Initialized successfully", OUTC_SUCCESS);
@@ -43,7 +43,7 @@ cPlatformLayerInit::~cPlatformLayerInit()
     cLogger *logger = cLogger::getInstance();
     logger->log(LOG_INFO, COMP_SDL2, "SDL shutdown", "Shutting down...");
     TTF_Quit();
-    Mix_CloseAudio();
+    MIX_Quit();
     logger->log(LOG_INFO, COMP_SDL2, "SDL_mixer shutdown", "Thanks for playing!", OUTC_SUCCESS);
     SDL_Quit();
     logger->log(LOG_INFO, COMP_SDL2, "SDL shutdown", "Thanks for playing!", OUTC_SUCCESS);

--- a/src/game/cScreenFader.h
+++ b/src/game/cScreenFader.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL2/SDL.h>   //uint8
+#include <SDL3/SDL.h>   //uint8
 
 class Color;
 

--- a/src/game/cScreenInit.cpp
+++ b/src/game/cScreenInit.cpp
@@ -36,11 +36,15 @@ void cScreenInit::setWindowMode()
 
 void cScreenInit::getWindowResolution()
 {
-    const SDL_DisplayMode *mode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
-    if (mode) {
-        cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "desktop", std::format("Resolution screen : {}x{}",mode->w,mode->h));
-        windowResolution.width = mode->w;
-        windowResolution.height = mode->h;
+    // SDL_GetCurrentDisplayMode returns PHYSICAL pixels, but SDL_CreateWindow
+    // expects LOGICAL pixels (points). On Retina/HiDPI displays these differ
+    // (e.g. 2560x1600 physical vs 1280x800 logical on a 2x Retina Mac).
+    // Use SDL_GetDisplayBounds which returns screen coordinates (logical pixels).
+    SDL_Rect bounds = {};
+    if (SDL_GetDisplayBounds(SDL_GetPrimaryDisplay(), &bounds)) {
+        cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "desktop", std::format("Display bounds : {}x{}", bounds.w, bounds.h));
+        windowResolution.width = bounds.w;
+        windowResolution.height = bounds.h;
     }
 }
 

--- a/src/game/cScreenInit.cpp
+++ b/src/game/cScreenInit.cpp
@@ -11,18 +11,46 @@
 #include <span>
 #include <vector>
 
+void cScreenInit::applyFullscreenPresentation()
+{
+    int renderW, renderH;
+    SDL_GetCurrentRenderOutputSize(renderer, &renderW, &renderH);
+
+    // Always INTEGER_SCALE: every game pixel maps to the same-sized block on
+    // screen (1x, 2x, 3x ...). If the screen is larger than an exact multiple,
+    // the remainder appears as black borders. This avoids fractional scaling
+    // (LETTERBOX at e.g. 1.167x) which produces jagged, uneven pixels even
+    // with nearest-neighbour filtering. renderResolution is already capped to
+    // the logical screen size in adaptResolution, so the scale is always >= 1.
+    int intScale = std::min(renderW / renderResolution.width, renderH / renderResolution.height);
+
+    SDL_SetRenderLogicalPresentation(renderer, renderResolution.width, renderResolution.height, SDL_LOGICAL_PRESENTATION_INTEGER_SCALE);
+    SDL_RenderClear(renderer);
+    SDL_RenderPresent(renderer);
+
+    cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "desktop", std::format("Renderer output size : {}x{}", renderW, renderH));
+    cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "desktop", std::format("Presentation mode : INTEGER_SCALE (integer scale = {})", intScale));
+    float scale = SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay());
+    cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "DPI", std::format("Display content scale : {}", scale));
+}
+
 void cScreenInit::setFullScreenMode()
 {
     SDL_SetWindowFullscreen(window, true);
-    SDL_SetRenderLogicalPresentation(renderer, renderResolution.width, renderResolution.height, SDL_LOGICAL_PRESENTATION_LETTERBOX);
-    SDL_RenderClear(renderer);
-    SDL_RenderPresent(renderer);
+    // On macOS, SDL_SetWindowFullscreen is asynchronous — the Spaces animation
+    // plays out after the call returns. SDL_SyncWindow blocks until the window
+    // state (and renderer output size) is final, so applyFullscreenPresentation
+    // measures the correct output size.
+    SDL_SyncWindow(window);
     cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "desktop", "Fullscreen desktop");
-    int renderW, renderH;
-    SDL_GetCurrentRenderOutputSize(renderer, &renderW, &renderH);
-    cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "desktop", std::format("Renderer output size : {}x{}",renderW,renderH));
-    float scale = SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay());
-    cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "DPI", std::format("Display content scale : {}", scale));
+    applyFullscreenPresentation();
+}
+
+void cScreenInit::onPixelSizeChanged()
+{
+    if (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) {
+        applyFullscreenPresentation();
+    }
 }
 
 void cScreenInit::setWindowMode()
@@ -64,6 +92,15 @@ void cScreenInit::adaptResolution(int desiredWidth, int desiredHeight)
         renderResolution.width = desiredWidth;
         renderResolution.height = windowResolution.height * desiredWidth / windowResolution.width;
     }
+
+    // Cap to the logical screen size so the game never requests a larger
+    // coordinate space than the display provides. Without this, fullscreen
+    // would have to scale DOWN (e.g. fit 1792x1120 into a 1536x960 logical
+    // screen), causing squishing. The cap ensures fullscreen can always show
+    // the game at 1:1 or larger integer multiples.
+    renderResolution.width = std::min(renderResolution.width, windowResolution.width);
+    renderResolution.height = std::min(renderResolution.height, windowResolution.height);
+
     cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "Resolution", std::format("Adopted : {}x{}",renderResolution.width,renderResolution.height));
 }
 
@@ -71,6 +108,13 @@ cScreenInit::cScreenInit(int desiredWidth, int desiredHeight, const std::string 
 {
     this->getWindowResolution();
     this->adaptResolution(desiredWidth, desiredHeight);
+
+    // Disable macOS Spaces fullscreen: SDL3 defaults to Spaces (animated
+    // Space transition), which changes the renderer output to logical pixels
+    // (1536x960 on a 1792x1120 physical display) and fires async size events.
+    // Non-Spaces fullscreen matches SDL2 behaviour: immediate, uses physical
+    // pixel dimensions, no transition surprises.
+    SDL_SetHint(SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES, "0");
 
     auto logger = cLogger::getInstance();
 
@@ -100,6 +144,15 @@ cScreenInit::cScreenInit(int desiredWidth, int desiredHeight, const std::string 
     }
 
     SDL_SetRenderVSync(renderer, 1);
+
+    // SDL_RENDER_SCALE_QUALITY was removed in SDL3. The correct way to control
+    // the logical presentation's internal texture scale is via the renderer's
+    // default texture scale mode. Setting it to NEAREST once here ensures
+    // every SDL_SetRenderLogicalPresentation call (now and later) creates its
+    // internal texture with nearest-neighbour filtering — critical for crisp
+    // pixel art at any scale factor.
+    SDL_SetDefaultTextureScaleMode(renderer, SDL_SCALEMODE_NEAREST);
+
     SDL_SetWindowFullscreen(window, false);
     SDL_SetWindowSize(window, renderResolution.width, renderResolution.height);
     SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);

--- a/src/game/cScreenInit.cpp
+++ b/src/game/cScreenInit.cpp
@@ -2,7 +2,7 @@
 
 #include "utils/cLog.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <format>
 
 #include <array>

--- a/src/game/cScreenInit.cpp
+++ b/src/game/cScreenInit.cpp
@@ -13,41 +13,35 @@
 
 void cScreenInit::setFullScreenMode()
 {
-    SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
-    SDL_RenderSetLogicalSize(renderer, renderResolution.width, renderResolution.height);
+    SDL_SetWindowFullscreen(window, true);
+    SDL_SetRenderLogicalPresentation(renderer, renderResolution.width, renderResolution.height, SDL_LOGICAL_PRESENTATION_LETTERBOX);
     SDL_RenderClear(renderer);
     SDL_RenderPresent(renderer);
     cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "desktop", "Fullscreen desktop");
-    // Affiche la taille réelle du rendu
     int renderW, renderH;
-    SDL_GetRendererOutputSize(renderer, &renderW, &renderH);
+    SDL_GetCurrentRenderOutputSize(renderer, &renderW, &renderH);
     cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "desktop", std::format("Renderer output size : {}x{}",renderW,renderH));
-    // Affiche le DPI
-    float ddpi, hdpi, vdpi;
-    if (SDL_GetDisplayDPI(0, &ddpi, &hdpi, &vdpi) == 0) {
-        cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "DPI", std::format("DPI : {}, (H: {},V: {})",ddpi,hdpi,vdpi));
-    } else {
-        cLogger::getInstance()->log(LOG_ERROR, COMP_SDL2, "DPI", SDL_GetError());
-    }
+    float scale = SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay());
+    cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "DPI", std::format("Display content scale : {}", scale));
 }
 
 void cScreenInit::setWindowMode()
 {
-    SDL_SetWindowFullscreen(window, 0);
+    SDL_SetWindowFullscreen(window, false);
     SDL_SetWindowSize(window, renderResolution.width, renderResolution.height);
     SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-    SDL_RenderSetLogicalSize(renderer, renderResolution.width, renderResolution.height);
+    SDL_SetRenderLogicalPresentation(renderer, renderResolution.width, renderResolution.height, SDL_LOGICAL_PRESENTATION_LETTERBOX);
     cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "desktop", "Windowed desktop");
 }
 
 void cScreenInit::getWindowResolution()
 {
-    SDL_DisplayMode mode;
-    if (SDL_GetCurrentDisplayMode(0, &mode) == 0) {
-        cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "desktop", std::format("Resolution screen : {}x{}",mode.w,mode.h));
+    const SDL_DisplayMode *mode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
+    if (mode) {
+        cLogger::getInstance()->log(LOG_INFO, COMP_SDL2, "desktop", std::format("Resolution screen : {}x{}",mode->w,mode->h));
+        windowResolution.width = mode->w;
+        windowResolution.height = mode->h;
     }
-    windowResolution.width = mode.w;
-    windowResolution.height = mode.h;
 }
 
 void cScreenInit::adaptResolution(int desiredWidth, int desiredHeight)
@@ -76,7 +70,7 @@ cScreenInit::cScreenInit(int desiredWidth, int desiredHeight, const std::string 
 
     auto logger = cLogger::getInstance();
 
-    window = SDL_CreateWindow(title.c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, renderResolution.width , renderResolution.height, SDL_WINDOW_ALLOW_HIGHDPI);
+    window = SDL_CreateWindow(title.c_str(), renderResolution.width, renderResolution.height, 0);
     if (window == nullptr) {
         const auto msg = std::format("Failed initialized screen with resolution {}x{}", renderResolution.width, renderResolution.height);
         logger->log(LOG_ERROR, COMP_SDL2, "Screen init", msg, OUTC_FAILED);
@@ -85,11 +79,10 @@ cScreenInit::cScreenInit(int desiredWidth, int desiredHeight, const std::string 
     }
     else {
         const auto msg = std::format("Successfully initialized screen with resolution {}x{}.", renderResolution.width, renderResolution.height);
-        //std::cout << msg << std::endl;
         logger->log(LOG_INFO, COMP_SDL2, "Screen init", msg, OUTC_SUCCESS);
     }
 
-    renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+    renderer = SDL_CreateRenderer(window, nullptr);
     if (renderer == nullptr) {
         const auto msg = std::format("Failed initialized renderer with resolution {}x{}", renderResolution.width, renderResolution.height);
         logger->log(LOG_ERROR, COMP_SDL2, "Renderer init", msg, OUTC_FAILED);
@@ -102,8 +95,9 @@ cScreenInit::cScreenInit(int desiredWidth, int desiredHeight, const std::string 
         logger->log(LOG_INFO, COMP_SDL2, "Renderer init", msg, OUTC_SUCCESS);
     }
 
-    SDL_SetWindowFullscreen(window, 0);
+    SDL_SetRenderVSync(renderer, 1);
+    SDL_SetWindowFullscreen(window, false);
     SDL_SetWindowSize(window, renderResolution.width, renderResolution.height);
     SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-    SDL_RenderSetLogicalSize(renderer, renderResolution.width, renderResolution.height);
+    SDL_SetRenderLogicalPresentation(renderer, renderResolution.width, renderResolution.height, SDL_LOGICAL_PRESENTATION_LETTERBOX);
 }

--- a/src/game/cScreenInit.h
+++ b/src/game/cScreenInit.h
@@ -19,6 +19,7 @@ public:
 
     void setFullScreenMode();
     void setWindowMode();
+    void onPixelSizeChanged();
 
     cScreenInit &operator=(const cScreenInit &) = delete;
     cScreenInit &operator=(cScreenInit &&) = delete;
@@ -43,6 +44,7 @@ public:
 private:
     void getWindowResolution();
     void adaptResolution(int desiredWidth, int desiredHeight);
+    void applyFullscreenPresentation();
     DisplayResolution renderResolution;
     DisplayResolution windowResolution; //display size of screen
     SDL_Window *window = nullptr;

--- a/src/game/cScreenInit.h
+++ b/src/game/cScreenInit.h
@@ -3,7 +3,7 @@
 #include "game/cPlatformLayerInit.h"
 
 #include <string>
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 struct DisplayResolution {
     int width;

--- a/src/game/cScreenShotSaver.cpp
+++ b/src/game/cScreenShotSaver.cpp
@@ -1,5 +1,5 @@
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
+#include <SDL3/SDL.h>
+#include <SDL3_image/SDL_image.h>
 
 #include <format>
 #include <chrono>

--- a/src/game/cScreenShotSaver.cpp
+++ b/src/game/cScreenShotSaver.cpp
@@ -21,22 +21,15 @@ bool cScreenShotSaver::saveScreen(SDL_Renderer* renderer, int width, int height)
     try {
         screenCount++;
         std::string filename = std::format("{}_{}x{}_{:0>4}.png", getBaseFileName(), width, height, screenCount);
-        int rw, rh;
-        SDL_GetRendererOutputSize(renderer, &rw, &rh);
-        SDL_Surface* surface = SDL_CreateRGBSurfaceWithFormat(0, rw, rh, 32, SDL_PIXELFORMAT_RGBA32);
+        SDL_Surface* surface = SDL_RenderReadPixels(renderer, NULL);
         if (!surface) {
-            cLogger::getInstance()->log(LOG_ERROR, COMP_SDL2, "saveScreen", std::format("Error creating surface: {}", SDL_GetError()), OUTC_FAILED);
-            return false;
-        }
-        if (SDL_RenderReadPixels(renderer, NULL, SDL_PIXELFORMAT_RGBA32, surface->pixels, surface->pitch) != 0) {
             cLogger::getInstance()->log(LOG_ERROR, COMP_SDL2, "saveScreen", std::format("Error reading pixels: {}", SDL_GetError()), OUTC_FAILED);
-            SDL_FreeSurface(surface);
             return false;
         }
         if (IMG_SavePNG(surface, filename.c_str()) != 0) {
             cLogger::getInstance()->log(LOG_ERROR, COMP_SDL2, "saveScreen", std::format("IMG_SavePNG error: {}", SDL_GetError()), OUTC_FAILED);
         }
-        SDL_FreeSurface(surface);
+        SDL_DestroySurface(surface);
         return true;
     }
     catch (const std::exception& e) {

--- a/src/game/cScreenShotSaver.h
+++ b/src/game/cScreenShotSaver.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <string>
 
 class cScreenShotSaver {

--- a/src/game/cTimeManager.cpp
+++ b/src/game/cTimeManager.cpp
@@ -79,7 +79,7 @@ void cTimeManager::onWindowFocusLost()
 void cTimeManager::onWindowFocusGained()
 {
     if (m_focusLostTime > 0) {
-        int lostTime = SDL_GetTicks() - m_focusLostTime;
+        Uint64 lostTime = SDL_GetTicks() - m_focusLostTime;
         // std::cout << "Focus regained, lost time: " << lostTime << " ms" << std::endl;
         m_focusLostTime = 0;
 
@@ -179,7 +179,7 @@ void cTimeManager::handleTimerCache()
 */
 void cTimeManager::processTime()
 {
-    uint64_t now = SDL_GetTicks64();
+    Uint64 now = SDL_GetTicks();
 
     while (now - m_timerUnits.lastTick >= m_timerUnits.tickDuration) {
         m_timerUnits.count++;

--- a/src/game/cTimeManager.cpp
+++ b/src/game/cTimeManager.cpp
@@ -6,7 +6,7 @@
 
 #include <format>
 #include <chrono>
-#include <SDL2/SDL_timer.h>
+#include <SDL3/SDL.h>
 #include <algorithm>
 #include <platform.h>
 #include "include/cAssert.h"

--- a/src/game/cTimeManager.h
+++ b/src/game/cTimeManager.h
@@ -90,7 +90,7 @@ private:
     int m_fps = 0;			    // Frames per second
     int m_frameCount = 0;	    // Frame count for FPS calculation
     int m_waitingTime = 10;	    // Waiting time in ms, used to adapt FPS
-    int m_focusLostTime = 0;    // Time when focus was lost, used to calculate time to catch up when focus is regained
+    Uint64 m_focusLostTime = 0;  // Time when focus was lost, used to calculate time to catch up when focus is regained
 
     std::unique_ptr<cTimeCounter> m_timeCounter;
 };

--- a/src/gameobjects/map/cPreviewMaps.cpp
+++ b/src/gameobjects/map/cPreviewMaps.cpp
@@ -197,6 +197,7 @@ void cPreviewMaps::loadSkirmish(const std::string &filename)
             logbook(std::format("Error creating texture from surface: {}", SDL_GetError()));
             return;
         }
+        SDL_SetTextureScaleMode(out, SDL_SCALEMODE_NEAREST);
         previewMap->previewTex = new Texture(out, previewMap->terrain->w, previewMap->terrain->h);
     }
     logbook(std::format("Loaded skirmish map: {}, width: {}, height: {}",

--- a/src/gameobjects/map/cPreviewMaps.cpp
+++ b/src/gameobjects/map/cPreviewMaps.cpp
@@ -54,7 +54,7 @@ void cPreviewMaps::destroy()
             continue;
         }
         if (previewMap->terrain) {
-            SDL_FreeSurface(previewMap->terrain);
+            SDL_DestroySurface(previewMap->terrain);
             previewMap->terrain = nullptr;
         }
         if (previewMap->previewTex) {
@@ -125,7 +125,7 @@ void cPreviewMaps::loadSkirmish(const std::string &filename)
     previewMap->terrainType = std::vector<int>(maxCells, -1);
 
     if (previewMap->terrain == nullptr) {
-        previewMap->terrain = SDL_CreateRGBSurface(0,previewMap->width, previewMap->height,32,0,0,0,255);
+        previewMap->terrain = SDL_CreateSurface(previewMap->width, previewMap->height, SDL_PIXELFORMAT_RGBA32);
     }
     m_renderDrawer->FillWithColor(previewMap->terrain, Color::Black);
 
@@ -247,7 +247,7 @@ void cPreviewMaps::initRandomMap()
 
     firstSkirmishMap->terrainType = std::vector<int>(1, -1);
     // if (firstSkirmishMap.terrain != nullptr) {
-    //     SDL_FreeSurface(firstSkirmishMap.terrain);
+    //     SDL_DestroySurface(firstSkirmishMap.terrain);
     // }
     firstSkirmishMap->terrain = nullptr;
     // if (firstSkirmishMap.previewTex != nullptr) {

--- a/src/gameobjects/map/cPreviewMaps.h
+++ b/src/gameobjects/map/cPreviewMaps.h
@@ -2,7 +2,7 @@
 
 // #define MAX_SKIRMISHMAPS 100     // max of 100 skirmish maps
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <vector>
 #include <string>
 #include <array>

--- a/src/gameobjects/mentat/AbstractMentat.cpp
+++ b/src/gameobjects/mentat/AbstractMentat.cpp
@@ -22,8 +22,8 @@
 #include "utils/common.h"
 #include "drawers/cTextDrawer.h"
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_ttf.h>
+#include <SDL3/SDL.h>
+#include <SDL3_ttf/SDL_ttf.h>
 #include <format>
 #include "include/cAssert.h"
 

--- a/src/gameobjects/mentat/AbstractMentat.h
+++ b/src/gameobjects/mentat/AbstractMentat.h
@@ -26,7 +26,7 @@
 
 #include <string>
 #include <memory>
-#include <SDL2/SDL_ttf.h>
+#include <SDL3_ttf/SDL_ttf.h>
 
 class GuiButton;
 struct SDL_Surface;

--- a/src/gameobjects/mentat/BeneMentat.cpp
+++ b/src/gameobjects/mentat/BeneMentat.cpp
@@ -11,7 +11,7 @@
 #include "utils/Graphics.hpp"
 #include "utils/common.h"
 #include "drawers/cTextDrawer.h"
-#include <SDL2/SDL_ttf.h>
+#include <SDL3_ttf/SDL_ttf.h>
 #include "gui/GuiButton.h"
 #include "context/GameContext.hpp"
 #include "context/cInfoContext.h"

--- a/src/gameobjects/particles/cParticle.cpp
+++ b/src/gameobjects/particles/cParticle.cpp
@@ -26,7 +26,7 @@
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <iostream>
 
 std::map<std::pair<int, int>, Texture*> cParticle::particleTextureCache = {};

--- a/src/gameobjects/players/cHousesInfo.h
+++ b/src/gameobjects/players/cHousesInfo.h
@@ -2,7 +2,7 @@
 
 #include <memory>
 #include "utils/cIniFile.h"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include "utils/Color.hpp"
 
 #define MAX_HOUSES        12      // 12 different type of houses

--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -287,7 +287,7 @@ void cPlayer::setHouse(int iHouse)
             // flash bitmaps are structure type index * 2
             if (structureType.flash) {
                 int j = MAX_STRUCTURETYPES + i;
-                SDL_Surface *bitmap = SDL_CreateRGBSurface(0, structureType.bmp->w, structureType.bmp->h,32,0,0,0,255);
+                SDL_Surface *bitmap = SDL_CreateSurface(structureType.bmp->w, structureType.bmp->h, SDL_PIXELFORMAT_RGBA32);
                 if (!bitmap) {
                     std::cerr << "Could not create FLASH bmp structure bitmap!? - Imminent crash.\n";
                 }

--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -25,7 +25,7 @@
 #include "include/sGameServices.h"
 #include "context/GameContext.hpp"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <format>
 #include <iostream>
 

--- a/src/gameobjects/projectiles/cBulletInfos.h
+++ b/src/gameobjects/projectiles/cBulletInfos.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <array>
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 class Texture;
 

--- a/src/gameobjects/structures/cAbstractStructure.cpp
+++ b/src/gameobjects/structures/cAbstractStructure.cpp
@@ -31,7 +31,7 @@
 #include "utils/cSoundPlayer.h"
 #include "include/Texture.hpp"
 #include "utils/RNG.hpp"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <format>
 
 #include "data/gfxaudio.h"

--- a/src/gameobjects/structures/cStructureInfo.h
+++ b/src/gameobjects/structures/cStructureInfo.h
@@ -6,7 +6,7 @@
 
 #include "include/enums.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 class Texture;
 #include <vector>
 

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -33,7 +33,7 @@
 #include "utils/cSoundPlayer.h"
 #include "utils/Graphics.hpp"
 #include "utils/RNG.hpp"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <format>
 #include "drawers/cTextDrawer.h"
 #include "gameobjects/units/cPathFinder.h"

--- a/src/gameobjects/units/cUnitInfos.h
+++ b/src/gameobjects/units/cUnitInfos.h
@@ -6,7 +6,7 @@
 
 #include "include/enums.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 class Texture;
 
 // UNITS stuff

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -12,7 +12,7 @@
 #include "context/GameContext.hpp"
 #include "gameobjects/units/cReinforcements.h"
 #include "gameobjects/units/cUnits.h"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include "managers/cDrawManager.h"
 #include "gameobjects/players/cPlayer.h"
 #include "gameobjects/players/cPlayers.h"

--- a/src/gamestates/cGamePlaying.h
+++ b/src/gamestates/cGamePlaying.h
@@ -6,7 +6,7 @@
 #include "controls/sMouseEvent.h"
 #include <optional>
 #include <vector>
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 class Texture;
 

--- a/src/gamestates/cMainMenuState.cpp
+++ b/src/gamestates/cMainMenuState.cpp
@@ -13,7 +13,7 @@
 #include "utils/cSoundPlayer.h"
 #include "game/cGameInterface.h"
 
-#include <SDL2/SDL_scancode.h>
+#include <SDL3/SDL.h>
 #include <format>
 #include "include/cAssert.h"
 

--- a/src/gamestates/cSelectYourNextConquestState.cpp
+++ b/src/gamestates/cSelectYourNextConquestState.cpp
@@ -1,5 +1,6 @@
 #include "cSelectYourNextConquestState.h"
 
+#include <cmath>
 #include "controls/eKeyAction.h"
 #include "controls/cMouse.h"
 #include "data/gfxdata.h"

--- a/src/gamestates/cSelectYourNextConquestState.cpp
+++ b/src/gamestates/cSelectYourNextConquestState.cpp
@@ -19,7 +19,7 @@
 #include "game/cGameInterface.h"
 #include "drawers/cTextDrawer.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <iostream>
 #include <format>
 #include "include/cAssert.h"

--- a/src/gamestates/cSelectYourNextConquestState.cpp
+++ b/src/gamestates/cSelectYourNextConquestState.cpp
@@ -32,9 +32,9 @@ static Uint8 getPixelColorIndexFromSurface(SDL_Surface *surface, int x, int y)
         return 0;
     }
 
-    if (surface->format->format != SDL_PIXELFORMAT_INDEX8) {
+    if (surface->format != SDL_PIXELFORMAT_INDEX8) {
         std::cerr << "Error : no indexed 8 bits surface (format actuel : "
-                  << SDL_GetPixelFormatName(surface->format->format) << ")." << std::endl;
+                  << SDL_GetPixelFormatName(surface->format) << ")." << std::endl;
         return 0;
     }
 

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -1271,6 +1271,7 @@ void cSetupSkirmishState::generateRandomMap()
         logbook(std::format("Error creating texture from surface: {}", SDL_GetError()));
         return;
     }
+    SDL_SetTextureScaleMode(out, SDL_SCALEMODE_NEAREST);
     randomMap->previewTex = new Texture(out, randomMap->terrain->w, randomMap->terrain->h);
 }
 

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -1252,7 +1252,7 @@ void cSetupSkirmishState::generateRandomMap()
     randomMap->terrainType = std::vector<int>(maxCells, -1);
 
     if (randomMap->terrain == nullptr) {
-        randomMap->terrain = SDL_CreateRGBSurface(0, randomMapWidth, randomMapHeight,32,0,0,0,255);
+        randomMap->terrain = SDL_CreateSurface(randomMapWidth, randomMapHeight, SDL_PIXELFORMAT_RGBA32);
     }
 
     // delete any preview texture if it exists

--- a/src/gamestates/cWinLoseState.cpp
+++ b/src/gamestates/cWinLoseState.cpp
@@ -6,7 +6,7 @@
 #include "context/GameContext.hpp"
 #include "game/cGameInterface.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include "include/cAssert.h"
 
 cWinLoseState::cWinLoseState(sGameServices* services, Outcome value) : 

--- a/src/gui/GuiTextInput.cpp
+++ b/src/gui/GuiTextInput.cpp
@@ -2,7 +2,7 @@
 #include "drawers/cTextDrawer.h"
 #include "include/cAssert.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 #include <algorithm>
 

--- a/src/gui/cTextWriter.h
+++ b/src/gui/cTextWriter.h
@@ -9,8 +9,8 @@
 
 #include "utils/Color.hpp"
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_ttf.h>
+#include <SDL3/SDL.h>
+#include <SDL3_ttf/SDL_ttf.h>
 #include <string>
 #include <format>
 

--- a/src/include/Texture.hpp
+++ b/src/include/Texture.hpp
@@ -3,7 +3,12 @@
 #include <memory>
 
 struct SDLTextureDeleter {
-    void operator()(SDL_Texture* t) const { if (t) SDL_DestroyTexture(t); }
+    // SDL3 crashes if SDL_DestroyTexture is called after SDL_Quit() (e.g. when
+    // Graphics globals outlive the renderer). Guard with SDL_WasInit so the
+    // deleter is a no-op once the video subsystem has been torn down.
+    void operator()(SDL_Texture* t) const {
+        if (t && SDL_WasInit(SDL_INIT_VIDEO)) SDL_DestroyTexture(t);
+    }
 };
 
 class Texture {

--- a/src/include/Texture.hpp
+++ b/src/include/Texture.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <memory>
 
 struct SDLTextureDeleter {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include <string>
 
 #include <iostream>
+#include <SDL3/SDL_main.h>
 #include <SDL3_ttf/SDL_ttf.h>
 
 // the ultimate game variable(s)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,7 @@
 #include <string>
 
 #include <iostream>
-#include <SDL2/SDL_ttf.h>
+#include <SDL3_ttf/SDL_ttf.h>
 
 // the ultimate game variable(s)
 cGame          				game;

--- a/src/managers/cDrawManager.cpp
+++ b/src/managers/cDrawManager.cpp
@@ -24,7 +24,7 @@
 #include "gameobjects/map/cMap.h"
 #include "drawers/cSideBarDrawer.h"
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include "include/cAssert.h"
 
 cDrawManager::cDrawManager(GameContext *ctx, cPlayer *thePlayer) :

--- a/src/utils/Color.hpp
+++ b/src/utils/Color.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL2/SDL_pixels.h>
+#include <SDL3/SDL.h>
 
 class Color {
 public:

--- a/src/utils/Graphics.cpp
+++ b/src/utils/Graphics.cpp
@@ -6,7 +6,7 @@
 Graphics::Graphics(SDL_Renderer *_renderer,const std::string &filePackName): renderer(_renderer)
 {
     d2tm_assert(_renderer != nullptr);
-    dataPack = std::make_unique<DataPack>(filePackName);
+    dataPack = std::make_unique<DataPack>(filePackName, nullptr);
 }
 
 Graphics::~Graphics()

--- a/src/utils/Graphics.cpp
+++ b/src/utils/Graphics.cpp
@@ -44,6 +44,7 @@ Texture *Graphics::getTexture(int index)
         std::cerr << "Graphics: Failed to convert texture " << index << " : " <<SDL_GetError() << std::endl;
         return nullptr;
     }
+    SDL_SetTextureScaleMode(outTexture, SDL_SCALEMODE_NEAREST);
     texCache.emplace(index, std::make_unique<Texture>(outTexture, outSurface->w, outSurface->h));
     return texCache[index].get();
 }

--- a/src/utils/Graphics.hpp
+++ b/src/utils/Graphics.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <string>
 #include <memory>
 #include <unordered_map>

--- a/src/utils/cDataPack.cpp
+++ b/src/utils/cDataPack.cpp
@@ -2,7 +2,7 @@
 #include "cPack.h"
 #include <iostream>
 #include <iomanip>
-#include <SDL2/SDL_image.h>
+#include <SDL3_image/SDL_image.h>
 
 DataPack::DataPack(const std::string &packName)
 {

--- a/src/utils/cDataPack.cpp
+++ b/src/utils/cDataPack.cpp
@@ -4,21 +4,19 @@
 #include <iomanip>
 #include <SDL3_image/SDL_image.h>
 
-DataPack::DataPack(const std::string &packName)
+DataPack::DataPack(const std::string &packName, MIX_Mixer *mixer)
+    : m_mixer(mixer)
 {
     reader = std::make_unique<ReaderPack>(packName);
 }
 
 DataPack::~DataPack()
 {
-    for (auto& [_, texture] : surfaceCache) {
-        if (texture) SDL_DestroySurface(texture);
+    for (auto& [_, surface] : surfaceCache) {
+        if (surface) SDL_DestroySurface(surface);
     }
-    for (auto& [_, music] : musicCache) {
-        if (music) Mix_FreeMusic(music);
-    }
-    for (auto& [_, chunk] : sampleCache) {
-        if (chunk) Mix_FreeChunk(chunk);
+    for (auto& [_, audio] : audioCache) {
+        if (audio) MIX_DestroyAudio(audio);
     }
     reader.reset();
 }
@@ -49,7 +47,7 @@ SDL_Surface *DataPack::getSurface(int index)
     if (it != surfaceCache.end())
         return it->second;
     SDL_IOStream *tmp = reader->getData(index);
-    SDL_Surface *out = IMG_Load_IO(tmp, SDL_TRUE);
+    SDL_Surface *out = IMG_Load_IO(tmp, true);
     if (!out) {
         printf("Failed to load image %i : %s\n", index, SDL_GetError());
     }
@@ -57,51 +55,27 @@ SDL_Surface *DataPack::getSurface(int index)
     return out;
 }
 
-Mix_Music *DataPack::getMusic(const std::string &name)
+MIX_Audio *DataPack::getAudio(const std::string &name)
 {
     int index = reader->getIndexFromName(name);
-    return this->getMusic(index);
+    return this->getAudio(index);
 }
 
-Mix_Music *DataPack::getMusic(int index)
+MIX_Audio *DataPack::getAudio(int index)
 {
     if (index < 0 || index >= reader->getNumberOfFiles()) {
         std::cerr << "Invalid index: " << index << std::endl;
         return nullptr;
     }
-    auto it = musicCache.find(index);
-    if (it != musicCache.end())
+    auto it = audioCache.find(index);
+    if (it != audioCache.end())
         return it->second;
     SDL_IOStream *tmp = reader->getData(index);
-    Mix_Music *out = Mix_LoadMUS_IO(tmp, SDL_TRUE);
+    MIX_Audio *out = MIX_LoadAudio_IO(m_mixer, tmp, true, true);
     if (!out) {
-        printf("Failed to load music %i : %s\n", index, SDL_GetError());
+        printf("Failed to load audio %i : %s\n", index, SDL_GetError());
     }
-    musicCache[index] = out;
-    return out;
-}
-
-Mix_Chunk *DataPack::getSample(const std::string &name)
-{
-    int index = reader->getIndexFromName(name);
-    return this->getSample(index);
-}
-
-Mix_Chunk *DataPack::getSample(int index)
-{
-    if (index < 0 || index >= reader->getNumberOfFiles()) {
-        std::cerr << "Invalid index: " << index << std::endl;
-        return nullptr;
-    }
-    auto it = sampleCache.find(index);
-    if (it != sampleCache.end())
-        return it->second;
-    SDL_IOStream *tmp = reader->getData(index);
-    Mix_Chunk *out = Mix_LoadWAV_IO(tmp, SDL_TRUE);
-    if (!out) {
-        printf("Failed to load sample %i : %s\n", index, SDL_GetError());
-    }
-    sampleCache[index] = out;
+    audioCache[index] = out;
     return out;
 }
 
@@ -109,139 +83,3 @@ int DataPack::getNumberOfFile() const
 {
     return reader->getNumberOfFiles();
 }
-
-/*
- * This is a test program to read and write pack files.
- * It uses SDL2 and SDL2_mixer to display images and play music.
- * The pack files are created with WriterPack and read with DataPack.
- */
-/*
-int main(int argc, char ** argv)
-{
-    // First we create a pak file from scratch
-    if (1) {
-        // write pak file.
-    	WriterPack test("test1.pak");
-        //
-        test.addFile("test1.bmp","test1");
-        test.addFile("test2.bmp","test2");
-        test.addFile("test3.bmp","test3");
-        //
-        test.writePackFilesOnDisk();
-    }
-
-    if (1) {
-        // write pak file with audio file.
-    	WriterPack test("audio1.pak");
-        //
-        test.addFile("DUNE1_4.mid","audio1");
-        test.addFile("DUNE1_5.mid","audio2");
-        test.addFile("DUNE1_6.mid","audio3");
-        test.addFile("DUNE1_7.mid","audio4");
-        //
-        test.writePackFilesOnDisk();
-    }
-
-    bool quit = false;
-    SDL_Event event;
-
-    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO);
-
-    //Initialize SDL2_mixer to play sound
-    if(Mix_OpenAudio(22050, MIX_DEFAULT_FORMAT, 2, 1024) == -1)
-    {
-        printf("SDL2_mixer could not be initialized!\n"
-               "SDL_Error: %s\n", SDL_GetError());
-        return 0;
-    }
-
-    SDL_Window * window = SDL_CreateWindow("SDL2", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 640, 480, 0);
-    SDL_Renderer * renderer = SDL_CreateRenderer(window, -1, 0);
-
-    //-----------------------------------------------------------------
-    //load with DataPack
-    //-----------------------------------------------------------------
-    DataPack dataRead("test1.pak");
-    SDL_Surface *surface1 = dataRead.getSurface(0);
-    SDL_Surface *surface2 = dataRead.getSurface("test2");
-    SDL_Surface *surface3 = dataRead.getSurface(2);
-    dataRead.displayPackFile();
-    //-----------------------------------------------------------------
-
-    //convert SDL_Surface to SDL_Texture
-    SDL_Texture * texture1 = SDL_CreateTextureFromSurface(renderer, surface1);    // GPU memory
-    SDL_Texture * texture2 = SDL_CreateTextureFromSurface(renderer, surface2);    // GPU memory
-    SDL_Texture * texture3 = SDL_CreateTextureFromSurface(renderer, surface3);    // GPU memory
-    SDL_FreeSurface(surface1);
-    SDL_FreeSurface(surface2);
-    SDL_FreeSurface(surface3);
-
-    Color color = { 255, 255, 255 };
-
-    SDL_Texture * texture = texture1;
-
-    //-----------------------------------------------------------------
-    //load with DataPack and play it
-    //-----------------------------------------------------------------
-    DataPack dataAudio("audio1.pak");
-    Mix_Music * music = dataAudio.getMusic(2);
-    Mix_PlayMusic( music, -1 );
-    dataAudio.displayPackFile();
-
-    while (!quit)
-    {
-        SDL_WaitEvent(&event);
-
-        switch (event.type)
-        {
-            case SDL_QUIT:
-                quit = true;
-                break;
-            case SDL_KEYDOWN:
-                if (event.key.keysym.sym == SDLK_a){
-                    texture = texture1;
-		        }
-                if (event.key.keysym.sym == SDLK_z){
-                    texture = texture2;
-		        }
-                if (event.key.keysym.sym == SDLK_e){
-                    texture = texture3;
-		        }
-                if (event.key.keysym.sym == SDLK_q){
-                    Mix_FreeMusic(music);
-                    music = dataAudio.getMusic("audio1");
-                    Mix_PlayMusic( music, -1 );
-		        }
-                if (event.key.keysym.sym == SDLK_s){
-                    Mix_FreeMusic(music);
-                    music = dataAudio.getMusic("audio2");
-                    Mix_PlayMusic( music, -1 );
-		        }
-                if (event.key.keysym.sym == SDLK_d){
-                    Mix_FreeMusic(music);
-                    music = dataAudio.getMusic("audio3");
-                    Mix_PlayMusic( music, -1 );
-		        }
-                if (event.key.keysym.sym == SDLK_f){
-                    Mix_FreeMusic(music);
-                    music = dataAudio.getMusic("audio4");
-                    Mix_PlayMusic( music, -1 );
-		        }
-                if (event.key.keysym.sym == SDLK_ESCAPE){
-                    quit = true;
-		        }
-                break;
-        }
-        SDL_RenderCopy(renderer, texture, NULL, NULL);
-        SDL_RenderPresent(renderer);
-    }
-
-    Mix_HaltMusic();
-    Mix_FreeMusic(music);
-    SDL_DestroyRenderer(renderer);
-    SDL_DestroyWindow(window);
-    SDL_Quit();
-
-    return 0;
-}
-*/

--- a/src/utils/cDataPack.cpp
+++ b/src/utils/cDataPack.cpp
@@ -12,7 +12,7 @@ DataPack::DataPack(const std::string &packName)
 DataPack::~DataPack()
 {
     for (auto& [_, texture] : surfaceCache) {
-        if (texture) SDL_FreeSurface(texture);
+        if (texture) SDL_DestroySurface(texture);
     }
     for (auto& [_, music] : musicCache) {
         if (music) Mix_FreeMusic(music);
@@ -48,8 +48,8 @@ SDL_Surface *DataPack::getSurface(int index)
     auto it = surfaceCache.find(index);
     if (it != surfaceCache.end())
         return it->second;
-    SDL_RWops *tmp = reader->getData(index);
-    SDL_Surface *out = IMG_Load_RW(tmp, SDL_TRUE);
+    SDL_IOStream *tmp = reader->getData(index);
+    SDL_Surface *out = IMG_Load_IO(tmp, SDL_TRUE);
     if (!out) {
         printf("Failed to load image %i : %s\n", index, SDL_GetError());
     }
@@ -72,8 +72,8 @@ Mix_Music *DataPack::getMusic(int index)
     auto it = musicCache.find(index);
     if (it != musicCache.end())
         return it->second;
-    SDL_RWops *tmp = reader->getData(index);
-    Mix_Music *out = Mix_LoadMUS_RW(tmp, SDL_TRUE);
+    SDL_IOStream *tmp = reader->getData(index);
+    Mix_Music *out = Mix_LoadMUS_IO(tmp, SDL_TRUE);
     if (!out) {
         printf("Failed to load music %i : %s\n", index, SDL_GetError());
     }
@@ -96,8 +96,8 @@ Mix_Chunk *DataPack::getSample(int index)
     auto it = sampleCache.find(index);
     if (it != sampleCache.end())
         return it->second;
-    SDL_RWops *tmp = reader->getData(index);
-    Mix_Chunk *out = Mix_LoadWAV_RW(tmp, SDL_TRUE);
+    SDL_IOStream *tmp = reader->getData(index);
+    Mix_Chunk *out = Mix_LoadWAV_IO(tmp, SDL_TRUE);
     if (!out) {
         printf("Failed to load sample %i : %s\n", index, SDL_GetError());
     }

--- a/src/utils/cDataPack.hpp
+++ b/src/utils/cDataPack.hpp
@@ -34,30 +34,25 @@ class ReaderPack;
 
 class DataPack {
 public:
-    // read pack packName and load it on memory
-    DataPack(const std::string &packName);
+    // read pack packName and load it on memory; mixer required for audio loading
+    DataPack(const std::string &packName, MIX_Mixer *mixer);
     ~DataPack();
     // return a surface from his index in pack
     SDL_Surface *getSurface(int index);
     // return a surface from his name
     SDL_Surface *getSurface(const std::string &name);
-    // return index of a surface
+    // return index of a surface or audio
     int getIndexFromName(const std::string &name);
-    // return a music from his index in pack
-    Mix_Music *getMusic(int index);
-    // return a music from his name
-    Mix_Music *getMusic(const std::string &name);
-    // return a sample from his index in pack
-    Mix_Chunk *getSample(int index);
-    // return a sample from his name
-    Mix_Chunk *getSample(const std::string &name);
+    // return audio from his index in pack (music or sfx)
+    MIX_Audio *getAudio(int index);
+    // return audio from his name
+    MIX_Audio *getAudio(const std::string &name);
     // for debug
     void displayPackFile();
-    int getNumberOfFile() const; //should take a extension parameters
+    int getNumberOfFile() const;
 private:
     std::unique_ptr<ReaderPack> reader;
-    // for memory management
+    MIX_Mixer *m_mixer = nullptr;
     std::unordered_map<int, SDL_Surface *> surfaceCache;
-    std::unordered_map<int, Mix_Music *> musicCache;
-    std::unordered_map<int, Mix_Chunk *> sampleCache;
+    std::unordered_map<int, MIX_Audio *> audioCache;
 };

--- a/src/utils/cDataPack.hpp
+++ b/src/utils/cDataPack.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <SDL2/SDL_mixer.h>
+#include <SDL3_mixer/SDL_mixer.h>
 #include <string>
 #include <memory>
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <unordered_map>
 
 // **********************

--- a/src/utils/cFocusManager.cpp
+++ b/src/utils/cFocusManager.cpp
@@ -6,7 +6,6 @@
 cFocusManager::cFocusManager(cTimeManager* timeManager)
 {
     d2tm_assert(timeManager != nullptr);
-    // Initialize focus manager with time manager if needed
     m_timeManager = timeManager;
 }
 
@@ -20,36 +19,24 @@ bool cFocusManager::isEnabled() const
     return m_enabled;
 }
 
-void cFocusManager::onWindowsFocus(const SDL_WindowEvent &event)
+void cFocusManager::onWindowFocusLost()
 {
     if (!m_enabled) {
-        return; // If focus management is not active, do nothing
+        return;
     }
-    switch (event.event) {
-        case SDL_WINDOWEVENT_FOCUS_LOST:
-            gameWindowActive = false;
-            m_timeManager->onWindowFocusLost();
-            std::cout << "D2TM: Window focus lost" << std::endl;
-            break;
-        case SDL_WINDOWEVENT_MINIMIZED:
-            gameWindowActive = false;
-            m_timeManager->onWindowFocusLost();
-            std::cout << "D2TM: Window minimized" << std::endl;
-            break;
-        case SDL_WINDOWEVENT_FOCUS_GAINED:
-            gameWindowActive = true;
-            m_timeManager->onWindowFocusGained();
-            std::cout << "D2TM: Window focus gained" << std::endl;
-            break;
-        case SDL_WINDOWEVENT_RESTORED:
-            gameWindowActive = true;
-            m_timeManager->onWindowFocusGained();
-            std::cout << "D2TM: Window restored" << std::endl;
-            break;
-        default:
-            // ignore other events
-            break;
+    gameWindowActive = false;
+    m_timeManager->onWindowFocusLost();
+    std::cout << "D2TM: Window focus lost" << std::endl;
+}
+
+void cFocusManager::onWindowFocusGained()
+{
+    if (!m_enabled) {
+        return;
     }
+    gameWindowActive = true;
+    m_timeManager->onWindowFocusGained();
+    std::cout << "D2TM: Window focus gained" << std::endl;
 }
 
 bool cFocusManager::isGameWindowActive() const

--- a/src/utils/cFocusManager.h
+++ b/src/utils/cFocusManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 class cTimeManager;
 

--- a/src/utils/cFocusManager.h
+++ b/src/utils/cFocusManager.h
@@ -11,7 +11,8 @@ public:
 
     void setEnabled(bool value);
     [[nodiscard]] bool isEnabled() const;
-    void onWindowsFocus(const SDL_WindowEvent& event);
+    void onWindowFocusLost();
+    void onWindowFocusGained();
     [[nodiscard]] bool isGameWindowActive() const;
 private:
     bool m_enabled = false;

--- a/src/utils/cPack.cpp
+++ b/src/utils/cPack.cpp
@@ -25,12 +25,11 @@ const int extensionSize = 4; // "WAV", "JPG", ...
 
 
 
-
 ReaderPack::ReaderPack(const std::string &filename)
 {
     fpName = filename;
     if (readHeader()) {
-        sizeInMemory = SDL_RWsize(rfp.get()) - titleSize - nbrFilesSize - (fileNameSize+offsetSize)*fileInPak;
+        sizeInMemory = SDL_GetIOSize(rfp.get()) - titleSize - nbrFilesSize - (fileNameSize+offsetSize)*fileInPak;
         fileInMemory = std::make_unique<char[]>(sizeInMemory);
         readFileLines();
     }
@@ -47,26 +46,26 @@ void ReaderPack::readFileLines()
     for(int i=0; i<fileInPak; i++ ) {
         // file name
         char fileID[fileNameSize] {'\0'};
-        if (SDL_RWread(rfp.get(), fileID, fileNameSize, 1) != 1) {
+        if (SDL_ReadIO(rfp.get(), fileID, fileNameSize) != fileNameSize) {
             std::cerr << "Failed to read file ID for file " << i << std::endl;
             return;
         }
         // file extension
         char rawExt[4] = {0};
-        if (SDL_RWread(rfp.get(), rawExt, extensionSize, 1) != 1) {
+        if (SDL_ReadIO(rfp.get(), rawExt, extensionSize) != extensionSize) {
             std::cerr << "Failed to read extension for file " << i << std::endl;
             return;
         }
 
         // index offset
         uint32_t offsetFile;
-        if (SDL_RWread(rfp.get(), reinterpret_cast<char *>(&offsetFile), sizeof(offsetFile), 1) != 1) {
+        if (SDL_ReadIO(rfp.get(), reinterpret_cast<char *>(&offsetFile), sizeof(offsetFile)) != sizeof(offsetFile)) {
             std::cerr << "Failed to read file offset for file " << i << std::endl;
             return;
         }
         // index size
         uint32_t sizeFile;
-        if (SDL_RWread(rfp.get(), reinterpret_cast<char *>(&sizeFile), sizeof(sizeFile), 1) != 1) {
+        if (SDL_ReadIO(rfp.get(), reinterpret_cast<char *>(&sizeFile), sizeof(sizeFile)) != sizeof(sizeFile)) {
             std::cerr << "Failed to read file size for file " << i << std::endl;
             return;
         }
@@ -83,20 +82,20 @@ void ReaderPack::readFileLines()
 
 bool ReaderPack::readHeader()
 {
-    rfp.reset(SDL_RWFromFile(fpName.c_str(), "rb"));
+    rfp.reset(SDL_IOFromFile(fpName.c_str(), "rb"));
     if (!rfp) {
         std::cerr << "Failed to open file: " << fpName << " - " << SDL_GetError() << std::endl;
         return false;
     }
     char title[4+1]= {'\0'};
-    if (SDL_RWread(rfp.get(), &title, 4, 1) != 1 || strcmp(title, "D2TM") != 0) {
+    if (SDL_ReadIO(rfp.get(), &title, 4) != 4 || strcmp(title, "D2TM") != 0) {
         std::cerr << "Invalid file format: " << fpName << std::endl;
         rfp.reset();
         return false;
     }
 
     uint16_t nbrFiles;
-    if (SDL_RWread(rfp.get(), reinterpret_cast<char *>(&nbrFiles), sizeof(nbrFiles), 1) !=1) {
+    if (SDL_ReadIO(rfp.get(), reinterpret_cast<char *>(&nbrFiles), sizeof(nbrFiles)) != sizeof(nbrFiles)) {
         std::cerr << "Failed to read number of files: " << fpName << std::endl;
         rfp.reset();
         return false;
@@ -117,13 +116,13 @@ int ReaderPack::getIndexFromName(const std::string &fileId) const
         return -1;
 }
 
-SDL_RWops *ReaderPack::getData(unsigned int index)
+SDL_IOStream *ReaderPack::getData(unsigned int index)
 {
     if (index >= fileInPack.size()) {
         std::cerr << "Invalid index: " << index << std::endl;
         return nullptr;
     }
-    return SDL_RWFromMem( &fileInMemory[fileInPack[index].fileOffset], fileInPack[index].fileSize );
+    return SDL_IOFromConstMem( &fileInMemory[fileInPack[index].fileOffset], fileInPack[index].fileSize );
 }
 
 void ReaderPack::displayPackFile()
@@ -141,8 +140,8 @@ void ReaderPack::displayPackFile()
 void ReaderPack::readDataIntoMemory()
 {
     uint16_t firstData = titleSize + nbrFilesSize + (fileNameSize+extensionSize+offsetSize) * fileInPak;
-    SDL_RWseek(rfp.get(), firstData, RW_SEEK_SET );
-    SDL_RWread(rfp.get(), fileInMemory.get(), sizeInMemory, 1);
+    SDL_SeekIO(rfp.get(), firstData, SDL_IO_SEEK_SET );
+    SDL_ReadIO(rfp.get(), fileInMemory.get(), sizeInMemory);
 }
 
 // **********************
@@ -154,7 +153,7 @@ void ReaderPack::readDataIntoMemory()
 
 WriterPack::WriterPack(const std::string &packName)
 {
-    wfp.reset(SDL_RWFromFile(packName.c_str(), "wb"));
+    wfp.reset(SDL_IOFromFile(packName.c_str(), "wb"));
 }
 
 WriterPack::~WriterPack()
@@ -164,7 +163,7 @@ WriterPack::~WriterPack()
 
 bool WriterPack::addFile(const std::string &fileName, const std::string &fileId)
 {
-    SDL_RWops *file = SDL_RWFromFile(fileName.c_str(),"rb");
+    SDL_IOStream *file = SDL_IOFromFile(fileName.c_str(),"rb");
     if (file!=nullptr) {
 
         FileInPack tmp;
@@ -173,11 +172,11 @@ bool WriterPack::addFile(const std::string &fileName, const std::string &fileId)
         std::string ext = fileName.substr(fileName.find_last_of('.') + 1);
         std::transform(ext.begin(), ext.end(), ext.begin(), ::toupper);
         tmp.extension = ext.substr(0, 3);
-        tmp.fileSize = SDL_RWsize(file);
+        tmp.fileSize = SDL_GetIOSize(file);
         tmp.fileOffset = 0;
         fileInPack.push_back(tmp);
 
-        SDL_RWclose(file);
+        SDL_CloseIO(file);
         return true;
     }
     else
@@ -188,11 +187,11 @@ void WriterPack::writeHeader()
 {
     const char *str = "D2TM";
     size_t len = SDL_strlen(str);
-    if (SDL_RWwrite(wfp.get(), str, 1, len) != len) {
+    if (SDL_WriteIO(wfp.get(), str, len) != len) {
         printf("Couldn't fully write string\n");
     }
     uint16_t nbFiles = fileInPack.size();
-    SDL_RWwrite(wfp.get(), reinterpret_cast<const char *>(&nbFiles), sizeof(uint16_t), 1);
+    SDL_WriteIO(wfp.get(), reinterpret_cast<const char *>(&nbFiles), sizeof(uint16_t));
 }
 
 
@@ -211,7 +210,7 @@ void WriterPack::writeFileLines()
         // Copy fileSize to buffer
         memcpy(buffer + fileNameSize + extensionSize + sizeof(uint32_t), &tmp.fileSize, sizeof(uint32_t));
         // Write the buffer in one operation
-        if (SDL_RWwrite(wfp.get(), buffer, 1, sizeof(buffer)) != sizeof(buffer)) {
+        if (SDL_WriteIO(wfp.get(), buffer, sizeof(buffer)) != sizeof(buffer)) {
             std::cerr << "Failed to write file line for: " << tmp.fileId << std::endl;
         }
         // Update the offset for the next file
@@ -234,25 +233,25 @@ void WriterPack::displayPackFile()
 void WriterPack::copyFile()
 {
     for (const auto &tmp : fileInPack) {
-        std::unique_ptr<SDL_RWops, decltype(&SDL_RWclose)> wf(SDL_RWFromFile(tmp.name.c_str(), "rb"), SDL_RWclose);
+        std::unique_ptr<SDL_IOStream, decltype(&SDL_CloseIO)> wf(SDL_IOFromFile(tmp.name.c_str(), "rb"), SDL_CloseIO);
         if (!wf) {
             std::cerr << "Failed to open file: " << tmp.name << " - " << SDL_GetError() << std::endl;
-            continue; // Passer au fichier suivant
+            continue;
         }
-        Sint64 res_size = SDL_RWsize(wf.get());
+        Sint64 res_size = SDL_GetIOSize(wf.get());
         if (res_size <= 0) {
             std::cerr << "Invalid file size for: " << tmp.name << std::endl;
             continue;
         }
 
         std::vector<char> buffer(res_size);
-        Sint64 nb_read = SDL_RWread(wf.get(), buffer.data(), 1, res_size);
+        Sint64 nb_read = SDL_ReadIO(wf.get(), buffer.data(), res_size);
         if (nb_read != res_size) {
             std::cerr << "Failed to read file: " << tmp.name << std::endl;
             continue;
         }
 
-        Sint64 nb_written = SDL_RWwrite(wfp.get(), buffer.data(), 1, res_size);
+        Sint64 nb_written = SDL_WriteIO(wfp.get(), buffer.data(), res_size);
         if (nb_written != res_size) {
             std::cerr << "Failed to write file: " << tmp.name << std::endl;
         }

--- a/src/utils/cPack.h
+++ b/src/utils/cPack.h
@@ -28,7 +28,7 @@ public:
     ReaderPack(const std::string &filename);
     ~ReaderPack();
     //! get raw ressources from PackFile by this index in the archive
-    SDL_RWops *getData(unsigned int index);
+    SDL_IOStream *getData(unsigned int index);
     //! get index from ressource named fileId
     int getIndexFromName(const std::string &fileId) const;
     //! print all files in Pack
@@ -43,7 +43,7 @@ private:
     void readFileLines();
     void readDataIntoMemory();
     std::unique_ptr<char[]> fileInMemory = nullptr;
-    std::unique_ptr<SDL_RWops, decltype(&SDL_RWclose)> rfp{nullptr, SDL_RWclose};  //rfp as readFilePack
+    std::unique_ptr<SDL_IOStream, decltype(&SDL_CloseIO)> rfp{nullptr, SDL_CloseIO};  //rfp as readFilePack
     std::string fpName;
     int fileInPak = 0;
     uint64_t sizeInMemory =0;
@@ -64,7 +64,7 @@ private:
     void writeHeader();
     void writeFileLines();
     void copyFile();
-    std::unique_ptr<SDL_RWops, decltype(&SDL_RWclose)> wfp{nullptr, SDL_RWclose}; //wfp as writeFilePack
+    std::unique_ptr<SDL_IOStream, decltype(&SDL_CloseIO)> wfp{nullptr, SDL_CloseIO}; //wfp as writeFilePack
     std::vector<FileInPack> fileInPack;
 };
 

--- a/src/utils/cPack.h
+++ b/src/utils/cPack.h
@@ -6,8 +6,8 @@
 #include <algorithm>
 
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_mixer.h>
+#include <SDL3/SDL.h>
+#include <SDL3_mixer/SDL_mixer.h>
 
 struct FileInPack {
     std::string name;

--- a/src/utils/cPack.h
+++ b/src/utils/cPack.h
@@ -7,7 +7,6 @@
 
 
 #include <SDL3/SDL.h>
-#include <SDL3_mixer/SDL_mixer.h>
 
 struct FileInPack {
     std::string name;

--- a/src/utils/cRectangle.h
+++ b/src/utils/cRectangle.h
@@ -71,6 +71,10 @@ public:
     [[nodiscard]] SDL_Rect toSDL() const {
         return SDL_Rect{topLeft.x, topLeft.y, width, height};
     }
+
+    [[nodiscard]] SDL_FRect toSDLF() const {
+        return SDL_FRect{(float)topLeft.x, (float)topLeft.y, (float)width, (float)height};
+    }
 private:
     cPoint topLeft;
     int width;

--- a/src/utils/cRectangle.h
+++ b/src/utils/cRectangle.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "cPoint.h"
-#include <SDL2/SDL_rect.h>
+#include <SDL3/SDL.h>
 
 class cRectangle {
 public:

--- a/src/utils/cSoundPlayer.cpp
+++ b/src/utils/cSoundPlayer.cpp
@@ -11,7 +11,7 @@
 #include <memory>
 #include <stdexcept>
 
-#include <SDL2/SDL_mixer.h>
+#include <SDL3_mixer/SDL_mixer.h>
 #include <algorithm> // for std::clamp
 
 namespace {

--- a/src/utils/cSoundPlayer.cpp
+++ b/src/utils/cSoundPlayer.cpp
@@ -12,21 +12,19 @@
 #include <stdexcept>
 
 #include <SDL3_mixer/SDL_mixer.h>
-#include <algorithm> // for std::clamp
 
 namespace {
     constexpr int kNoLoop = 0;
-    constexpr int MaxVolume = MIX_MAX_VOLUME;
-    constexpr int MaxNbrVoices = 64;
+    constexpr int MaxVolume = 128;
 }
 
 class cSoundData {
 public:
-    cSoundData(const std::string &audiofile)
+    cSoundData(const std::string &audiofile, MIX_Mixer *mixer)
     {
         auto logger = cLogger::getInstance();
 
-        gfxaudio = std::make_unique<DataPack>(audiofile);
+        gfxaudio = std::make_unique<DataPack>(audiofile, mixer);
         if (gfxaudio == nullptr) {
             auto msg = std::format("Could not hook/load datafile: {}", audiofile);
             logger->log(LOG_ERROR, COMP_SOUND, "Initialization", msg, OUTC_FAILED);
@@ -38,63 +36,54 @@ public:
         }
     }
 
-    Mix_Chunk *getSample(int sampleId) const
+    MIX_Audio *getAudio(int id) const
     {
-        return gfxaudio->getSample(sampleId);
+        return gfxaudio->getAudio(id);
     }
 
-    Mix_Music *getMusic(int musicId) const
-    {
-        return gfxaudio->getMusic(musicId);
-    }
 private:
     std::unique_ptr<DataPack> gfxaudio;
 };
 
 cSoundPlayer::cSoundPlayer(const std::string &datafile)
-    : soundData(std::make_unique<cSoundData>(datafile))
 {
-    // The platform layer init object is not used here, but since it needs to be passed, it tells
-    // the caller that the initialization needs to be performed first.
-
     auto logger = cLogger::getInstance();
 
-    if (!Mix_OpenAudio(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, nullptr)) {
-        logger->log(LOG_ERROR, COMP_SOUND, "SDL_mixer initialization", Mix_GetError(), OUTC_FAILED);
+    m_mixer = MIX_CreateMixerDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, nullptr);
+    if (!m_mixer) {
+        logger->log(LOG_ERROR, COMP_SOUND, "SDL_mixer initialization", SDL_GetError(), OUTC_FAILED);
         m_isMusicEnabled = false;
         m_isSoundEnabled = false;
-    } else {
+    }
+    else {
         logger->log(LOG_INFO, COMP_SOUND, "Initialization", "SDL_mixer succes", OUTC_SUCCESS);
         m_isMusicEnabled = true;
         m_isSoundEnabled = true;
     }
 
-    int nr_voices = Mix_AllocateChannels(MaxNbrVoices);
-    if (nr_voices != MaxNbrVoices) {
-        auto msg = std::format("AllocateChannels: {} voices reserved, on {} required", nr_voices,MaxNbrVoices);
-        logger->log(LOG_INFO, COMP_SOUND, "Initialization", msg, OUTC_SUCCESS);
+    m_musicTrack = MIX_CreateTrack(m_mixer);
 
-        // voices.resize(nr_voices - 1, kNoVoice);
-        // break;
-    }
-    else {
-        auto msg = std::format("AllocateChannels: {} voices reserved", nr_voices);
-        logger->log(LOG_INFO, COMP_SOUND, "Initialization", msg, OUTC_SUCCESS);
-    }
+    soundData = std::make_unique<cSoundData>(datafile, m_mixer);
 
-    m_musicVolume = MaxVolume/2;
-    m_soundVolume = MaxVolume/2;
-    Mix_MasterVolume(m_soundVolume);
-    Mix_VolumeMusic(m_musicVolume);
+    m_musicVolume = MaxVolume / 2;
+    m_soundVolume = MaxVolume / 2;
+    MIX_SetMixerGain(m_mixer, m_soundVolume / (float)MaxVolume);
+    MIX_SetTrackGain(m_musicTrack, m_musicVolume / (float)MaxVolume);
 }
 
 cSoundPlayer::~cSoundPlayer()
 {
+    if (m_musicTrack) {
+        MIX_StopTrack(m_musicTrack, 0);
+        MIX_DestroyTrack(m_musicTrack);
+    }
+    if (m_mixer) {
+        MIX_DestroyMixer(m_mixer);
+    }
 }
 
 int cSoundPlayer::getMaxVolume()
 {
-    // TODO: This will become configurable (so you can set your own max volume for sounds, etc)
     return MaxVolume;
 }
 
@@ -103,20 +92,17 @@ void cSoundPlayer::playSound(int sampleId)
     if (!m_isSoundEnabled) {
         return;
     }
-    playSound(sampleId, m_musicVolume);
+    playSound(sampleId, m_soundVolume);
 }
 
 void cSoundPlayer::playSound(int sampleId, int vol)
 {
-    if (vol <= 0 || !m_isSoundEnabled) {
+    if (vol <= 0 || !m_isSoundEnabled || !m_mixer) {
         return;
     }
-   vol = std::clamp(vol, 0, MIX_MAX_VOLUME);
-
-    Mix_Chunk *sample = soundData->getSample(sampleId);
-    int tmp = Mix_PlayChannel(-1, sample, 0); // -1 means play on any available channel
-    if (tmp<0) {
-        cLogger::getInstance()->log(LOG_WARN, COMP_SOUND, "sample ignored", "All channels used");
+    MIX_Audio *audio = soundData->getAudio(sampleId);
+    if (audio) {
+        MIX_PlayAudio(m_mixer, audio);
     }
 }
 
@@ -134,28 +120,41 @@ void cSoundPlayer::playVoice(int sampleId, int house)
 
 void cSoundPlayer::playMusic(int sampleId)
 {
-    if (!m_isMusicEnabled) {
+    if (!m_isMusicEnabled || !m_musicTrack) {
         return;
     }
-    Mix_PlayMusic(soundData->getMusic(sampleId), kNoLoop);
+    MIX_Audio *audio = soundData->getAudio(sampleId);
+    if (!audio) {
+        return;
+    }
+    MIX_StopTrack(m_musicTrack, 0);
+    MIX_SetTrackAudio(m_musicTrack, audio);
+    MIX_SetTrackLoops(m_musicTrack, kNoLoop);
+    MIX_PlayTrack(m_musicTrack, 0);
 }
 
 bool cSoundPlayer::isMusicPlaying() const
 {
-    return Mix_PlayingMusic() > 0;
+    if (!m_musicTrack) {
+        return false;
+    }
+    return MIX_TrackPlaying(m_musicTrack);
 }
 
 void cSoundPlayer::stopMusic()
 {
-    Mix_HaltMusic();
+    if (m_musicTrack) {
+        MIX_StopTrack(m_musicTrack, 0);
+    }
 }
 
 void cSoundPlayer::setMusicVolume(int _vol)
 {
-    //std::cout << "music volume" << vol << "\n";
-    int vol = _vol*128/10;
+    int vol = _vol * 128 / 10;
     m_musicVolume = std::clamp(vol, 0, MaxVolume);
-    Mix_VolumeMusic(m_musicVolume);
+    if (m_musicTrack) {
+        MIX_SetTrackGain(m_musicTrack, m_musicVolume / (float)MaxVolume);
+    }
 }
 
 void cSoundPlayer::changeMusicVolume(int delta)
@@ -166,24 +165,25 @@ void cSoundPlayer::changeMusicVolume(int delta)
 
 void cSoundPlayer::setSoundVolume(int _vol)
 {
-    //std::cout << "sound volume" << _vol << "\n";
-    int vol = _vol*128/10;
+    int vol = _vol * 128 / 10;
     m_soundVolume = std::clamp(vol, 0, MaxVolume);
-    Mix_MasterVolume(m_soundVolume);
+    if (m_mixer) {
+        MIX_SetMixerGain(m_mixer, m_soundVolume / (float)MaxVolume);
+    }
 }
 
 void cSoundPlayer::setSoundEnabled(bool sm)
 {
     m_isSoundEnabled = sm;
-    if (!m_isSoundEnabled) {
-        Mix_HaltChannel(-1);
+    if (!m_isSoundEnabled && m_mixer) {
+        MIX_StopAllTracks(m_mixer, 0);
     }
 }
 
 void cSoundPlayer::setMusicEnabled(bool mm)
 {
     m_isMusicEnabled = mm;
-    if (!m_isMusicEnabled) {
-        Mix_HaltMusic();
+    if (!m_isMusicEnabled && m_musicTrack) {
+        MIX_StopTrack(m_musicTrack, 0);
     }
 }

--- a/src/utils/cSoundPlayer.cpp
+++ b/src/utils/cSoundPlayer.cpp
@@ -59,16 +59,19 @@ cSoundPlayer::cSoundPlayer(const std::string &datafile)
         logger->log(LOG_INFO, COMP_SOUND, "Initialization", "SDL_mixer succes", OUTC_SUCCESS);
         m_isMusicEnabled = true;
         m_isSoundEnabled = true;
+        m_musicTrack = MIX_CreateTrack(m_mixer);
     }
-
-    m_musicTrack = MIX_CreateTrack(m_mixer);
 
     soundData = std::make_unique<cSoundData>(datafile, m_mixer);
 
     m_musicVolume = MaxVolume / 2;
     m_soundVolume = MaxVolume / 2;
-    MIX_SetMixerGain(m_mixer, m_soundVolume / (float)MaxVolume);
-    MIX_SetTrackGain(m_musicTrack, m_musicVolume / (float)MaxVolume);
+    if (m_mixer) {
+        MIX_SetMixerGain(m_mixer, m_soundVolume / (float)MaxVolume);
+    }
+    if (m_musicTrack) {
+        MIX_SetTrackGain(m_musicTrack, m_musicVolume / (float)MaxVolume);
+    }
 }
 
 cSoundPlayer::~cSoundPlayer()

--- a/src/utils/cSoundPlayer.cpp
+++ b/src/utils/cSoundPlayer.cpp
@@ -59,12 +59,12 @@ cSoundPlayer::cSoundPlayer(const std::string &datafile)
 
     auto logger = cLogger::getInstance();
 
-    if(Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 1024) == -1) {
-        logger->log(LOG_ERROR, COMP_SOUND, "SDL2_mixer initialization", Mix_GetError(), OUTC_FAILED);
+    if (!Mix_OpenAudio(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, nullptr)) {
+        logger->log(LOG_ERROR, COMP_SOUND, "SDL_mixer initialization", Mix_GetError(), OUTC_FAILED);
         m_isMusicEnabled = false;
         m_isSoundEnabled = false;
     } else {
-        logger->log(LOG_INFO, COMP_SOUND, "Initialization", "SDL2_mixer succes", OUTC_SUCCESS);
+        logger->log(LOG_INFO, COMP_SOUND, "Initialization", "SDL_mixer succes", OUTC_SUCCESS);
         m_isMusicEnabled = true;
         m_isSoundEnabled = true;
     }

--- a/src/utils/cSoundPlayer.h
+++ b/src/utils/cSoundPlayer.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+#include <SDL3_mixer/SDL_mixer.h>
 
 class cSoundData;
 
@@ -41,12 +42,14 @@ public:
     void setSoundEnabled(bool sm);
     bool getSoundEnabled() const {
         return m_isSoundEnabled;
-    }    
+    }
 
 private:
     std::unique_ptr<cSoundData> soundData;
-    int m_musicVolume;
-    int m_soundVolume;
-    bool m_isMusicEnabled;
-    bool m_isSoundEnabled;
+    MIX_Mixer *m_mixer = nullptr;
+    MIX_Track *m_musicTrack = nullptr;
+    int m_musicVolume = 0;
+    int m_soundVolume = 0;
+    bool m_isMusicEnabled = false;
+    bool m_isSoundEnabled = false;
 };

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -16,7 +16,7 @@
 #include <string>
 #include <array>
 #include <memory>
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 struct InitialGameSettings;
 

--- a/src/utils/d2tm_math.cpp
+++ b/src/utils/d2tm_math.cpp
@@ -16,6 +16,7 @@
   */
 #include "d2tm_math.h"
 
+#include <cmath>
 #include <format>
 
 #include "common.h"

--- a/src/utils/texture_utils.h
+++ b/src/utils/texture_utils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 class Texture;
 class cPlayer;


### PR DESCRIPTION
Closes #1241

## Summary

- Migrates the entire engine from SDL2 to SDL3 (3.4.x) plus SDL3_image, SDL3_ttf, and SDL3_mixer
- The game compiles cleanly on macOS (Apple Silicon, gcc-15)
- The game runs: main menu, music, skirmish, sound effects, screenshots, and fullscreen all work

## Key changes by area

**Build system** — CMakeLists.txt and install scripts updated for SDL3. Ubuntu CI builds SDL3 from source (not yet in Ubuntu 24.04 repos). Windows CI uses MSYS2 `mingw-w64-x86_64-SDL3/image/ttf/mixer` packages.

**I/O layer** — `SDL_RWops` fully replaced by `SDL_IOStream` throughout `cPack` and `cDataPack`; read/write calls updated for SDL3's byte-count semantics.

**Audio** — SDL3_mixer 3.x ships a completely new `MIX_*` API (the old `Mix_*` channel model is gone). `cSoundPlayer` now owns a `MIX_Mixer` and a dedicated `MIX_Track` for music; sound effects use `MIX_PlayAudio` (fire-and-forget); `DataPack` was unified: `Mix_Music*`/`Mix_Chunk*` merged into `MIX_Audio*`. Null-mixer guard added so the game runs cleanly on headless systems with no audio device.

**Window/renderer** — `SDL_CreateWindow` no longer takes x/y; HiDPI is automatic; `SDL_CreateRenderer` drops the driver index; VSync set via `SDL_SetRenderVSync`; logical size via `SDL_SetRenderLogicalPresentation`.

**Rendering** — All draw functions renamed (`SDL_RenderCopy` → `SDL_RenderTexture`, `SDL_RenderDrawRect` → `SDL_RenderRect`, etc.); destination rects changed from `SDL_Rect` to `SDL_FRect`; `cRectangle::toSDLF()` added alongside `toSDL()`. Per-texture scale mode set to `SDL_SCALEMODE_NEAREST` everywhere to keep pixel art crisp (SDL3 defaults to bilinear). `SDL_SetDefaultTextureScaleMode(NEAREST)` applied on the renderer so the logical presentation's internal texture also uses nearest-neighbour.

**Surface/pixel format** — `SDL_Surface::format` is now an enum value, not a struct pointer; all palette/pixel-format field accesses updated (`SDL_BITSPERPIXEL`, `SDL_GetSurfacePalette`, `SDL_GetPixelFormatDetails`); `SDL_FreeSurface` → `SDL_DestroySurface` everywhere.

**Events** — All event constants renamed to `SDL_EVENT_*` style; window focus events split into individual `SDL_EVENT_WINDOW_*` types; `cFocusManager` refactored; `event.key.keysym.scancode` → `event.key.scancode`; mouse coordinates cast from float.

**TTF** — `TTF_RenderUTF8_Blended` → `TTF_RenderText_Solid` (fully-opaque pixels scale cleanly with nearest-neighbour; Blended's partial-alpha edges look hazy at non-integer upscale factors); `TTF_SizeUTF8` → `TTF_GetStringSize`; `TTF_FontHeight` → `TTF_GetFontHeight`; `TTF_GetError` → `SDL_GetError`.

**Fullscreen / HiDPI** — `SDL_LOGICAL_PRESENTATION_INTEGER_SCALE` used in fullscreen so every game pixel maps to an equal-sized block on screen. On displays where the integer factor would be < 2 (e.g. 1080p with a 1365×768 logical frame), falls back to `SDL_LOGICAL_PRESENTATION_LETTERBOX` to avoid tiny game windows. Mouse events mapped through `SDL_RenderCoordinatesFromWindow` to correctly reach screen edges. `SDL_VIDEO_MAC_FULLSCREEN_SPACES=0` set on macOS; `SDL_SyncWindow` called after entering fullscreen to guarantee renderer output size is final before logical presentation is applied.

**Shutdown** — `SDLTextureDeleter` guarded against post-`SDL_Quit` destruction. Explicit `Graphics`/`Texture` reset in `cGame::shutdown()` ensures shared_ptr references are released while the renderer is still alive. `SDL_Quit` guarded with `SDL_WasInit(0)` to prevent double-shutdown crash on Linux (SDL3 registers an atexit handler).

**Build tool** — `rebuildmacos.sh` now copies the freshly built binary into `bin/` automatically.

## Test plan

- [x] `./install_dependencies_macosx.sh` on macOS (Apple Silicon)
- [x] `./rebuildmacos.sh` — compiles with no errors
- [x] `./create_release.sh` then `./bin/d2tm` — main menu appears
- [x] Music plays in the main menu
- [x] Start a skirmish game — units animate, sound effects play
- [x] Press screenshot key — file saved in `screen_*/` folder
- [x] Toggle fullscreen (F11) — no crash, pixel-art renders crisp