### PR TITLE
Step 1 of 15: gamestates has zero game. references

### DIFF
--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -1260,7 +1260,6 @@ void cSetupSkirmishState::generateRandomMap()
 
     randomMapGenerator->generateRandomMap(randomMapWidth, randomMapHeight, iStartingPoints, *randomMap);
 
-    // @mira do better than (game.m_gameObjectsContext->getMap()->getWidth() * game.m_gameObjectsContext->getMap()->getHeight() > 64 * 64)
     spawnWorms = (randomMapWidth * randomMapHeight > 64 * 64) ? 4 : 2;
 
     randomMap->validMap = true;


### PR DESCRIPTION
## Summary

- Removes the single `game.` reference from `src/gamestates/` (a stale `@mira` comment in `cSetupSkirmishState.cpp`)
- The code below the comment already used local `randomMapWidth`/`randomMapHeight` variables, making the comment obsolete

Part of #1254 — Step 1.

## Test plan

- [x] `./rebuildmacos.sh` passes (43/43 tests)
- [x] `grep -rn "game\." src/gamestates/` returns empty