### PR TITLE
Step 2 of 15: cFlag and mentat classes have zero game. references

### DIFF
--- a/src/game/cGameInterface.cpp
+++ b/src/game/cGameInterface.cpp
@@ -1,4 +1,5 @@
 #include "game/cGameInterface.h"
+#include "context/cGameObjectContext.h"
 #include "data/gfxaudio.h"
 #include "game/cGame.h"
 #include "utils/cLog.h"
@@ -267,4 +268,19 @@ cDrawManager* cGameInterface::getRenderDrawManager() const
 int cGameInterface::getCurrentState() const
 {
     return m_game->getCurrentState();
+}
+
+void cGameInterface::changeStateFromMentat() const
+{
+    m_game->changeStateFromMentat();
+}
+
+cPlayer* cGameInterface::getPlayer(int id) const
+{
+    return m_game->m_gameObjectsContext->getPlayer(id);
+}
+
+cGameSettings* cGameInterface::getGameSettings() const
+{
+    return m_game->m_gameSettings.get();
 }

--- a/src/game/cGameInterface.h
+++ b/src/game/cGameInterface.h
@@ -6,6 +6,7 @@
 #include <string>
 
 class cGame;
+class cGameSettings;
 class cMouse;
 class cPlayer;
 class cDrawManager;
@@ -75,6 +76,10 @@ public:
     int getTotalPowerOutForPlayer(cPlayer *pPlayer) const;
     int getTotalSpiceCapacityForPlayer(cPlayer *pPlayer) const;
     int getStructureTypeByUnitBuildId(int unitBuildId) const;
+
+    void changeStateFromMentat() const;
+    cPlayer* getPlayer(int id) const;
+    cGameSettings* getGameSettings() const;
 private:
     cGame* m_game = nullptr;
 };

--- a/src/gameobjects/cFlag.cpp
+++ b/src/gameobjects/cFlag.cpp
@@ -1,6 +1,5 @@
 #include "cFlag.h"
 #include "game/cGameSettings.h"
-#include "game/cGame.h"
 #include "include/d2tmc.h"
 #include "drawers/SDLDrawer.hpp"
 #include "gameobjects/map/cMapCamera.h"
@@ -8,9 +7,11 @@
 #include "include/Texture.hpp"
 #include "include/cAssert.h"
 
-cFlag::cFlag(cPlayer *player, cPoint &absCoords, int frames, int animationDelay)
+cFlag::cFlag(cPlayer *player, cPoint &absCoords, int frames, int animationDelay, cMapCamera *mapCamera, cGameSettings *settings)
     : m_absCoords(absCoords)
     , m_player(player)
+    , m_mapCamera(mapCamera)
+    , m_settings(settings)
     , m_TIMER_animate(0)
     , m_big(true)
     , m_animationDelay(animationDelay)
@@ -18,6 +19,8 @@ cFlag::cFlag(cPlayer *player, cPoint &absCoords, int frames, int animationDelay)
     , m_frame(0)
 {
     d2tm_assert(player != nullptr);
+    d2tm_assert(mapCamera != nullptr);
+    d2tm_assert(settings != nullptr);
 }
 
 void cFlag::draw()
@@ -25,12 +28,10 @@ void cFlag::draw()
     Texture *flagBitmap = m_big? m_player->getFlagBitmap() : m_player->getFlagSmallBitmap();
     if (!flagBitmap) return;
 
-    int drawX = game.m_mapCamera->getWindowXPosition(m_absCoords.x);
-    int drawY = game.m_mapCamera->getWindowYPosition(m_absCoords.y);
+    int drawX = m_mapCamera->getWindowXPosition(m_absCoords.x);
+    int drawY = m_mapCamera->getWindowYPosition(m_absCoords.y);
 
-    if ((drawX >= 0 && drawX < game.m_gameSettings->getScreenW()) && (drawY >= 0 && drawY < game.m_gameSettings->getScreenH())) { // within screen
-        // draw it
-
+    if ((drawX >= 0 && drawX < m_settings->getScreenW()) && (drawY >= 0 && drawY < m_settings->getScreenH())) {
         int pixelWidth = flagBitmap->w;
         int pixelHeight = flagBitmap->h / m_frames; // frames in a flag
 
@@ -38,8 +39,8 @@ void cFlag::draw()
         // So multiply the height of the flag size times frame
         int iSourceY = pixelHeight * m_frame;
 
-        int scaledWidth = game.m_mapCamera->factorZoomLevel(pixelWidth);
-        int scaledHeight = game.m_mapCamera->factorZoomLevel(pixelHeight);
+        int scaledWidth = m_mapCamera->factorZoomLevel(pixelWidth);
+        int scaledHeight = m_mapCamera->factorZoomLevel(pixelHeight);
         cRectangle src = {0, iSourceY, pixelWidth, pixelHeight};
         cRectangle dest = {drawX, drawY, scaledWidth, scaledHeight};
 
@@ -59,28 +60,20 @@ void cFlag::thinkFast()
     }
 }
 
-std::unique_ptr<cFlag> cFlag::createBigFlag(cPlayer *player, cPoint &position)
+std::unique_ptr<cFlag> cFlag::createBigFlag(cPlayer *player, cPoint &position, cMapCamera *mapCamera, cGameSettings *settings)
 {
-    cPoint correctedPoint = cPoint(
-                                position.x,
-                                position.y
-                            );
+    cPoint correctedPoint = cPoint(position.x, position.y);
     correctedPoint.x -= 15; // width of flag
-    auto pFlag = std::make_unique<cFlag>(player, correctedPoint, 12, 24);
-    // cFlag *pFlag = newFlag(player, correctedPoint, 12, 24);
+    auto pFlag = std::make_unique<cFlag>(player, correctedPoint, 12, 24, mapCamera, settings);
     pFlag->setBig(true);
     return pFlag;
 }
 
-std::unique_ptr<cFlag> cFlag::createSmallFlag(cPlayer *player, cPoint &position)
+std::unique_ptr<cFlag> cFlag::createSmallFlag(cPlayer *player, cPoint &position, cMapCamera *mapCamera, cGameSettings *settings)
 {
-    cPoint correctedPoint = cPoint(
-                                position.x,
-                                position.y
-                            );
+    cPoint correctedPoint = cPoint(position.x, position.y);
     correctedPoint.x -= 10; // width of flag
-    auto pFlag = std::make_unique<cFlag>(player, correctedPoint, 12, 24);
-    // cFlag *pFlag = new cFlag(player, correctedPoint, 12, 24);
+    auto pFlag = std::make_unique<cFlag>(player, correctedPoint, 12, 24, mapCamera, settings);
     pFlag->setBig(false);
     return pFlag;
 }

--- a/src/gameobjects/cFlag.h
+++ b/src/gameobjects/cFlag.h
@@ -4,19 +4,21 @@
 #include <memory>
 
 class cPlayer;
+class cMapCamera;
+class cGameSettings;
 
 class cFlag {
 
 public:
-    cFlag(cPlayer *player, cPoint &absCoords, int frames, int animationDelay);
+    cFlag(cPlayer *player, cPoint &absCoords, int frames, int animationDelay, cMapCamera *mapCamera, cGameSettings *settings);
     ~cFlag() = default;
 
     void draw();
 
     void thinkFast();
 
-    static std::unique_ptr<cFlag> createBigFlag(cPlayer *player, cPoint &position);
-    static std::unique_ptr<cFlag> createSmallFlag(cPlayer *player, cPoint &position);
+    static std::unique_ptr<cFlag> createBigFlag(cPlayer *player, cPoint &position, cMapCamera *mapCamera, cGameSettings *settings);
+    static std::unique_ptr<cFlag> createSmallFlag(cPlayer *player, cPoint &position, cMapCamera *mapCamera, cGameSettings *settings);
 
     void setBig(bool value) {
         m_big = value;
@@ -25,6 +27,8 @@ private:
     cPoint m_absCoords;
 
     cPlayer *m_player;
+    cMapCamera *m_mapCamera;
+    cGameSettings *m_settings;
     int m_TIMER_animate;
 
     bool m_big;

--- a/src/gameobjects/mentat/AbstractMentat.cpp
+++ b/src/gameobjects/mentat/AbstractMentat.cpp
@@ -11,12 +11,13 @@
   */
 
 #include "AbstractMentat.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "definitions.h"
+#include "include/eGameState.h"
 #include "drawers/SDLDrawer.hpp"
 #include "utils/RNG.hpp"
 #include "context/GameContext.hpp"
+#include "game/cGameInterface.h"
+#include "game/cGameSettings.h"
 #include "gui/GuiButton.h"
 #include "utils/Graphics.hpp"
 #include "utils/common.h"
@@ -30,6 +31,7 @@
 AbstractMentat::AbstractMentat(GameContext* ctx, bool canMissionSelect)
 {
     d2tm_assert(ctx != nullptr);
+    m_gameInterface = ctx->getGameInterface();
     gfxmentat = ctx->getGraphicsContext()->gfxmentat.get();
     m_textDrawer = ctx->getTextContext()->getBeneTextDrawer();
     m_renderDrawer = ctx->getSDLDrawer();
@@ -61,19 +63,19 @@ AbstractMentat::AbstractMentat(GameContext* ctx, bool canMissionSelect)
     if (canMissionSelect) {
 
         int length = m_textDrawer->getTextLength("Mission select");
-        const cRectangle &toMissionSelectRect = *m_textDrawer->getAsRectangle(game.m_gameSettings->getScreenW() - length,
-                                                game.m_gameSettings->getScreenH() - m_textDrawer->getFontHeight(),
+        const cRectangle &toMissionSelectRect = *m_textDrawer->getAsRectangle(m_gameInterface->getGameSettings()->getScreenW() - length,
+                                                m_gameInterface->getGameSettings()->getScreenH() - m_textDrawer->getFontHeight(),
                                                 "Mission select");
-        
+
         auto gui_btn_toMissionSelect = GuiButtonBuilder()
-            .withRect(toMissionSelectRect)        
+            .withRect(toMissionSelectRect)
             .withLabel("Mission select")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)    
+            .withRenderer(m_renderDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
-            .onClick([] {
-                game.setNextStateToTransitionTo(GAME_MISSIONSELECT);
+            .onClick([this] {
+                m_gameInterface->setNextStateToTransitionTo(GAME_MISSIONSELECT);
             })
             .build();
         m_guiBtnToMissionSelect = std::move(gui_btn_toMissionSelect);
@@ -84,9 +86,8 @@ AbstractMentat::AbstractMentat(GameContext* ctx, bool canMissionSelect)
 
     state = INIT;
 
-    // offsetX = 0 for screen resolution 640x480, ie, meaning > 640 we take the difference / 2
-    offsetX = (game.m_gameSettings->getScreenW() - 640) / 2;
-    offsetY = (game.m_gameSettings->getScreenH() - 480) / 2; // same goes for offsetY (but then for 480 height).
+    offsetX = (m_gameInterface->getGameSettings()->getScreenW() - 640) / 2;
+    offsetY = (m_gameInterface->getGameSettings()->getScreenH() - 480) / 2;
     movieTopleftX = offsetX + 256;
     movieTopleftY = offsetY + 120;
     memset(sentence, 0, sizeof(sentence));

--- a/src/gameobjects/mentat/AbstractMentat.cpp
+++ b/src/gameobjects/mentat/AbstractMentat.cpp
@@ -28,6 +28,11 @@
 #include <format>
 #include "include/cAssert.h"
 
+// The mentat screen artwork was designed for 640x480. On higher resolutions it
+// is centered, so the offset is half the extra pixels on each axis.
+static constexpr int MENTAT_SCREEN_W = 640;
+static constexpr int MENTAT_SCREEN_H = 480;
+
 AbstractMentat::AbstractMentat(GameContext* ctx, bool canMissionSelect)
 {
     d2tm_assert(ctx != nullptr);
@@ -86,8 +91,8 @@ AbstractMentat::AbstractMentat(GameContext* ctx, bool canMissionSelect)
 
     state = INIT;
 
-    offsetX = (m_gameInterface->getGameSettings()->getScreenW() - 640) / 2;
-    offsetY = (m_gameInterface->getGameSettings()->getScreenH() - 480) / 2;
+    offsetX = (m_gameInterface->getGameSettings()->getScreenW() - MENTAT_SCREEN_W) / 2;
+    offsetY = (m_gameInterface->getGameSettings()->getScreenH() - MENTAT_SCREEN_H) / 2;
     movieTopleftX = offsetX + 256;
     movieTopleftY = offsetY + 120;
     memset(sentence, 0, sizeof(sentence));
@@ -266,7 +271,7 @@ void AbstractMentat::draw()
     draw_movie();
 
     Texture *tmp = getBackgroundBitmap();
-    cRectangle dest = {offsetX, offsetY,640, 480};
+    cRectangle dest = {offsetX, offsetY, MENTAT_SCREEN_W, MENTAT_SCREEN_H};
     m_renderDrawer->renderStrechFullSprite(tmp, dest);
 
     draw_eyes();

--- a/src/gameobjects/mentat/AbstractMentat.h
+++ b/src/gameobjects/mentat/AbstractMentat.h
@@ -32,6 +32,7 @@ class GuiButton;
 struct SDL_Surface;
 class Texture;
 class GameContext;
+class cGameInterface;
 class SDLDrawer;
 class cTextDrawer;
 
@@ -123,4 +124,5 @@ protected:
 
     std::unique_ptr<GuiButton> m_guiBtnToMissionSelect;
     Graphics* gfxmentat;
+    cGameInterface* m_gameInterface = nullptr;
 };

--- a/src/gameobjects/mentat/AtreidesMentat.cpp
+++ b/src/gameobjects/mentat/AtreidesMentat.cpp
@@ -1,7 +1,6 @@
 #include "AtreidesMentat.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "data/gfxmentat.h"
+#include "game/cGameInterface.h"
 #include "drawers/SDLDrawer.hpp"
 #include "utils/Graphics.hpp"
 #include "utils/common.h"
@@ -32,9 +31,9 @@ AtreidesMentat::AtreidesMentat(GameContext* ctx, bool allowMissionSelect) : Abst
             .withTexture(gfxmentat->getTexture(BTN_YES))
             .withRenderer(m_renderDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
-            .onClick([]() {
+            .onClick([this]() {
                 logbook("cYesButtonCommand::changeStateFromMentat()");
-                game.changeStateFromMentat();})
+                m_gameInterface->changeStateFromMentat();})
             .build();
 }
 

--- a/src/gameobjects/mentat/BeneMentat.cpp
+++ b/src/gameobjects/mentat/BeneMentat.cpp
@@ -2,11 +2,10 @@
 
 #include "controls/eKeyAction.h"
 #include "data/gfxmentat.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
+#include "game/cGameInterface.h"
+#include "include/eGameState.h"
 #include "include/sDataCampaign.h"
 #include "gameobjects/players/cPlayer.h"
-#include "gameobjects/players/cPlayers.h"
 #include "drawers/SDLDrawer.hpp"
 #include "utils/Graphics.hpp"
 #include "utils/common.h"
@@ -15,7 +14,6 @@
 #include "gui/GuiButton.h"
 #include "context/GameContext.hpp"
 #include "context/cInfoContext.h"
-#include "context/cGameObjectContext.h"
 #include <iostream>
 
 BeneMentat::BeneMentat(GameContext* ctx, s_DataCampaign* dataCampaign) : AbstractMentat(ctx, false), m_dataCampaign(dataCampaign)
@@ -48,23 +46,22 @@ BeneMentat::BeneMentat(GameContext* ctx, s_DataCampaign* dataCampaign) : Abstrac
 void BeneMentat::onYesButtonPressed()
 {
     logbook("cYesButtonCommand::execute()");
-    game.setNextStateToTransitionTo(GAME_BRIEFING);
+    m_gameInterface->setNextStateToTransitionTo(GAME_BRIEFING);
     m_dataCampaign->mission = 1; // first mission
     m_dataCampaign->region  = 1; // and the first "region" so to speak
-    game.missionInit();
-    game.m_gameObjectsContext->getPlayer(HUMAN)->setHouse(this->getHouse());
+    m_gameInterface->missionInit();
+    m_gameInterface->getPlayer(HUMAN)->setHouse(this->getHouse());
     m_dataCampaign->housePlayer = this->getHouse();
-    game.initiateFadingOut();
+    m_gameInterface->initiateFadingOut();
 }
 
 void BeneMentat::onNoButtonPressed()
 {
     logbook("cNoButtonCommand::execute()");
-    // head back to choose house
-    game.m_gameObjectsContext->getPlayer(HUMAN)->setHouse(GENERALHOUSE);
+    m_gameInterface->getPlayer(HUMAN)->setHouse(GENERALHOUSE);
     m_dataCampaign->housePlayer = GENERALHOUSE;
-    game.setNextStateToTransitionTo(GAME_SELECT_HOUSE);
-    game.initiateFadingOut();
+    m_gameInterface->setNextStateToTransitionTo(GAME_SELECT_HOUSE);
+    m_gameInterface->initiateFadingOut();
 }
 
 void BeneMentat::think()

--- a/src/gameobjects/mentat/HarkonnenMentat.cpp
+++ b/src/gameobjects/mentat/HarkonnenMentat.cpp
@@ -1,7 +1,6 @@
 #include "HarkonnenMentat.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "data/gfxmentat.h"
+#include "game/cGameInterface.h"
 #include "drawers/SDLDrawer.hpp"
 #include "utils/Graphics.hpp"
 #include "utils/common.h"
@@ -31,9 +30,9 @@ HarkonnenMentat::HarkonnenMentat(GameContext* ctx, bool allowMissionSelect) : Ab
             .withTexture(gfxmentat->getTexture(BTN_YES))
             .withRenderer(m_renderDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
-            .onClick([]() {
+            .onClick([this]() {
                 logbook("cYesButtonCommand::changeStateFromMentat()");
-                game.changeStateFromMentat();})
+                m_gameInterface->changeStateFromMentat();})
             .build();
 }
 

--- a/src/gameobjects/mentat/OrdosMentat.cpp
+++ b/src/gameobjects/mentat/OrdosMentat.cpp
@@ -1,7 +1,6 @@
 #include "OrdosMentat.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "data/gfxmentat.h"
+#include "game/cGameInterface.h"
 #include "drawers/SDLDrawer.hpp"
 #include "utils/Graphics.hpp"
 #include "utils/common.h"
@@ -30,9 +29,9 @@ OrdosMentat::OrdosMentat(GameContext* ctx, bool allowMissionSelect) : AbstractMe
             .withTexture(gfxmentat->getTexture(BTN_YES))
             .withRenderer(m_renderDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
-            .onClick([]() {
+            .onClick([this]() {
                 logbook("cYesButtonCommand::changeStateFromMentat()");
-                game.changeStateFromMentat();})
+                m_gameInterface->changeStateFromMentat();})
             .build();
 }
 

--- a/src/gameobjects/structures/cStructureFactory.cpp
+++ b/src/gameobjects/structures/cStructureFactory.cpp
@@ -136,10 +136,10 @@ cAbstractStructure *cStructureFactory::createStructure(int iCell, int iStructure
                      );
 
         if (flag.big) {
-            str->addFlag(cFlag::createBigFlag(player, pos));
+            str->addFlag(cFlag::createBigFlag(player, pos, game.m_mapCamera, game.m_gameSettings.get()));
         }
         else {
-            str->addFlag(cFlag::createSmallFlag(player, pos));
+            str->addFlag(cFlag::createSmallFlag(player, pos, game.m_mapCamera, game.m_gameSettings.get()));
         }
     }
 


### PR DESCRIPTION
## Summary

Step 2 of #1254 — migrates `src/gameobjects/cFlag.cpp` and `src/gameobjects/mentat/` off the `game` global.

**`cGameInterface` additions** (3 new methods to support the migration):
- `changeStateFromMentat()` — delegates to `cGame::changeStateFromMentat()`
- `getPlayer(int id)` — delegates to `m_gameObjectsContext->getPlayer(id)`
- `getGameSettings()` — returns `m_gameSettings.get()`

**Mentat classes** — `AbstractMentat` now stores `cGameInterface* m_gameInterface` (extracted from the `GameContext*` it already receives). All subclasses use it instead of `game.`:
- `AbstractMentat`: screen dimensions for button placement and offsets
- `AtreidesMentat`, `HarkonnenMentat`, `OrdosMentat`: `changeStateFromMentat()` on "Yes" button click
- `BeneMentat`: state transitions, `missionInit()`, player house assignment

**`cFlag`** — constructor and static factory methods now take `cMapCamera*` and `cGameSettings*` directly. Call site in `cStructureFactory` passes `game.m_mapCamera` / `game.m_gameSettings.get()` (those will be cleaned up in step 14).

## Test plan

- [x] `./rebuildmacos.sh` passes (43/43 tests)
- [x] `grep -rn "game\." src/gameobjects/cFlag.cpp src/gameobjects/mentat/` returns empty