### PR TITLE
Step 4 of 15: cParticle has zero game. references

### DIFF
--- a/src/context/cGameObjectContext.cpp
+++ b/src/context/cGameObjectContext.cpp
@@ -161,4 +161,6 @@ void cGameObjectContext::serviceInit(sGameServices* services)
     m_map->serviceInit(services);
     d2tm_assert(m_Units != nullptr);
     m_Units->serviceInit(services);
+    d2tm_assert(m_particles != nullptr);
+    m_particles->serviceInit(services);
 }

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -611,7 +611,7 @@ void cMouseUnitsSelectedState::spawnParticle(const int type)
 {
     int absoluteXCoordinate = game.m_mapCamera->getAbsMapMouseX(m_mouse->getX());
     int absoluteYCoordinate = game.m_mapCamera->getAbsMapMouseY(m_mouse->getY());
-    cParticle::create(absoluteXCoordinate, absoluteYCoordinate, type, -1, -1);
+    cParticle::create(absoluteXCoordinate, absoluteYCoordinate, type, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
 }
 
 void cMouseUnitsSelectedState::onFocus()

--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -427,7 +427,7 @@ void cMiniMapDrawer::onMouseClickedLeft(const s_MouseEvent &event) {
             units->move_to(mouseCellOnMinimap);
 
             auto absPoint = m_map->getGeometry()->getAbsolutePositionFromCell(mouseCellOnMinimap);
-            cParticle::create(absPoint.x, absPoint.y, D2TM_PARTICLE_MOVE, -1, -1);
+            cParticle::create(absPoint.x, absPoint.y, D2TM_PARTICLE_MOVE, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
 
             sSelectedUnitTypes selectedUnitTypes = m_player->getSelectedUnitTypes();
             if (selectedUnitTypes.hasInfantry) {

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -748,6 +748,7 @@ bool cGame::setupGame()
         delete m_mapCamera;
 
     m_mapCamera = new cMapCamera(m_gameObjectsContext->getMap(), m_cameraDragMoveSpeed, m_cameraBorderOrKeyMoveSpeed, m_cameraEdgeMove);
+    m_services->mapCamera = m_mapCamera;
 
     m_cIni->installGame(m_gameFilename);
     // Now we are ready for the menu state

--- a/src/gameobjects/particles/cParticle.cpp
+++ b/src/gameobjects/particles/cParticle.cpp
@@ -12,8 +12,8 @@
 #include "cParticle.h"
 #include "utils/RNG.hpp"
 #include "utils/texture_utils.h"
-#include "game/cGame.h"
 #include "include/d2tmc.h"
+#include "include/sGameServices.h"
 #include "drawers/SDLDrawer.hpp"
 #include "gameobjects/map/cMapCamera.h"
 #include "gameobjects/players/cPlayer.h"
@@ -41,6 +41,11 @@ cParticle::~cParticle()
 {
     bmp = nullptr;
     dimensions.reset();
+}
+
+void cParticle::serviceInit(sGameServices* services)
+{
+    m_services = services;
 }
 
 void cParticle::reset()
@@ -85,11 +90,11 @@ bool cParticle::isValid() const {
 }
 
 int cParticle::draw_x() const {
-    return game.m_mapCamera->getWindowXPositionWithOffset(x, drawXBmpOffset);
+    return m_services->mapCamera->getWindowXPositionWithOffset(x, drawXBmpOffset);
 }
 
 int cParticle::draw_y() const {
-    return game.m_mapCamera->getWindowYPositionWithOffset(y, drawYBmpOffset);
+    return m_services->mapCamera->getWindowYPositionWithOffset(y, drawYBmpOffset);
 }
 
 /**
@@ -99,7 +104,7 @@ int cParticle::draw_y() const {
 void cParticle::think_position()
 {
     if (boundUnitID > -1) {
-        cUnit *pUnit = game.m_gameObjectsContext->getUnit(boundUnitID);
+        cUnit *pUnit = m_services->objects->getUnit(boundUnitID);
         if (!pUnit->isValid()) {
             bindToUnit(-1);
         }
@@ -107,9 +112,9 @@ void cParticle::think_position()
 
     // keep updating dimensions
     dimensions->move(draw_x(), draw_y());
-    if (game.m_mapCamera) {
-        dimensions->resize(game.m_mapCamera->factorZoomLevel(getFrameWidth()),
-                           game.m_mapCamera->factorZoomLevel(getFrameHeight()));
+    if (m_services->mapCamera) {
+        dimensions->resize(m_services->mapCamera->factorZoomLevel(getFrameWidth()),
+                           m_services->mapCamera->factorZoomLevel(getFrameHeight()));
     }
 }
 
@@ -126,8 +131,8 @@ void cParticle::draw()
     int frameHeight = getFrameHeight();
 
     // create proper sized bitmap
-    int bmp_width = game.m_mapCamera->factorZoomLevel(frameWidth);
-    int bmp_height = game.m_mapCamera->factorZoomLevel(frameHeight);
+    int bmp_width = m_services->mapCamera->factorZoomLevel(frameWidth);
+    int bmp_height = m_services->mapCamera->factorZoomLevel(frameHeight);
 
     int drawX = draw_x();
     int drawY = draw_y();
@@ -149,7 +154,7 @@ void cParticle::draw()
 }
 
 s_ParticleInfo &cParticle::getParticleInfo() const {
-    s_ParticleInfo &particleInfo = game.m_infoContext->getParticleInfo(iType);
+    s_ParticleInfo &particleInfo = m_services->info->getParticleInfo(iType);
     return particleInfo;
 }
 
@@ -586,18 +591,19 @@ void cParticle::thinkFast()
  * @param iFrame
  * @return
  */
-int cParticle::create(long x, long y, int iType, int iHouse, int iFrame, int iUnitID)
+int cParticle::create(long x, long y, int iType, int iHouse, int iFrame,
+                      cGameObjectContext* objects, cInfoContext* info, int iUnitID)
 {
-    int iNewId = findNewSlot();
+    int iNewId = findNewSlot(objects);
 
     if (iNewId < 0) {
         return -1;
     }
 
-    cParticle &pParticle = game.m_gameObjectsContext->getParticles()[iNewId];
-    const int particleInfoCount = game.m_infoContext->getParticleInfos()->size();
+    cParticle &pParticle = objects->getParticles()[iNewId];
+    const int particleInfoCount = info->getParticleInfos()->size();
     if (iType >= 0 && iType < particleInfoCount) {
-        s_ParticleInfo &sParticle = game.m_infoContext->getParticleInfo(iType);
+        s_ParticleInfo &sParticle = info->getParticleInfo(iType);
         pParticle.init(sParticle);
     }
     else {
@@ -625,7 +631,7 @@ int cParticle::create(long x, long y, int iType, int iHouse, int iFrame, int iUn
 
     if (iType == D2TM_PARTICLE_EXPLOSION_TRIKE) {
         // TODO: Spawn additional particle property
-        create(x, y, D2TM_PARTICLE_OBJECT_BOOM03, -1, 0, iUnitID);
+        create(x, y, D2TM_PARTICLE_OBJECT_BOOM03, -1, 0, objects, info, iUnitID);
     }
 
     if (iType == D2TM_PARTICLE_SMOKE) {
@@ -638,7 +644,7 @@ int cParticle::create(long x, long y, int iType, int iHouse, int iFrame, int iUn
 
     if (iType == D2TM_PARTICLE_SMOKE_WITH_SHADOW) {
         pParticle.TIMER_dead = 1500;
-        int shadowParticleId = create(x + 16, y + 38, D2TM_PARTICLE_SMOKE_SHADOW, -1, -1, iUnitID);
+        int shadowParticleId = create(x + 16, y + 38, D2TM_PARTICLE_SMOKE_SHADOW, -1, -1, objects, info, iUnitID);
 
         // since x, y is 'center' of particle, we have to compensate. Because smoke "starts" at the bottom (ie, its
         // offset is not in center). So we have to subtract half of the sprite's height
@@ -679,7 +685,7 @@ int cParticle::create(long x, long y, int iType, int iHouse, int iFrame, int iUn
             iType == D2TM_PARTICLE_EXPLOSION_GAS) {
 
         if (iType != D2TM_PARTICLE_EXPLOSION_STRUCTURE01 && iType != D2TM_PARTICLE_EXPLOSION_STRUCTURE02) {
-            create(x, y, D2TM_PARTICLE_OBJECT_BOOM02, -1, 0, iUnitID);
+            create(x, y, D2TM_PARTICLE_OBJECT_BOOM02, -1, 0, objects, info, iUnitID);
         }
 
     }
@@ -704,9 +710,9 @@ int cParticle::create(long x, long y, int iType, int iHouse, int iFrame, int iUn
         pParticle.iAlpha = 255;
         pParticle.TIMER_frame = 500 + RNG::rnd(300);
 
-        create(x, y - 18, D2TM_PARTICLE_EXPLOSION_FIRE, -1, -1, iUnitID);
-        create(x, y - 18, D2TM_PARTICLE_SMOKE, -1, -1, iUnitID);
-        create(x, y, D2TM_PARTICLE_OBJECT_BOOM02, -1, 0, iUnitID);
+        create(x, y - 18, D2TM_PARTICLE_EXPLOSION_FIRE, -1, -1, objects, info, iUnitID);
+        create(x, y - 18, D2TM_PARTICLE_SMOKE, -1, -1, objects, info, iUnitID);
+        create(x, y, D2TM_PARTICLE_OBJECT_BOOM02, -1, 0, objects, info, iUnitID);
     }
 
     if (iType == D2TM_PARTICLE_CARRYPUFF) {
@@ -718,17 +724,17 @@ int cParticle::create(long x, long y, int iType, int iHouse, int iFrame, int iUn
     if (iType == D2TM_PARTICLE_EXPLOSION_ROCKET || iType == D2TM_PARTICLE_EXPLOSION_ROCKET_SMALL) {
         pParticle.iAlpha = 255;
         // also create bloom
-        create(x, y, D2TM_PARTICLE_OBJECT_BOOM03, iHouse, 0, iUnitID);
+        create(x, y, D2TM_PARTICLE_OBJECT_BOOM03, iHouse, 0, objects, info, iUnitID);
     }
 
     pParticle.recolorForHouseIfGiven();
     return iNewId;
 }
 
-int cParticle::findNewSlot()
+int cParticle::findNewSlot(cGameObjectContext* objects)
 {
     int i = 0;
-    for (auto &particle : game.m_gameObjectsContext->getParticles()) {
+    for (auto &particle : objects->getParticles()) {
         if (!particle.isValid()) {
             return i;
         }
@@ -783,7 +789,7 @@ void cParticle::think_new()
 void cParticle::bindToUnit(int unitID)
 {
     if (boundUnitID > -1) {
-        cUnit *pUnit = game.m_gameObjectsContext->getUnit(boundUnitID);
+        cUnit *pUnit = m_services->objects->getUnit(boundUnitID);
         if (pUnit->isValid()) {
             pUnit->setBoundParticleId(-1);
         }
@@ -795,7 +801,7 @@ void cParticle::addPosX(float d)
 {
     this->x += d;
     if (boundParticleID > -1) {
-        cParticle &otherParticle = game.m_gameObjectsContext->getParticles()[boundParticleID];
+        cParticle &otherParticle = m_services->objects->getParticles()[boundParticleID];
         if (otherParticle.isValid()) {
             otherParticle.addPosX(d);
         }
@@ -809,7 +815,7 @@ void cParticle::addPosY(float d)
 {
     this->y += d;
     if (boundParticleID > -1) {
-        cParticle &otherParticle = game.m_gameObjectsContext->getParticles()[boundParticleID];
+        cParticle &otherParticle = m_services->objects->getParticles()[boundParticleID];
         if (otherParticle.isValid()) {
             otherParticle.addPosY(d);
         }
@@ -824,7 +830,7 @@ void cParticle::die()
     bindToUnit(-1);
     bAlive = false;
     if (boundParticleID > -1) {
-        cParticle &pParticle = game.m_gameObjectsContext->getParticles()[boundParticleID];
+        cParticle &pParticle = m_services->objects->getParticles()[boundParticleID];
         if (pParticle.isValid()) {
             pParticle.die();
         }
@@ -838,7 +844,7 @@ void cParticle::recolorForHouseIfGiven() {
         return;
     }
 
-    int bmpIndex = game.m_infoContext->getParticleInfo(iType).bmpIndex;
+    int bmpIndex = m_services->info->getParticleInfo(iType).bmpIndex;
     if (global_renderDrawer->isSurface8BitPaletted(gfxdata->getSurface(bmpIndex)) == false) {
         //std::cout << "cParticle::recolorForHouseIfGiven: Particle type " << iType << " with bmpIndex " << bmpIndex << " is not an 8-bit paletted surface, cannot recolor.\n";
         return;
@@ -852,7 +858,7 @@ void cParticle::recolorForHouseIfGiven() {
         return;
     }
     
-    cPlayer *player = game.m_gameObjectsContext->getPlayer(this->iHousePal);
+    cPlayer *player = m_services->objects->getPlayer(this->iHousePal);
     auto tex = gfxdata->getSurface(bmpIndex);
     auto recoloredBmp = createPlayerTextureFromIndexedSurfaceWithPalette(player, tex, TransparentColorIndex);
     if (recoloredBmp != nullptr) {

--- a/src/gameobjects/particles/cParticle.cpp
+++ b/src/gameobjects/particles/cParticle.cpp
@@ -14,6 +14,7 @@
 #include "utils/texture_utils.h"
 #include "include/d2tmc.h"
 #include "include/sGameServices.h"
+#include "gameobjects/particles/cParticles.h"
 #include "drawers/SDLDrawer.hpp"
 #include "gameobjects/map/cMapCamera.h"
 #include "gameobjects/players/cPlayer.h"
@@ -594,7 +595,7 @@ void cParticle::thinkFast()
 int cParticle::create(long x, long y, int iType, int iHouse, int iFrame,
                       cGameObjectContext* objects, cInfoContext* info, int iUnitID)
 {
-    int iNewId = findNewSlot(objects);
+    int iNewId = findNewSlot(objects->getParticles());
 
     if (iNewId < 0) {
         return -1;
@@ -731,10 +732,10 @@ int cParticle::create(long x, long y, int iType, int iHouse, int iFrame,
     return iNewId;
 }
 
-int cParticle::findNewSlot(cGameObjectContext* objects)
+int cParticle::findNewSlot(cParticles& particles)
 {
     int i = 0;
-    for (auto &particle : objects->getParticles()) {
+    for (auto &particle : particles) {
         if (!particle.isValid()) {
             return i;
         }
@@ -742,6 +743,11 @@ int cParticle::findNewSlot(cGameObjectContext* objects)
     }
 
     return -1;
+}
+
+cParticle& cParticle::getBoundParticle()
+{
+    return m_services->objects->getParticles()[boundParticleID];
 }
 
 void cParticle::init(const s_ParticleInfo &particleInfo)
@@ -801,7 +807,7 @@ void cParticle::addPosX(float d)
 {
     this->x += d;
     if (boundParticleID > -1) {
-        cParticle &otherParticle = m_services->objects->getParticles()[boundParticleID];
+        cParticle &otherParticle = getBoundParticle();
         if (otherParticle.isValid()) {
             otherParticle.addPosX(d);
         }
@@ -815,7 +821,7 @@ void cParticle::addPosY(float d)
 {
     this->y += d;
     if (boundParticleID > -1) {
-        cParticle &otherParticle = m_services->objects->getParticles()[boundParticleID];
+        cParticle &otherParticle = getBoundParticle();
         if (otherParticle.isValid()) {
             otherParticle.addPosY(d);
         }
@@ -830,7 +836,7 @@ void cParticle::die()
     bindToUnit(-1);
     bAlive = false;
     if (boundParticleID > -1) {
-        cParticle &pParticle = m_services->objects->getParticles()[boundParticleID];
+        cParticle &pParticle = getBoundParticle();
         if (pParticle.isValid()) {
             pParticle.die();
         }

--- a/src/gameobjects/particles/cParticle.cpp
+++ b/src/gameobjects/particles/cParticle.cpp
@@ -807,9 +807,9 @@ void cParticle::addPosX(float d)
 {
     this->x += d;
     if (boundParticleID > -1) {
-        cParticle &otherParticle = getBoundParticle();
-        if (otherParticle.isValid()) {
-            otherParticle.addPosX(d);
+        cParticle &boundParticle = getBoundParticle();
+        if (boundParticle.isValid()) {
+            boundParticle.addPosX(d);
         }
         else {
             boundParticleID = -1;
@@ -821,9 +821,9 @@ void cParticle::addPosY(float d)
 {
     this->y += d;
     if (boundParticleID > -1) {
-        cParticle &otherParticle = getBoundParticle();
-        if (otherParticle.isValid()) {
-            otherParticle.addPosY(d);
+        cParticle &boundParticle = getBoundParticle();
+        if (boundParticle.isValid()) {
+            boundParticle.addPosY(d);
         }
         else {
             boundParticleID = -1;
@@ -836,9 +836,9 @@ void cParticle::die()
     bindToUnit(-1);
     bAlive = false;
     if (boundParticleID > -1) {
-        cParticle &pParticle = getBoundParticle();
-        if (pParticle.isValid()) {
-            pParticle.die();
+        cParticle &boundParticle = getBoundParticle();
+        if (boundParticle.isValid()) {
+            boundParticle.die();
         }
     }
     boundParticleID = -1;

--- a/src/gameobjects/particles/cParticle.h
+++ b/src/gameobjects/particles/cParticle.h
@@ -24,6 +24,7 @@ class Texture;
 struct sGameServices;
 class cGameObjectContext;
 class cInfoContext;
+class cParticles;
 
 class cParticle {
 public:
@@ -35,7 +36,7 @@ public:
     // Factory methods
     static int create(long x, long y, int iType, int iHouse, int iFrame,
                       cGameObjectContext* objects, cInfoContext* info, int iUnitID = -1);
-    static int findNewSlot(cGameObjectContext* objects);
+    static int findNewSlot(cParticles& particles);
     // resets the particle system (frees all particles textures colored for houses)
     static void reset();
 
@@ -119,6 +120,7 @@ private:
 
     void recreateDimensions();
     void recolorForHouseIfGiven();
+    cParticle& getBoundParticle();
 
     static std::map<std::pair<int, int>, Texture*> particleTextureCache;
 };

--- a/src/gameobjects/particles/cParticle.h
+++ b/src/gameobjects/particles/cParticle.h
@@ -21,15 +21,21 @@
 #include <tuple>
 
 class Texture;
+struct sGameServices;
+class cGameObjectContext;
+class cInfoContext;
 
 class cParticle {
 public:
     cParticle();
     ~cParticle();
 
+    void serviceInit(sGameServices* services);
+
     // Factory methods
-    static int create(long x, long y, int iType, int iHouse, int iFrame, int iUnitID = -1);
-    static int findNewSlot();
+    static int create(long x, long y, int iType, int iHouse, int iFrame,
+                      cGameObjectContext* objects, cInfoContext* info, int iUnitID = -1);
+    static int findNewSlot(cGameObjectContext* objects);
     // resets the particle system (frees all particles textures colored for houses)
     static void reset();
 
@@ -96,6 +102,8 @@ private:
     int drawYBmpOffset;
 
     bool oldParticle;
+
+    sGameServices* m_services = nullptr;
 
     int boundUnitID;
     int boundParticleID; // when particles are 'tied together'

--- a/src/gameobjects/particles/cParticles.h
+++ b/src/gameobjects/particles/cParticles.h
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include "cParticle.h"
 
+struct sGameServices;
+
 class cParticles {
 public:
     cParticles()
@@ -34,6 +36,12 @@ public:
     // initialisation
     void reset() noexcept {
         cParticle::reset();
+    }
+
+    void serviceInit(sGameServices* services) {
+        for (auto &particle : m_particles) {
+            particle.serviceInit(services);
+        }
     }
 
     // itérateurs

--- a/src/gameobjects/projectiles/bullet.cpp
+++ b/src/gameobjects/projectiles/bullet.cpp
@@ -173,7 +173,7 @@ void cBullet::thinkFast()
             if (smokeParticle > -1) {
                 long x = pos_x();
                 long y = pos_y();
-                cParticle::create(x, y, smokeParticle, -1, -1);
+                cParticle::create(x, y, smokeParticle, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
             }
 
             TIMER_frame = 0;
@@ -331,7 +331,7 @@ void cBullet::arrivedAtDestinationLogic()
             // create particle of explosion
             if (sBullet.deathParticle > -1) {
                 // depending on 'explosion size'
-                cParticle::create(posX, posY, sBullet.deathParticle, -1, -1);
+                cParticle::create(posX, posY, sBullet.deathParticle, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
             }
 
             if (iType == ROCKET_BIG) {
@@ -342,7 +342,7 @@ void cBullet::arrivedAtDestinationLogic()
                                                distanceBetweenCellAndCenterOfScreen(cellToDamage));
                 }
                 if (RNG::rnd(100) < 20) {
-                    cParticle::create(posX, posY, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
+                    cParticle::create(posX, posY, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
                 }
             }
 

--- a/src/gameobjects/structures/cAbstractStructure.cpp
+++ b/src/gameobjects/structures/cAbstractStructure.cpp
@@ -212,21 +212,21 @@ void cAbstractStructure::die()
             int posX = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteXPositionFromCell(iCll);
             int posY = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteYPositionFromCell(iCll);
 
-            cParticle::create(posX + half, posY + half, D2TM_PARTICLE_OBJECT_BOOM01, -1, -1);
+            cParticle::create(posX + half, posY + half, D2TM_PARTICLE_OBJECT_BOOM01, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
 
             for (int i=0; i < 3; i++) {
                 game.m_gameObjectsContext->getMap()->smudge_increase(SmudgeType::S_ROCK, iCll);
 
                 // create particle
                 int iType = D2TM_PARTICLE_EXPLOSION_STRUCTURE01 + RNG::rnd(2);
-                cParticle::create(posX + half, posY + half, iType, -1, -1);
+                cParticle::create(posX + half, posY + half, iType, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
 
                 // create smoke
                 if (RNG::rnd(100) < 15) {
                     int randomX = -8 + RNG::rnd(16);
                     int randomY = -8 + RNG::rnd(16);
 
-                    cParticle::create(posX + half + randomX, posY + half + randomY, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
+                    cParticle::create(posX + half + randomX, posY + half + randomY, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
                 }
 
                 // create fire
@@ -235,7 +235,7 @@ void cAbstractStructure::die()
                     int randomY = -8 + RNG::rnd(16);
 
                     cParticle::create(posX + half + randomX, posY + half + randomY, D2TM_PARTICLE_EXPLOSION_FIRE, -1,
-                                      -1);
+                                      -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
                 }
 
             }
@@ -510,7 +510,7 @@ void cAbstractStructure::damage(int hp, int originId)
         if (RNG::rnd(100) < iChance) {
             long x = getRandomPosX();
             long y = getRandomPosY();
-            int particleIndex = cParticle::create(x, y, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
+            int particleIndex = cParticle::create(x, y, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
             if (particleIndex > -1) {
                 TIMER_reduceSmoke = game.m_gameObjectsContext->getParticles()[particleIndex].getTimerDeadInTicks();
                 m_smokeParticlesCreated++;

--- a/src/gameobjects/structures/cGunTurret.cpp
+++ b/src/gameobjects/structures/cGunTurret.cpp
@@ -182,7 +182,7 @@ void cGunTurret::think_fire()
                     int iShootX = pos_x() + half;
                     int iShootY = pos_y() + half;
                     int bmp_head = convertAngleToDrawIndex(iHeadFacing);
-                    cParticle::create(iShootX, iShootY, D2TM_PARTICLE_TANKSHOOT, -1, bmp_head);
+                    cParticle::create(iShootX, iShootY, D2TM_PARTICLE_TANKSHOOT, -1, bmp_head, game.m_gameObjectsContext.get(), game.m_infoContext.get());
                 }
             }
 

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -271,11 +271,11 @@ void cUnit::createSquishedParticle()
     // when we do not 'blow up', we died by something else. Only infantry will be 'squished' here now.
     if (iType == SOLDIER || iType == TROOPER || iType == UNIT_FREMEN_ONE) {
         int iType1 = D2TM_PARTICLE_SQUISH01 + RNG::rnd(2);
-        cParticle::create(iDieX, iDieY, iType1, iPlayer, rendering.iFrame);
+        cParticle::create(iDieX, iDieY, iType1, iPlayer, rendering.iFrame, m_objects, m_infos);
         m_interface->playSoundWithDistance(SOUND_SQUISH, distanceBetweenCellAndCenterOfScreen(position.iCell));
     }
     else if (iType == TROOPERS || iType == INFANTRY || iType == UNIT_FREMEN_THREE) {
-        cParticle::create(iDieX, iDieY, D2TM_PARTICLE_SQUISH03, iPlayer, rendering.iFrame);
+        cParticle::create(iDieX, iDieY, D2TM_PARTICLE_SQUISH03, iPlayer, rendering.iFrame, m_objects, m_infos);
         m_interface->playSoundWithDistance(SOUND_SQUISH, distanceBetweenCellAndCenterOfScreen(position.iCell));
     }
 }
@@ -289,18 +289,18 @@ void cUnit::createExplosionParticle()
 
     if (iType == TRIKE || iType == RAIDER || iType == QUAD) {
         // play quick 'boom' sound and show animation
-        cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_TRIKE, -1, -1);
+        cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_TRIKE, -1, -1, m_objects, m_infos);
         m_interface->playSoundWithDistance(SOUND_TRIKEDIE, distanceBetweenCellAndCenterOfScreen(position.iCell));
 
         if (RNG::rnd(100) < 30) {
-            cParticle::create(iDieX, iDieY - 24, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
+            cParticle::create(iDieX, iDieY - 24, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, m_objects, m_infos);
         }
     }
 
     if ((iType == SIEGETANK || iType == DEVASTATOR) && RNG::rnd(100) < 25) {
         if (rendering.iBodyFacing == Facing::UPLEFT ||
             rendering.iBodyFacing == Facing::DOWNRIGHT) {
-            cParticle::create(iDieX, iDieY, D2TM_PARTICLE_SIEGEDIE, iPlayer, -1);
+            cParticle::create(iDieX, iDieY, D2TM_PARTICLE_SIEGEDIE, iPlayer, -1, m_objects, m_infos);
         }
     }
 
@@ -308,16 +308,16 @@ void cUnit::createExplosionParticle()
             iType == HARVESTER || iType == ORNITHOPTER || iType == CARRYALL || iType == MCV || iType == FRIGATE) {
         // play quick 'boom' sound and show animation
         if (RNG::rnd(100) < 50) {
-            cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_TANK_ONE, -1, -1);
+            cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_TANK_ONE, -1, -1, m_objects, m_infos);
             m_interface->playSoundWithDistance(SOUND_TANKDIE2, distanceBetweenCellAndCenterOfScreen(position.iCell));
         }
         else {
-            cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_TANK_TWO, -1, -1);
+            cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_TANK_TWO, -1, -1, m_objects, m_infos);
             m_interface->playSoundWithDistance(SOUND_TANKDIE, distanceBetweenCellAndCenterOfScreen(position.iCell));
         }
 
         if (RNG::rnd(100) < 30) {
-            cParticle::create(iDieX, iDieY - 24, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
+            cParticle::create(iDieX, iDieY - 24, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, m_objects, m_infos);
         }
 
         if (iType == HARVESTER) {
@@ -327,11 +327,11 @@ void cUnit::createExplosionParticle()
 
         // For now carry-all and ornithopter share same death particle
         if (iType == ORNITHOPTER) {
-            cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_ORNI, -1, -1);
+            cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_ORNI, -1, -1, m_objects, m_infos);
         }
         // For now carry-all and ornithopter share same death particle
         if (iType == CARRYALL) {
-            cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_CARRYALL, -1, -1);
+            cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_CARRYALL, -1, -1, m_objects, m_infos);
         }
         // Frigate death particle? (doesnt exist in Dune 2, but would be cool to have)
     }
@@ -352,7 +352,7 @@ void cUnit::createExplosionParticle()
 
                 for (int i = 0; i < 2; i++) {
                     int iType1 = D2TM_PARTICLE_EXPLOSION_STRUCTURE01 + RNG::rnd(2);
-                    cParticle::create(iDieX + (cx * 32), iDieY + (cy * 32), iType1, -1, -1);
+                    cParticle::create(iDieX + (cx * 32), iDieY + (cy * 32), iType1, -1, -1, m_objects, m_infos);
                 }
 
                 if (RNG::rnd(100) < 35)
@@ -413,7 +413,7 @@ void cUnit::createExplosionParticle()
                         if (RNG::rnd(100) < iChance) {
                             long x = pos_x() + (m_mapCamera->getViewportStartX()) + 16 + (-8 + RNG::rnd(16));
                             long y = pos_y() + (m_mapCamera->getViewportStartY()) + 16 + (-8 + RNG::rnd(16));
-                            cParticle::create(x, y, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1);
+                            cParticle::create(x, y, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, m_objects, m_infos);
                         }
                     }
                 }
@@ -444,18 +444,18 @@ void cUnit::createExplosionParticle()
             }
 
 
-        cParticle::create(iOrgDieX, iOrgDieY, D2TM_PARTICLE_OBJECT_BOOM02, -1, -1);
+        cParticle::create(iOrgDieX, iOrgDieY, D2TM_PARTICLE_OBJECT_BOOM02, -1, -1, m_objects, m_infos);
 
-        cParticle::create(iOrgDieX - 32, iOrgDieY, D2TM_PARTICLE_OBJECT_BOOM02, -1, -1);
-        cParticle::create(iOrgDieX + 32, iOrgDieY, D2TM_PARTICLE_OBJECT_BOOM02, -1, -1);
-        cParticle::create(iOrgDieX, iOrgDieY - 32, D2TM_PARTICLE_OBJECT_BOOM02, -1, -1);
-        cParticle::create(iOrgDieX, iOrgDieY + 32, D2TM_PARTICLE_OBJECT_BOOM02, -1, -1);
+        cParticle::create(iOrgDieX - 32, iOrgDieY, D2TM_PARTICLE_OBJECT_BOOM02, -1, -1, m_objects, m_infos);
+        cParticle::create(iOrgDieX + 32, iOrgDieY, D2TM_PARTICLE_OBJECT_BOOM02, -1, -1, m_objects, m_infos);
+        cParticle::create(iOrgDieX, iOrgDieY - 32, D2TM_PARTICLE_OBJECT_BOOM02, -1, -1, m_objects, m_infos);
+        cParticle::create(iOrgDieX, iOrgDieY + 32, D2TM_PARTICLE_OBJECT_BOOM02, -1, -1, m_objects, m_infos);
     }
 
     if (iType == TROOPER || iType == SOLDIER || iType == UNIT_FREMEN_ONE) {
         // create particle of dead body
 
-        cParticle::create(iDieX, iDieY, D2TM_PARTICLE_DEADINF02, iPlayer, -1);
+        cParticle::create(iDieX, iDieY, D2TM_PARTICLE_DEADINF02, iPlayer, -1, m_objects, m_infos);
 
         m_interface->playSoundWithDistance(SOUND_DIE01 + RNG::rnd(5), distanceBetweenCellAndCenterOfScreen(position.iCell));
     }
@@ -463,7 +463,7 @@ void cUnit::createExplosionParticle()
     if (iType == TROOPERS || iType == INFANTRY || iType == UNIT_FREMEN_THREE) {
         // create particle of dead body
 
-        cParticle::create(iDieX, iDieY, D2TM_PARTICLE_DEADINF01, iPlayer, -1);
+        cParticle::create(iDieX, iDieY, D2TM_PARTICLE_DEADINF01, iPlayer, -1, m_objects, m_infos);
 
         m_interface->playSoundWithDistance(SOUND_DIE01 + RNG::rnd(5), distanceBetweenCellAndCenterOfScreen(position.iCell));
     }
@@ -1208,7 +1208,7 @@ void cUnit::thinkActionAgnostic()
         if (wormTrailTimer.incrementUntil(2)) {
             long x = pos_x_centered();
             long y = pos_y_centered();
-            cParticle::create(x, y, D2TM_PARTICLE_WORMTRAIL, -1, -1);
+            cParticle::create(x, y, D2TM_PARTICLE_WORMTRAIL, -1, -1, m_objects, m_infos);
         }
     }
 
@@ -1535,7 +1535,7 @@ void cUnit::thinkFast_move_airUnit()
                                 int pufX = (pos_x() + getBmpWidth() / 2);
                                 int pufY = (pos_y() + getBmpHeight() / 2);
 
-                                cParticle::create(pufX, pufY, D2TM_PARTICLE_CARRYPUFF, -1, -1);
+                                cParticle::create(pufX, pufY, D2TM_PARTICLE_CARRYPUFF, -1, -1, m_objects, m_infos);
 
                                 log("Pick up unit");
                                 return;
@@ -1632,7 +1632,7 @@ void cUnit::thinkFast_move_airUnit()
 
                             int pufX = (pos_x() + getBmpWidth() / 2);
                             int pufY = (pos_y() + getBmpHeight() / 2);
-                            cParticle::create(pufX, pufY, D2TM_PARTICLE_CARRYPUFF, -1, -1);
+                            cParticle::create(pufX, pufY, D2TM_PARTICLE_CARRYPUFF, -1, -1, m_objects, m_infos);
                         }
                         else {
                             // find a new spot
@@ -1771,7 +1771,7 @@ void cUnit::thinkFast_move_airUnit()
                             cellType == TERRAIN_SPICEHILL) {
                         int pufX = (pos_x() + getBmpWidth() / 2);
                         int pufY = (pos_y() + getBmpHeight() / 2);
-                        cParticle::create(pufX, pufY, D2TM_PARTICLE_CARRYPUFF, -1, -1);
+                        cParticle::create(pufX, pufY, D2TM_PARTICLE_CARRYPUFF, -1, -1, m_objects, m_infos);
                     }
                 }
                 movedelayTimer.reset((dist - iLength) * (dist * slowDownStep));
@@ -1992,10 +1992,10 @@ void cUnit::shoot(int iTargetCell)
 
     // TODO: add this in sUnitInfo
     if (iType == TANK) {
-        cParticle::create(iShootX, iShootY, D2TM_PARTICLE_TANKSHOOT, -1, bmp_head);
+        cParticle::create(iShootX, iShootY, D2TM_PARTICLE_TANKSHOOT, -1, bmp_head, m_objects, m_infos);
     }
     else if (iType == SIEGETANK) {
-        cParticle::create(iShootX, iShootY, D2TM_PARTICLE_SIEGESHOOT, -1, bmp_head);
+        cParticle::create(iShootX, iShootY, D2TM_PARTICLE_SIEGESHOOT, -1, bmp_head, m_objects, m_infos);
     }
 
     s_UnitInfo &unitInfo = getUnitInfo();
@@ -2193,7 +2193,7 @@ void cUnit::think_hit(int iShotUnit, int iShotStructure)
                 int iDieX = pos_x() + half;
                 int iDieY = pos_y() + half;
 
-                cParticle::create(iDieX, iDieY, D2TM_PARTICLE_DEADINF01, iPlayer, -1);
+                cParticle::create(iDieX, iDieY, D2TM_PARTICLE_DEADINF01, iPlayer, -1, m_objects, m_infos);
 
                 m_interface->playSoundWithDistance(SOUND_DIE01 + RNG::rnd(5),
                                            distanceBetweenCellAndCenterOfScreen(position.iCell));
@@ -2381,7 +2381,7 @@ void cUnit::think_attack_sandworm()
         unitsEaten++;
         long x = pos_x_centered();
         long y = pos_y_centered();
-        cParticle::create(x, y, D2TM_PARTICLE_WORMEAT, -1, -1);
+        cParticle::create(x, y, D2TM_PARTICLE_WORMEAT, -1, -1, m_objects, m_infos);
         m_interface->playSoundWithDistance(SOUND_WORM, distanceBetweenCellAndCenterOfScreen(position.iCell));
         actionGuard();
         movewaitTimer.reset((1000/5) * 4); // wait for 4 seconds before moving again
@@ -2962,12 +2962,12 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
 
             // horizontal when only going horizontal
             if (bToLeft > -1 && bToDown < 0) {
-                cParticle::create(iParX, iParY, D2TM_PARTICLE_TRACK_HOR, -1, -1);
+                cParticle::create(iParX, iParY, D2TM_PARTICLE_TRACK_HOR, -1, -1, m_objects, m_infos);
             }
 
             // vertical, when only going vertical
             if (bToDown > -1 && bToLeft < 0) {
-                cParticle::create(iParX, iParY, D2TM_PARTICLE_TRACK_VER, -1, -1);
+                cParticle::create(iParX, iParY, D2TM_PARTICLE_TRACK_VER, -1, -1, m_objects, m_infos);
             }
 
             // diagonal when going both ways
@@ -2975,19 +2975,19 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
                 if (bToDown == 0) {
                     // going up
                     if (bToLeft == 1) {
-                        cParticle::create(iParX, iParY, D2TM_PARTICLE_TRACK_DIA, -1, -1);
+                        cParticle::create(iParX, iParY, D2TM_PARTICLE_TRACK_DIA, -1, -1, m_objects, m_infos);
                     }
                     else {
-                        cParticle::create(iParX, iParY, D2TM_PARTICLE_TRACK_DIA2, -1, -1);
+                        cParticle::create(iParX, iParY, D2TM_PARTICLE_TRACK_DIA2, -1, -1, m_objects, m_infos);
                     }
 
                 }
                 else {
                     if (bToLeft == 0) {
-                        cParticle::create(iParX, iParY, D2TM_PARTICLE_TRACK_DIA, -1, -1);
+                        cParticle::create(iParX, iParY, D2TM_PARTICLE_TRACK_DIA, -1, -1, m_objects, m_infos);
                     }
                     else {
-                        cParticle::create(iParX, iParY, D2TM_PARTICLE_TRACK_DIA2, -1, -1);
+                        cParticle::create(iParX, iParY, D2TM_PARTICLE_TRACK_DIA2, -1, -1, m_objects, m_infos);
                     }
                 }
 
@@ -3541,6 +3541,8 @@ void cUnit::takeDamage(int damage, int unitWhoDealsDamage, int structureWhoDeals
                                          D2TM_PARTICLE_SMOKE, // non-shadow smoke looks better on unit
                                          -1,
                                          -1,
+                                         m_objects,
+                                         m_infos,
                                          iID
                                      );
                     boundParticleId = particleId;

--- a/src/include/sGameServices.h
+++ b/src/include/sGameServices.h
@@ -5,6 +5,7 @@ class cGameObjectContext;
 class cInfoContext;
 class cGameSettings;
 class cLog;
+class cMapCamera;
 class cStructureUtils;
 class cEventEmitter;
 
@@ -14,6 +15,7 @@ struct sGameServices
     cGameObjectContext *objects = nullptr;
     cInfoContext *info = nullptr;
     cGameSettings *settings = nullptr;
+    cMapCamera *mapCamera = nullptr;
     cStructureUtils *structureUtils = nullptr;
     cLog *m_log = nullptr;
     cEventEmitter *eventEmitter = nullptr;


### PR DESCRIPTION
## Summary

Step 4 of #1254 — migrates `src/gameobjects/particles/` off the `game` global.

**Infrastructure:**
- `cMapCamera*` added to `sGameServices` (first use) and populated in `cGame_logic` right after camera creation
- `serviceInit(sGameServices*)` added to `cParticle` and `cParticles`; `cGameObjectContext::serviceInit` now calls `m_particles->serviceInit(services)` so all 600 particle slots receive the services pointer at startup

**`cParticle` instance methods** (`draw_x`, `draw_y`, `think_position`, `draw`, `getParticleInfo`, `bindToUnit`, `addPosX/Y`, `die`, `recolorForHouseIfGiven`) now use `m_services->mapCamera`, `->objects`, `->info` instead of the `game` global.

**Static methods** `create()` and `findNewSlot()` now take `cGameObjectContext*` and `cInfoContext*` directly. All call sites updated:
- `cUnit.cpp` uses `m_objects` / `m_infos` (already injected via its own `serviceInit`)
- `cAbstractStructure.cpp`, `cGunTurret.cpp`, `bullet.cpp`, `cMiniMapDrawer.cpp`, `cMouseUnitsSelectedState.cpp` temporarily pass `game.m_gameObjectsContext.get()` / `game.m_infoContext.get()` until their respective migration steps

## Test plan

- [x] `./rebuildmacos.sh` passes (43/43 tests)
- [x] `src/gameobjects/particles/` contains zero `game.` references