### PR TITLE
Step 6 of 15: cMapCamera and cRandomMapGenerator have zero game. references

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -747,7 +747,7 @@ bool cGame::setupGame()
     if (m_mapCamera != nullptr)
         delete m_mapCamera;
 
-    m_mapCamera = new cMapCamera(m_gameObjectsContext->getMap(), m_cameraDragMoveSpeed, m_cameraBorderOrKeyMoveSpeed, m_cameraEdgeMove);
+    m_mapCamera = new cMapCamera(m_gameObjectsContext->getMap(), m_cameraDragMoveSpeed, m_cameraBorderOrKeyMoveSpeed, m_cameraEdgeMove, m_gameSettings.get(), getMouse());
     m_services->mapCamera = m_mapCamera;
 
     m_cIni->installGame(m_gameFilename);

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -747,7 +747,7 @@ bool cGame::setupGame()
     if (m_mapCamera != nullptr)
         delete m_mapCamera;
 
-    m_mapCamera = new cMapCamera(m_gameObjectsContext->getMap(), m_cameraDragMoveSpeed, m_cameraBorderOrKeyMoveSpeed, m_cameraEdgeMove, m_gameSettings.get(), getMouse());
+    m_mapCamera = new cMapCamera(m_gameObjectsContext->getMap(), m_cameraDragMoveSpeed, m_cameraBorderOrKeyMoveSpeed, m_cameraEdgeMove, m_gameSettings.get(), m_mouse);
     m_services->mapCamera = m_mapCamera;
 
     m_cIni->installGame(m_gameFilename);

--- a/src/gameobjects/map/cMapCamera.cpp
+++ b/src/gameobjects/map/cMapCamera.cpp
@@ -1,14 +1,11 @@
 #include "cMapCamera.h"
 
+#include "controls/cMouse.h"
 #include "controls/eKeyAction.h"
 #include "data/gfxdata.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "sidebar/cSideBar.h"
 #include "gameobjects/map/MapGeometry.hpp"
 #include "game/cGameSettings.h"
-#include "context/cInfoContext.h"
-#include "context/cGameObjectContext.h"
 #include "gameobjects/map/cMap.h"
 #include <algorithm>
 #include "include/cAssert.h"
@@ -17,23 +14,27 @@ namespace {
 constexpr auto kMapBoundaryScrollSpeed = 5.0f;
 }
 
-cMapCamera::cMapCamera(cMap *theMap, float moveSpeedDrag, float moveSpeedBorderOrKeys, bool cameraEdgeMove) :
+cMapCamera::cMapCamera(cMap *theMap, float moveSpeedDrag, float moveSpeedBorderOrKeys, bool cameraEdgeMove, cGameSettings* gameSettings, cMouse* mouse) :
     m_moveSpeedDrag(moveSpeedDrag),
     m_moveSpeedBorderOrKeys(moveSpeedBorderOrKeys),
     m_cameraEdgeMove(cameraEdgeMove),
     m_pMap(theMap),
-    m_mapGeometry(theMap ? theMap->getGeometry() : nullptr)
+    m_mapGeometry(theMap ? theMap->getGeometry() : nullptr),
+    m_gameSettings(gameSettings),
+    m_mouse(mouse)
 {
     d2tm_assert(theMap != nullptr);
     d2tm_assert(m_mapGeometry != nullptr);
+    d2tm_assert(gameSettings != nullptr);
+    d2tm_assert(mouse != nullptr);
     m_viewportStartX = m_viewportStartY = 32;
     m_zoomLevel = 1.0f;
 
     int widthOfSidebar = cSideBar::SidebarWidth;
     m_heightOfTopBar = cSideBar::TopBarHeight;
 
-    m_windowWidth= game.m_gameSettings->getScreenW() - widthOfSidebar;
-    m_windowHeight= game.m_gameSettings->getScreenH() - m_heightOfTopBar;
+    m_windowWidth= m_gameSettings->getScreenW() - widthOfSidebar;
+    m_windowHeight= m_gameSettings->getScreenH() - m_heightOfTopBar;
 
     m_viewportWidth=m_windowWidth;
     m_viewportHeight=m_windowHeight;
@@ -84,7 +85,6 @@ void cMapCamera::zoomIn()
 {
     if (m_zoomLevel < 4.0) {
         m_zoomLevel += 0.1;
-        auto m_mouse = game.getMouse();
         adjustViewport(m_mouse->getX(), m_mouse->getY());
     }
 }
@@ -112,7 +112,6 @@ void cMapCamera::zoomOut()
 {
     if (m_zoomLevel > 0.25) {
         m_zoomLevel -= 0.1;
-        auto m_mouse = game.getMouse();
         adjustViewport(m_mouse->getX(), m_mouse->getY());
     }
 }
@@ -139,12 +138,12 @@ void cMapCamera::keepViewportWithinReasonableBounds()
         m_viewportStartY = -halfViewportHeight;
     }
 
-    int maxWidth = (game.m_gameObjectsContext->getMap()->getWidth() * TILESIZE_WIDTH_PIXELS) + halfViewportWidth;
+    int maxWidth = (m_pMap->getWidth() * TILESIZE_WIDTH_PIXELS) + halfViewportWidth;
     if (getViewportEndX() > maxWidth) {
         m_viewportStartX = maxWidth - m_viewportWidth;
     }
 
-    int maxHeight = (game.m_gameObjectsContext->getMap()->getHeight() * TILESIZE_HEIGHT_PIXELS) + halfViewportHeight;
+    int maxHeight = (m_pMap->getHeight() * TILESIZE_HEIGHT_PIXELS) + halfViewportHeight;
     if ((getViewportEndY()) > maxHeight) {
         m_viewportStartY = maxHeight - m_viewportHeight;
     }
@@ -154,7 +153,7 @@ void cMapCamera::centerAndJumpViewPortToCell(int cell)
 {
     // fix any boundaries
     if (cell < 0) cell = 0;
-    if (cell >= game.m_gameObjectsContext->getMap()->getMaxCells()) cell = (game.m_gameObjectsContext->getMap()->getMaxCells()-1);
+    if (cell >= m_pMap->getMaxCells()) cell = (m_pMap->getMaxCells()-1);
 
     int mapCellX = m_mapGeometry->getAbsoluteXPositionFromCell(cell);
     int mapCellY = m_mapGeometry->getAbsoluteYPositionFromCell(cell);
@@ -221,10 +220,10 @@ void cMapCamera::onNotifyMouseEvent(const s_MouseEvent &event)
             onMouseMovedTo(event);
             break;
         case eMouseEventType::MOUSE_SCROLLED_DOWN:
-            game.m_mapCamera->zoomOut();
+            zoomOut();
             break;
         case eMouseEventType::MOUSE_SCROLLED_UP:
-            game.m_mapCamera->zoomIn();
+            zoomIn();
             break;
         case eMouseEventType::MOUSE_RIGHT_BUTTON_PRESSED:
             onMouseRightButtonPressed(event);
@@ -239,21 +238,19 @@ void cMapCamera::onNotifyMouseEvent(const s_MouseEvent &event)
 
 void cMapCamera::onMouseMovedTo(const s_MouseEvent &event)
 {
-    cMouse *pMouse = game.getMouse();
-
     // mouse is 'moving by pressing right mouse button', this supersedes behavior with edges
-    if (!pMouse->isMapScrolling() && m_cameraEdgeMove) {
+    if (!m_mouse->isMapScrolling() && m_cameraEdgeMove) {
 
         int mouseX = event.coords.x;
         int mouseY = event.coords.y;
 
         if (mouseX <= 2) {
             setMoveX(-kMapBoundaryScrollSpeed, m_moveSpeedBorderOrKeys);
-            pMouse->setTile(MOUSE_LEFT);
+            m_mouse->setTile(MOUSE_LEFT);
         }
-        else if (mouseX >= (game.m_gameSettings->getScreenW() - 2)) {
+        else if (mouseX >= (m_gameSettings->getScreenW() - 2)) {
             setMoveX(kMapBoundaryScrollSpeed, m_moveSpeedBorderOrKeys);
-            pMouse->setTile(MOUSE_RIGHT);
+            m_mouse->setTile(MOUSE_RIGHT);
         }
         else {
             if (!m_keyPressedLeft && !m_keyPressedRight) {
@@ -263,11 +260,11 @@ void cMapCamera::onMouseMovedTo(const s_MouseEvent &event)
 
         if (mouseY <= 2) {
             setMoveY(-kMapBoundaryScrollSpeed, m_moveSpeedBorderOrKeys);
-            pMouse->setTile(MOUSE_UP);
+            m_mouse->setTile(MOUSE_UP);
         }
-        else if (mouseY >= (game.m_gameSettings->getScreenH() - 2)) {
+        else if (mouseY >= (m_gameSettings->getScreenH() - 2)) {
             setMoveY(kMapBoundaryScrollSpeed, m_moveSpeedBorderOrKeys);
-            pMouse->setTile(MOUSE_DOWN);
+            m_mouse->setTile(MOUSE_DOWN);
         }
         else {
             if (!m_keyPressedUp && !m_keyPressedDown) {
@@ -296,7 +293,7 @@ void cMapCamera::onMouseRightButtonPressed(const s_MouseEvent &)
     m_moveX = 0.0f;
     m_moveY = 0.0f;
 
-    cMouse *pMouse = game.getMouse();
+    cMouse *pMouse = m_mouse;
 
     // mouse is 'moving by pressing right mouse button', this supersedes behavior with borders
     if (pMouse->isMapScrolling()) {
@@ -344,7 +341,7 @@ void cMapCamera::setMoveY(float y, float moveSpeed)
 
 void cMapCamera::onKeyHold(const cKeyboardEvent &event)
 {
-    cMouse *pMouse = game.getMouse();
+    cMouse *pMouse = m_mouse;
 
     // mouse is 'moving by pressing right mouse button', this supersedes reacting to keypress
     if (!pMouse->isMapScrolling()) {

--- a/src/gameobjects/map/cMapCamera.cpp
+++ b/src/gameobjects/map/cMapCamera.cpp
@@ -19,12 +19,11 @@ cMapCamera::cMapCamera(cMap *theMap, float moveSpeedDrag, float moveSpeedBorderO
     m_moveSpeedBorderOrKeys(moveSpeedBorderOrKeys),
     m_cameraEdgeMove(cameraEdgeMove),
     m_pMap(theMap),
-    m_mapGeometry(theMap ? theMap->getGeometry() : nullptr),
+    m_mapGeometry(theMap->getGeometry()),
     m_gameSettings(gameSettings),
     m_mouse(mouse)
 {
     d2tm_assert(theMap != nullptr);
-    d2tm_assert(m_mapGeometry != nullptr);
     d2tm_assert(gameSettings != nullptr);
     d2tm_assert(mouse != nullptr);
     m_viewportStartX = m_viewportStartY = 32;
@@ -293,13 +292,11 @@ void cMapCamera::onMouseRightButtonPressed(const s_MouseEvent &)
     m_moveX = 0.0f;
     m_moveY = 0.0f;
 
-    cMouse *pMouse = m_mouse;
-
     // mouse is 'moving by pressing right mouse button', this supersedes behavior with borders
-    if (pMouse->isMapScrolling()) {
+    if (m_mouse->isMapScrolling()) {
         // difference in pixels (- means up/left, + means down/right)
-        int diffX = pMouse->getMouseDragDeltaX();
-        int diffY = pMouse->getMouseDragDeltaY();
+        int diffX = m_mouse->getMouseDragDeltaX();
+        int diffY = m_mouse->getMouseDragDeltaY();
 
         // now calculate the speed in which we want to do this, the further
         // away (greater distance) the faster.
@@ -341,31 +338,29 @@ void cMapCamera::setMoveY(float y, float moveSpeed)
 
 void cMapCamera::onKeyHold(const cKeyboardEvent &event)
 {
-    cMouse *pMouse = m_mouse;
-
     // mouse is 'moving by pressing right mouse button', this supersedes reacting to keypress
-    if (!pMouse->isMapScrolling()) {
+    if (!m_mouse->isMapScrolling()) {
         if (event.isAction(eKeyAction::SCROLL_LEFT)) {
             setMoveX(-kMapBoundaryScrollSpeed, m_moveSpeedBorderOrKeys);
-            pMouse->setTile(MOUSE_LEFT);
+            m_mouse->setTile(MOUSE_LEFT);
             m_keyPressedLeft = true;
         }
 
         if (event.isAction(eKeyAction::SCROLL_UP)) {
             setMoveY(-kMapBoundaryScrollSpeed, m_moveSpeedBorderOrKeys);
-            pMouse->setTile(MOUSE_UP);
+            m_mouse->setTile(MOUSE_UP);
             m_keyPressedUp = true;
         }
 
         if (event.isAction(eKeyAction::SCROLL_RIGHT)) {
             setMoveX(kMapBoundaryScrollSpeed, m_moveSpeedBorderOrKeys);
-            pMouse->setTile(MOUSE_RIGHT);
+            m_mouse->setTile(MOUSE_RIGHT);
             m_keyPressedRight = true;
         }
 
         if (event.isAction(eKeyAction::SCROLL_DOWN)) {
             setMoveY(kMapBoundaryScrollSpeed, m_moveSpeedBorderOrKeys);
-            pMouse->setTile(MOUSE_DOWN);
+            m_mouse->setTile(MOUSE_DOWN);
             m_keyPressedDown = true;
         }
     }

--- a/src/gameobjects/map/cMapCamera.h
+++ b/src/gameobjects/map/cMapCamera.h
@@ -19,11 +19,13 @@
 
 class cMap;
 class MapGeometry;
+class cGameSettings;
+class cMouse;
 
 class cMapCamera : cInputObserver {
 
 public:
-    cMapCamera(cMap *theMap, float moveSpeedDrag, float moveSpeedKeys, bool cameraEdgeMove);
+    cMapCamera(cMap *theMap, float moveSpeedDrag, float moveSpeedKeys, bool cameraEdgeMove, cGameSettings* gameSettings, cMouse* mouse);
 
     ~cMapCamera();
 
@@ -214,6 +216,8 @@ private:
     // the map this camera is viewing
     cMap *m_pMap;
     MapGeometry *m_mapGeometry = nullptr;
+    cGameSettings *m_gameSettings;
+    cMouse *m_mouse;
 
     void adjustViewport(float screenX, float screenY);
 

--- a/src/gameobjects/map/cRandomMapGenerator.cpp
+++ b/src/gameobjects/map/cRandomMapGenerator.cpp
@@ -1,6 +1,5 @@
 #include "cRandomMapGenerator.h"
 
-#include "game/cGame.h"
 #include "include/d2tmc.h"
 #include "data/gfxdata.h"
 //#include "data/gfxinter.h"
@@ -11,18 +10,17 @@
 #include "utils/Graphics.hpp"
 #include "utils/RNG.hpp"
 #include "utils/d2tm_math.h"
-#include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
 
 cRandomMapGenerator::cRandomMapGenerator()
 {
 }
 
-void cRandomMapGenerator::generateRandomMap(int width, int height, int startingPoints, s_PreviewMap &randomMapEntry)
+void cRandomMapGenerator::generateRandomMap(int width, int height, int startingPoints, s_PreviewMap &randomMapEntry, cGameObjectContext* objects)
 {
     // create random map
-    game.m_gameObjectsContext->getMap()->init(width, height);
-    auto mapEditor = cMapEditor(game.m_gameObjectsContext->getMap());
+    objects->getMap()->init(width, height);
+    auto mapEditor = cMapEditor(objects->getMap());
 
     int a_spice = RNG::rnd((startingPoints * 8)) + (startingPoints * 12);
     int a_rock = 32 + RNG::rnd(startingPoints * 3);
@@ -50,15 +48,15 @@ void cRandomMapGenerator::generateRandomMap(int width, int height, int startingP
 
     // draw
     while (a_rock > 0) {
-        int iCll = game.m_gameObjectsContext->getMapGeometry()->getRandomCellWithinMapWithSafeDistanceFromBorder(4);
+        int iCll = objects->getMapGeometry()->getRandomCellWithinMapWithSafeDistanceFromBorder(4);
         if (iCll < 0) continue;
 
         bool bOk = true;
         if (iSpot < maxRockSpots) {
             for (int s = 0; s < maxRockSpots; s++) {
                 if (iSpotRock[s] > -1) {
-                    if (ABS_length(game.m_gameObjectsContext->getMapGeometry()->getCellX(iCll), game.m_gameObjectsContext->getMapGeometry()->getCellY(iCll), game.m_gameObjectsContext->getMapGeometry()->getCellX(iSpotRock[s]),
-                                   game.m_gameObjectsContext->getMapGeometry()->getCellY(iSpotRock[s])) < iDistance) {
+                    if (ABS_length(objects->getMapGeometry()->getCellX(iCll), objects->getMapGeometry()->getCellY(iCll), objects->getMapGeometry()->getCellX(iSpotRock[s]),
+                                   objects->getMapGeometry()->getCellY(iSpotRock[s])) < iDistance) {
                         bOk = false;
                     }
                     else {
@@ -100,13 +98,13 @@ void cRandomMapGenerator::generateRandomMap(int width, int height, int startingP
     mapEditor.removeSingleRockSpots();
 
     while (a_spice > 0) {
-        int iCll = game.m_gameObjectsContext->getMapGeometry()->getRandomCellWithinMapWithSafeDistanceFromBorder(0);
+        int iCll = objects->getMapGeometry()->getRandomCellWithinMapWithSafeDistanceFromBorder(0);
         mapEditor.createRandomField(iCll, TERRAIN_SPICE, 2500);
         a_spice--;
     }
 
     while (a_hill > 0) {
-        int cell = game.m_gameObjectsContext->getMapGeometry()->getRandomCellWithinMapWithSafeDistanceFromBorder(0);
+        int cell = objects->getMapGeometry()->getRandomCellWithinMapWithSafeDistanceFromBorder(0);
         mapEditor.createRandomField(cell, TERRAIN_HILL, 500 + RNG::rnd(500));
         a_hill--;
     }
@@ -124,16 +122,16 @@ void cRandomMapGenerator::generateRandomMap(int width, int height, int startingP
     global_renderDrawer->FillWithColor(randomMapEntry.terrain, Color::Black);
 
     // now put in previewmap 0
-    for (int x = 0; x < game.m_gameObjectsContext->getMap()->getWidth(); x++) {
-        for (int y = 0; y < game.m_gameObjectsContext->getMap()->getHeight(); y++) {
+    for (int x = 0; x < objects->getMap()->getWidth(); x++) {
+        for (int y = 0; y < objects->getMap()->getHeight(); y++) {
 
-            int cll = game.m_gameObjectsContext->getMapGeometry()->getCellWithMapDimensions(x, y);
+            int cll = objects->getMapGeometry()->getCellWithMapDimensions(x, y);
             if (cll < 0) continue;
 
             Color iColor = Color{194, 125, 60,255};
 
             // rock
-            int cellType = game.m_gameObjectsContext->getMap()->getCellType(cll);
+            int cellType = objects->getMap()->getCellType(cll);
             if (cellType == TERRAIN_ROCK) iColor = Color{80, 80, 60,255};
             if (cellType == TERRAIN_MOUNTAIN) iColor = Color{48, 48, 36,255};
             if (cellType == TERRAIN_SPICEHILL) iColor = Color{180, 90, 25,255}; // a bit darker
@@ -144,8 +142,8 @@ void cRandomMapGenerator::generateRandomMap(int width, int height, int startingP
 
             for (int s = 0; s < 4; s++) {
                 if (randomMapEntry.iStartCell[s] > -1) {
-                    int sx = game.m_gameObjectsContext->getMapGeometry()->getCellX(randomMapEntry.iStartCell[s]);
-                    int sy = game.m_gameObjectsContext->getMapGeometry()->getCellY(randomMapEntry.iStartCell[s]);
+                    int sx = objects->getMapGeometry()->getCellX(randomMapEntry.iStartCell[s]);
+                    int sy = objects->getMapGeometry()->getCellY(randomMapEntry.iStartCell[s]);
 
                     if (sx == x && sy == y)
                         iColor = Color::White;

--- a/src/gameobjects/map/cRandomMapGenerator.h
+++ b/src/gameobjects/map/cRandomMapGenerator.h
@@ -2,10 +2,12 @@
 
 #include "gameobjects/map/cPreviewMaps.h"
 
+class cGameObjectContext;
+
 class cRandomMapGenerator {
 public:
     cRandomMapGenerator();
-    void generateRandomMap(int width, int height, int startingPoints, s_PreviewMap &randomMapEntry);
+    void generateRandomMap(int width, int height, int startingPoints, s_PreviewMap &randomMapEntry, cGameObjectContext* objects);
 
 private:
     //void drawProgress(float progress) const;

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -1258,7 +1258,7 @@ void cSetupSkirmishState::generateRandomMap()
     // delete any preview texture if it exists
     delete randomMap->previewTex;
 
-    randomMapGenerator->generateRandomMap(randomMapWidth, randomMapHeight, iStartingPoints, *randomMap);
+    randomMapGenerator->generateRandomMap(randomMapWidth, randomMapHeight, iStartingPoints, *randomMap, m_objects);
 
     spawnWorms = (randomMapWidth * randomMapHeight > 64 * 64) ? 4 : 2;
 


### PR DESCRIPTION
## Summary

- `cMapCamera` constructor gains `cGameSettings*` and `cMouse*` parameters; both stored as members (`m_gameSettings`, `m_mouse`)
- All `game.getMouse()` calls replaced with `m_mouse`
- All `game.m_gameSettings->` calls replaced with `m_gameSettings->`
- `game.m_gameObjectsContext->getMap()->getWidth()/getHeight()/getMaxCells()` replaced with `m_pMap->` (already a member)
- `game.m_mapCamera->zoomIn()/zoomOut()` replaced with `zoomIn()/zoomOut()` (the camera was calling itself through the global)
- `cRandomMapGenerator::generateRandomMap` gains a `cGameObjectContext* objects` parameter; all `game.m_gameObjectsContext->` replaced with `objects->`
- Call site in `cSetupSkirmishState` passes `m_objects` (already available)
- `cGame_logic.cpp` passes `m_gameSettings.get(), getMouse()` to updated `cMapCamera` constructor

Part of #1254 (step 6).