### PR TITLE
Step 8 of 15: src/sidebar/ has zero game. references

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -189,9 +189,6 @@ cGame::cGame()
     m_players = m_gameObjectsContext->getPlayers();
     d2tm_assert(m_players != nullptr);
 
-    m_sideBarFactory = std::make_unique<cSideBarFactory>();
-    m_buildingListFactory = std::make_unique<cBuildingListFactory>();
-
     m_eventEmitter = std::make_unique<cEventEmitter>(
         [this](const s_GameEvent &event) {
             dispatchGameEvent(event);
@@ -206,6 +203,9 @@ cGame::cGame()
     m_services->structureUtils = m_structureUtils.get();
     m_services->m_log = nullptr;
     m_services->eventEmitter = m_eventEmitter.get();
+
+    m_buildingListFactory = std::make_unique<cBuildingListFactory>(m_gameSettings.get());
+    m_sideBarFactory = std::make_unique<cSideBarFactory>(m_buildingListFactory.get(), m_services.get());
 
     m_cIni = std::make_unique<cIni>(m_services.get());
 }

--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -1712,7 +1712,7 @@ void cPlayer::onNotifyGameEvent(const s_GameEvent &event)
                     };
                     m_interface->onNotifyGameEvent(newEvent);
                 }
-                if (cBuildingListItem::isAutoBuild(buildEvent->entityType, buildEvent->entitySpecificType)) {
+                if (cBuildingListItem::isAutoBuild(buildEvent->entityType, buildEvent->entitySpecificType, m_infos)) {
                     startBuilding(buildEvent->entityType, buildEvent->entitySpecificType);
                 }
             }
@@ -1721,7 +1721,7 @@ void cPlayer::onNotifyGameEvent(const s_GameEvent &event)
         case eGameEventType::GAME_EVENT_LIST_ITEM_ADDED:
         case eGameEventType::GAME_EVENT_LIST_ITEM_CANCELLED:
             if (const auto *buildEvent = std::get_if<BuildingEvent>(&event.data)) {
-                if (buildEvent->player == this && cBuildingListItem::isAutoBuild(buildEvent->entityType, buildEvent->entitySpecificType)) {
+                if (buildEvent->player == this && cBuildingListItem::isAutoBuild(buildEvent->entityType, buildEvent->entitySpecificType, m_infos)) {
                     startBuilding(buildEvent->entityType, buildEvent->entitySpecificType);
                 }
             }

--- a/src/gameobjects/players/cPlayers.cpp
+++ b/src/gameobjects/players/cPlayers.cpp
@@ -17,6 +17,7 @@
 #include "controls/cMouse.h"
 #include "gameobjects/structures/cOrderProcesser.h"
 #include "sidebar/cBuildingListUpdater.h"
+#include "sidebar/cSideBar.h"
 #include "sidebar/cSideBarFactory.h"
 #include "utils/cLog.h"
 #include "brains/cPlayerBrainSkirmish.h"
@@ -110,12 +111,14 @@ void cPlayers::setupRuntimePlayerComponents(cSideBarFactory* sideBarFactory, cMo
         cPlayer* player = m_players[i];
 
         auto buildingListUpdater = std::make_unique<cBuildingListUpdater>(player);
+        buildingListUpdater->serviceInit(services);
         auto itemBuilder = std::make_unique<cItemBuilder>(player, buildingListUpdater.get());
         itemBuilder->serviceInit(services);
         player->setBuildingListUpdater(std::move(buildingListUpdater));
         player->setItemBuilder(std::move(itemBuilder));
 
         auto sidebar = sideBarFactory->createSideBar(player);
+        sidebar->serviceInit(services);
         player->setSideBar(sidebar);
 
         auto orderProcesser = std::make_unique<cOrderProcesser>(player);

--- a/src/sidebar/cBuildingList.cpp
+++ b/src/sidebar/cBuildingList.cpp
@@ -1,9 +1,9 @@
 #include "cBuildingList.h"
 #include "context/cInfoContext.h"
-#include "context/cGameObjectContext.h"
 #include "building/cItemBuilder.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
+#include "context/GameContext.hpp"
+#include "game/cGameInterface.h"
+#include "include/sGameServices.h"
 #include "utils/common.h"
 
 #include <vector>
@@ -80,7 +80,7 @@ cBuildingListItem *cBuildingList::getItemByBuildId(int buildId)
 
 void cBuildingList::addUpgradeToList(int upgradeType)
 {
-    auto upgradeInfo = game.m_infoContext->getUpgradeInfo(upgradeType);
+    auto upgradeInfo = m_info->getUpgradeInfo(upgradeType);
     cBuildingListItem *item = new cBuildingListItem(
         upgradeType,
         upgradeInfo
@@ -93,7 +93,7 @@ void cBuildingList::addUpgradeToList(int upgradeType)
 
 void cBuildingList::addStructureToList(int structureType, int subList)
 {
-    cBuildingListItem *item = new cBuildingListItem(structureType, game.m_infoContext->getStructureInfo(structureType), subList);
+    cBuildingListItem *item = new cBuildingListItem(structureType, m_info->getStructureInfo(structureType), subList);
     if (!addItemToList(item)) {
         delete item;
     }
@@ -101,7 +101,7 @@ void cBuildingList::addStructureToList(int structureType, int subList)
 
 void cBuildingList::addUnitToList(int unitType, int subList)
 {
-    cBuildingListItem *item = new cBuildingListItem(unitType, game.m_infoContext->getUnitInfo(unitType), subList);
+    cBuildingListItem *item = new cBuildingListItem(unitType, m_info->getUnitInfo(unitType), subList);
     if (!addItemToList(item)) {
         delete item;
     }
@@ -109,7 +109,7 @@ void cBuildingList::addUnitToList(int unitType, int subList)
 
 void cBuildingList::addSpecialToList(int specialType, int subList)
 {
-    s_SpecialInfo &special = game.m_infoContext->getSpecialInfo(specialType);
+    s_SpecialInfo &special = m_info->getSpecialInfo(specialType);
     cBuildingListItem *item = new cBuildingListItem(specialType, special, subList);
     if (!addItemToList(item)) {
         delete item;
@@ -134,6 +134,7 @@ bool cBuildingList::addItemToList(cBuildingListItem *item)
     m_items[slotId] = item;
     item->setSlotId(slotId);
     item->setList(this);
+    item->serviceInit(m_info, m_settings, m_gameInterface);
     m_maxItems = slotId + 1;
 
     // notify game that the item just has been added!
@@ -149,7 +150,7 @@ bool cBuildingList::addItemToList(cBuildingListItem *item)
             .buildingListItem = item
         }
     };
-    game.onNotifyGameEvent(event);
+    m_gameInterface->onNotifyGameEvent(event);
 
     if (isAvailable() != beforeAddingAvailable) {
         // emit another event that this list became available! (so that sidebar can animate things)
@@ -163,7 +164,7 @@ bool cBuildingList::addItemToList(cBuildingListItem *item)
                 .buildingList = this
             }
         };
-        game.onNotifyGameEvent(event);
+        m_gameInterface->onNotifyGameEvent(event);
     }
 
     startFlashing();
@@ -232,7 +233,7 @@ bool cBuildingList::removeItemFromList(int position)
                 .buildingList = this
             }
         };
-        game.onNotifyGameEvent(event);
+        m_gameInterface->onNotifyGameEvent(event);
     }
     return true;
 }
@@ -428,9 +429,16 @@ void cBuildingList::setItemBuilder(cItemBuilder *value)
     m_itemBuilder = value;
 }
 
+void cBuildingList::serviceInit(sGameServices* services)
+{
+    m_info = services->info;
+    m_gameInterface = services->ctx->getGameInterface();
+    m_settings = services->settings;
+}
+
 Color cBuildingList::getFlashingColor()
 {
-    return game.getColorFadeSelected(255, 209, 64);
+    return m_gameInterface->getColorFadeSelected(255, 209, 64);
 }
 
 void cBuildingList::think()

--- a/src/sidebar/cBuildingList.h
+++ b/src/sidebar/cBuildingList.h
@@ -9,6 +9,10 @@
 #include "utils/Color.hpp"
 
 class cItemBuilder;
+class cInfoContext;
+class cGameInterface;
+class cGameSettings;
+struct sGameServices;
 
 /**
  *
@@ -141,6 +145,7 @@ public:
     void resetTimesOrderedForAllItems();
 
     void setItemBuilder(cItemBuilder *value);
+    void serviceInit(sGameServices* services);
 
     void startFlashing();
 
@@ -176,6 +181,9 @@ private:
     cBuildingListItem *m_items[MAX_ITEMS];
 
     cItemBuilder *m_itemBuilder;
+    cInfoContext* m_info = nullptr;
+    cGameInterface* m_gameInterface = nullptr;
+    cGameSettings* m_settings = nullptr;
 
     int getFreeSlot();
 

--- a/src/sidebar/cBuildingListFactory.cpp
+++ b/src/sidebar/cBuildingListFactory.cpp
@@ -1,10 +1,8 @@
 #include "cBuildingListFactory.h"
 #include "game/cGameSettings.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "data/gfxinter.h"
 
-cBuildingListFactory::cBuildingListFactory()
+cBuildingListFactory::cBuildingListFactory(cGameSettings* settings) : m_settings(settings)
 {}
 
 int cBuildingListFactory::getButtonDrawY()
@@ -16,7 +14,7 @@ int cBuildingListFactory::getButtonDrawY()
 
 int cBuildingListFactory::getButtonDrawXStart()
 {
-    return (game.m_gameSettings->getScreenW() - 200) + 2;
+    return (m_settings->getScreenW() - 200) + 2;
 }
 
 

--- a/src/sidebar/cBuildingListFactory.h
+++ b/src/sidebar/cBuildingListFactory.h
@@ -2,10 +2,12 @@
 
 #include "sidebar/cBuildingList.h"
 
+class cGameSettings;
+
 class cBuildingListFactory {
 
 public:
-    cBuildingListFactory();
+    explicit cBuildingListFactory(cGameSettings* settings);
     ~cBuildingListFactory() = default;
     void initializeList(cBuildingList *list, eListType listType);
     cBuildingList *createList(eListType listType);
@@ -13,4 +15,7 @@ public:
 protected:
     int getButtonDrawY();
     int getButtonDrawXStart();
+
+private:
+    cGameSettings* m_settings;
 };

--- a/src/sidebar/cBuildingListItem.cpp
+++ b/src/sidebar/cBuildingListItem.cpp
@@ -1,11 +1,10 @@
 #include "cBuildingListItem.h"
 
 #include "utils/cLog.h"
-#include "game/cGame.h"
 #include "utils/common.h"
-#include "include/d2tmc.h"
 #include "sidebar/cBuildingList.h"
 #include "context/cInfoContext.h"
+#include "game/cGameInterface.h"
 #include "game/cGameSettings.h"
 #include <format>
 #include "include/cAssert.h"
@@ -35,23 +34,30 @@ cBuildingListItem::cBuildingListItem(eBuildType type, int buildId, int cost, int
     m_TIMER_progressFrame = 0.0f;
     m_TIMER_flashing = 500;
 
-    m_timerCap = game.m_gameSettings->isCheatMode() ? cBuildingListItem::DebugTimerCap : cBuildingListItem::DefaultTimerCap;
+    m_timerCap = DefaultTimerCap;
 
     m_myList = list; // this can be nullptr! (it will be set from the outside by cBuildingList convenience methods)
 
-    int totalBuildTime = getTotalBuildTime();
-    if (m_cost > 0 && totalBuildTime > 0) {
-        m_creditsPerProgressTime = (float)m_cost / (float)totalBuildTime;
-    }
-
     cLogger::getInstance()->log(LOG_DEBUG, COMP_STRUCTURES, "cBuildingListItem",
-        std::format("constructor [{}], cost = {}, totalBuildTime = {}, creditsPerProgressTime = {}",
-            getNameString().c_str(), m_cost, totalBuildTime, m_creditsPerProgressTime));
+        std::format("constructor [{}], cost = {}, creditsPerProgressTime = {}",
+            getNameString().c_str(), m_cost, m_creditsPerProgressTime));
 }
 
 cBuildingListItem::~cBuildingListItem()
 {
     m_myList = NULL;
+}
+
+void cBuildingListItem::serviceInit(cInfoContext* info, cGameSettings* settings, cGameInterface* gameInterface)
+{
+    m_info = info;
+    m_settings = settings;
+    m_gameInterface = gameInterface;
+    m_timerCap = m_settings->isCheatMode() ? DebugTimerCap : DefaultTimerCap;
+    int totalBuildTime = getTotalBuildTime();
+    if (m_cost > 0 && totalBuildTime > 0) {
+        m_creditsPerProgressTime = (float)m_cost / (float)totalBuildTime;
+    }
 }
 
 /**
@@ -148,16 +154,16 @@ void cBuildingListItem::increaseProgress(int byAmount)
 int cBuildingListItem::getTotalBuildTime() const
 {
     if (m_type == STRUCTURE) {
-        return game.m_infoContext->getStructureInfo(m_buildId).buildTime;
+        return m_info->getStructureInfo(m_buildId).buildTime;
     }
     if (m_type == UPGRADE) {
-        return game.m_infoContext->getUpgradeInfo(m_buildId).buildTime;
+        return m_info->getUpgradeInfo(m_buildId).buildTime;
     }
     if (m_type == SPECIAL) {
-        return game.m_infoContext->getSpecialInfo(m_buildId).buildTime;
+        return m_info->getSpecialInfo(m_buildId).buildTime;
     }
     // assumes units by default
-    return game.m_infoContext->getUnitInfo(m_buildId).buildTime;
+    return m_info->getUnitInfo(m_buildId).buildTime;
 }
 
 bool cBuildingListItem::isDoneBuilding()
@@ -197,7 +203,7 @@ s_UpgradeInfo &cBuildingListItem::getUpgradeInfo()
         logbook("ERROR!!! - calling getUpgradeInfo while type is not UPGRADE! - falling back to buildId 1 as safety");
         buildId = 1;
     }
-    return game.m_infoContext->getUpgradeInfo(buildId);
+    return m_info->getUpgradeInfo(buildId);
 }
 
 s_SpecialInfo &cBuildingListItem::getSpecialInfo()
@@ -207,7 +213,7 @@ s_SpecialInfo &cBuildingListItem::getSpecialInfo()
         logbook("ERROR!!! - calling gets_Special while type is not SPECIAL! - falling back to buildId 1 as safety");
         buildId = 1;
     }
-    return game.m_infoContext->getSpecialInfo(buildId);
+    return m_info->getSpecialInfo(buildId);
 }
 
 s_UnitInfo &cBuildingListItem::getUnitInfo()
@@ -217,7 +223,7 @@ s_UnitInfo &cBuildingListItem::getUnitInfo()
         logbook("ERROR!!! - calling getUnitInfo while type is not UNIT! - falling back to buildId 1 as safety");
         buildId = 1;
     }
-    return game.m_infoContext->getUnitInfo(buildId);
+    return m_info->getUnitInfo(buildId);
 }
 
 s_StructureInfo &cBuildingListItem::getStructureInfo()
@@ -227,7 +233,7 @@ s_StructureInfo &cBuildingListItem::getStructureInfo()
         logbook("ERROR!!! - calling getStructureInfo while type is not STRUCTURE! - falling back to buildId 1 as safety");
         buildId = 1;
     }
-    return game.m_infoContext->getStructureInfo(buildId);
+    return m_info->getStructureInfo(buildId);
 }
 
 void cBuildingListItem::resetTimesOrdered()
@@ -314,21 +320,21 @@ int cBuildingListItem::getProgressBuildTimeInMs()
     return getInTicks(m_progress) * 5; // 5 = ms for every time we call the itemBuilder
 }
 
-int cBuildingListItem::getTotalBuildTimeInTicks(eBuildType type, int buildId)
+int cBuildingListItem::getTotalBuildTimeInTicks(eBuildType type, int buildId, cInfoContext* info)
 {
     int buildTime = 0;
     switch (type) {
         case UNIT:
-            buildTime = game.m_infoContext->getUnitInfo(buildId).buildTime;
+            buildTime = info->getUnitInfo(buildId).buildTime;
             break;
         case STRUCTURE:
-            buildTime = game.m_infoContext->getStructureInfo(buildId).buildTime;
+            buildTime = info->getStructureInfo(buildId).buildTime;
             break;
         case SPECIAL:
-            buildTime = game.m_infoContext->getSpecialInfo(buildId).buildTime;
+            buildTime = info->getSpecialInfo(buildId).buildTime;
             break;
         case UPGRADE:
-            buildTime = game.m_infoContext->getUpgradeInfo(buildId).buildTime;
+            buildTime = info->getUpgradeInfo(buildId).buildTime;
             break;
         case BULLET:
         default:
@@ -338,18 +344,18 @@ int cBuildingListItem::getTotalBuildTimeInTicks(eBuildType type, int buildId)
     return buildTime * 35;
 }
 
-int cBuildingListItem::getListId(eBuildType type, int buildId)
+int cBuildingListItem::getListId(eBuildType type, int buildId, cInfoContext* info)
 {
     switch (type) {
         case UNIT:
-            return eListTypeAsInt(game.m_infoContext->getUnitInfo(buildId).listType);
+            return eListTypeAsInt(info->getUnitInfo(buildId).listType);
         case STRUCTURE:
-            return game.m_infoContext->getStructureInfo(buildId).list;
+            return info->getStructureInfo(buildId).list;
         case SPECIAL:
-            return eListTypeAsInt(game.m_infoContext->getSpecialInfo(buildId).listType);
+            return eListTypeAsInt(info->getSpecialInfo(buildId).listType);
             break;
         case UPGRADE:
-//            return game.m_infoContext->getUpgradeInfo(buildId).;
+//            return info->getUpgradeInfo(buildId).;
             return eListTypeAsInt(eListType::LIST_UPGRADES);
             break;
         default:
@@ -357,11 +363,11 @@ int cBuildingListItem::getListId(eBuildType type, int buildId)
     }
 }
 
-bool cBuildingListItem::isAutoBuild(eBuildType type, int buildId)
+bool cBuildingListItem::isAutoBuild(eBuildType type, int buildId, cInfoContext* info)
 {
     switch (type) {
         case SPECIAL:
-            return game.m_infoContext->getSpecialInfo(buildId).autoBuild;
+            return info->getSpecialInfo(buildId).autoBuild;
         default:
             return false;
     }
@@ -369,7 +375,7 @@ bool cBuildingListItem::isAutoBuild(eBuildType type, int buildId)
 
 bool cBuildingListItem::isAutoBuild()
 {
-    return cBuildingListItem::isAutoBuild(m_type, m_buildId);
+    return cBuildingListItem::isAutoBuild(m_type, m_buildId, m_info);
 }
 
 std::string cBuildingListItem::getInfo()
@@ -391,7 +397,7 @@ std::string cBuildingListItem::getInfo()
             msg = std::format("${} | {} | {} Secs", getBuildCost(), unitType.name, seconds);
         }
         else {
-            msg = std::format("{} | {} Secs", game.m_infoContext->getUnitInfo(getBuildId()).name, seconds);
+            msg = std::format("{} | {} Secs", m_info->getUnitInfo(getBuildId()).name, seconds);
         }
     }
     else if (isTypeUpgrade()) {

--- a/src/sidebar/cBuildingListItem.cpp
+++ b/src/sidebar/cBuildingListItem.cpp
@@ -39,8 +39,7 @@ cBuildingListItem::cBuildingListItem(eBuildType type, int buildId, int cost, int
     m_myList = list; // this can be nullptr! (it will be set from the outside by cBuildingList convenience methods)
 
     cLogger::getInstance()->log(LOG_DEBUG, COMP_STRUCTURES, "cBuildingListItem",
-        std::format("constructor [{}], cost = {}, creditsPerProgressTime = {}",
-            getNameString().c_str(), m_cost, m_creditsPerProgressTime));
+        std::format("constructor [type={}, id={}], cost = {}", eBuildTypeString(m_type), m_buildId, m_cost));
 }
 
 cBuildingListItem::~cBuildingListItem()

--- a/src/sidebar/cBuildingListItem.h
+++ b/src/sidebar/cBuildingListItem.h
@@ -11,6 +11,9 @@
 #include "include/enums.h"
 
 class cBuildingList;
+class cInfoContext;
+class cGameInterface;
+class cGameSettings;
 struct s_SpecialInfo;
 struct s_UpgradeInfo;
 struct s_UnitInfo;
@@ -30,6 +33,8 @@ public:
     cBuildingListItem(int theID, s_SpecialInfo entry, int subList);
     cBuildingListItem(int theID, s_UnitInfo entry, int subList);
     cBuildingListItem(int theID, s_UpgradeInfo entry);
+
+    void serviceInit(cInfoContext* info, cGameSettings* settings, cGameInterface* gameInterface);
 
     static const int DefaultTimerCap = 35;
     static const int DebugTimerCap = 2;
@@ -248,9 +253,9 @@ public:
 
     int getTotalBuildTimeInTicks() const;
 
-    static int getTotalBuildTimeInTicks(eBuildType type, int buildId);
-    static int getListId(eBuildType type, int buildId);
-    static bool isAutoBuild(eBuildType type, int buildId);
+    static int getTotalBuildTimeInTicks(eBuildType type, int buildId, cInfoContext* info);
+    static int getListId(eBuildType type, int buildId, cInfoContext* info);
+    static bool isAutoBuild(eBuildType type, int buildId, cInfoContext* info);
 
     bool isAutoBuild();
 
@@ -288,6 +293,9 @@ private:
     int m_timerCap;           // passed in by item builder (determined by power outage, etc)
 
     cBuildingList *m_myList;
+    cInfoContext* m_info = nullptr;
+    cGameSettings* m_settings = nullptr;
+    cGameInterface* m_gameInterface = nullptr;
 
     cBuildingListItem(int theID, s_StructureInfo entry, cBuildingList *list, int subList);
     cBuildingListItem(int theID, s_UnitInfo entry, cBuildingList *list, int subList);

--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -1,14 +1,12 @@
 #include "cBuildingListUpdater.h"
 #include "building/cItemBuilder.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/players/cPlayer.h"
 #include "utils/cLog.h"
 #include "sidebar/cSideBar.h"
 #include "gameobjects/structures/cOrderProcesser.h"
 #include "context/cInfoContext.h"
-#include "context/cGameObjectContext.h"
 #include "game/cGameSettings.h"
+#include "include/sGameServices.h"
 
 #include <format>
 #include "include/cAssert.h"
@@ -17,6 +15,12 @@ cBuildingListUpdater::cBuildingListUpdater(cPlayer *thePlayer)
 {
     d2tm_assert(thePlayer!=nullptr);
     m_player = thePlayer;
+}
+
+void cBuildingListUpdater::serviceInit(sGameServices* services)
+{
+    m_info = services->info;
+    m_settings = services->settings;
 }
 
 void cBuildingListUpdater::onStructureCreated(int structureType)
@@ -31,7 +35,7 @@ void cBuildingListUpdater::onStructureCreated(int structureType)
     else {
         // AI m_players...
 
-        if (game.m_gameSettings->isSkirmish()) {
+        if (m_settings->isSkirmish()) {
             // on skirmish mode use the 'strict' / no cheating mode (same as human m_players)
             onStructureCreatedSkirmishMode(structureType);
             evaluateUpgrades();
@@ -500,7 +504,7 @@ void cBuildingListUpdater::onStructureDestroyed(int structureType)
     else {
         // AI m_players...
 
-        if (game.m_gameSettings->isSkirmish()) {
+        if (m_settings->isSkirmish()) {
             // on skirmish mode use the 'strict' / no cheating mode (same as human m_players)
             onStructureDestroyedSkirmishMode();
             evaluateUpgrades();
@@ -524,7 +528,7 @@ void cBuildingListUpdater::evaluateUpgrades()
     cBuildingList *listUpgrades = sideBar->getList(eListType::LIST_UPGRADES);
 
     for (int i = 0; i < MAX_UPGRADETYPES; i++) {
-        s_UpgradeInfo &upgradeInfo = game.m_infoContext->getUpgradeInfo(i);
+        s_UpgradeInfo &upgradeInfo = m_info->getUpgradeInfo(i);
         if (!upgradeInfo.enabled) continue;
         // check techlevel (this is a non-changing value per mission, usually coupled with mission nr, ie
         // mission 1 = techlevel 1. Mission 9 = techlevel 9. Skirmish is usually techlevel 9.
@@ -543,7 +547,7 @@ void cBuildingListUpdater::evaluateUpgrades()
         if (!hasRequiredStructureType) {
             addToUpgradesList = false;
             m_player->log(std::format("Upgrade [{}] has not required structureType (upgradeInfo.structureType) #1 [{}].",
-                                    upgradeInfo.description, game.m_infoContext->getStructureInfo(upgradeInfo.structureType).name));
+                                    upgradeInfo.description, m_info->getStructureInfo(upgradeInfo.structureType).name));
         }
 
         // check if m_player has the additional structure (if required)
@@ -552,7 +556,7 @@ void cBuildingListUpdater::evaluateUpgrades()
             if (!hasRequiredStructureType) {
                 addToUpgradesList = false;
                 m_player->log(std::format("Upgrade [{}] has not required additional structureType (upgradeInfo.needsStructureType) [{}].",
-                                        upgradeInfo.description, game.m_infoContext->getStructureInfo(upgradeInfo.needsStructureType).name));
+                                        upgradeInfo.description, m_info->getStructureInfo(upgradeInfo.needsStructureType).name));
             }
         }
 

--- a/src/sidebar/cBuildingListUpdater.h
+++ b/src/sidebar/cBuildingListUpdater.h
@@ -3,10 +3,14 @@
 #include "cBuildingListItem.h"
 
 class cPlayer;
+class cInfoContext;
+class cGameSettings;
+struct sGameServices;
 
 class cBuildingListUpdater {
 public:
     explicit cBuildingListUpdater(cPlayer *thePlayer);
+    void serviceInit(sGameServices* services);
 
     // update methods are event based. Ie, when structure is created,
     // when structure is destroyed, etc
@@ -36,6 +40,8 @@ private:
     // this player will be used to read state from
     // in order to know what to update
     cPlayer *m_player;
+    cInfoContext* m_info = nullptr;
+    cGameSettings* m_settings = nullptr;
 
     void applyUpgrade(const s_UpgradeInfo &upgradeType);
 

--- a/src/sidebar/cSideBar.cpp
+++ b/src/sidebar/cSideBar.cpp
@@ -1,15 +1,15 @@
 #include "cSideBar.h"
 #include "game/cGameSettings.h"
 #include "building/cItemBuilder.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "managers/cDrawManager.h"
 #include "gameobjects/players/cPlayer.h"
 #include "utils/cLog.h"
-#include "utils/cSoundPlayer.h"
 #include "controls/cGameControlsContext.h"
 #include "gameobjects/structures/cOrderProcesser.h"
 #include "data/gfxaudio.h"
+#include "game/cGameInterface.h"
+#include "context/GameContext.hpp"
+#include "include/sGameServices.h"
 
 #include <format>
 #include "include/cAssert.h"
@@ -55,9 +55,16 @@ void cSideBar::think()
     thinkProgressAnimation();
 }
 
+void cSideBar::serviceInit(sGameServices* services)
+{
+    m_gameInterface = services->ctx->getGameInterface();
+    m_drawManager = m_gameInterface->getDrawManager();
+    m_settings = services->settings;
+}
+
 void cSideBar::drawMessageBarWithItemInfo(cBuildingListItem *item) const
 {
-    game.m_drawManager->setMessage(item->getInfo());
+    m_drawManager->setMessage(item->getInfo());
 }
 
 bool cSideBar::startBuildingItemIfOk(cBuildingListItem *item) const
@@ -137,14 +144,14 @@ void cSideBar::thinkProgressAnimation()
 
 void cSideBar::onMouseAt(const s_MouseEvent &event)
 {
-    m_isMouseOverSidebarValue = event.coords.x > (game.m_gameSettings->getScreenW() - cSideBar::SidebarWidth);
-    game.m_drawManager->setKeepMessage(m_isMouseOverSidebarValue);
+    m_isMouseOverSidebarValue = event.coords.x > (m_settings->getScreenW() - cSideBar::SidebarWidth);
+    m_drawManager->setKeepMessage(m_isMouseOverSidebarValue);
 
     if (m_selectedListID < 0) return;
 
     // when mouse is selecting a list, and over an item, then draw message bar...!?
     cBuildingList *list = getList(m_selectedListID);
-    cBuildingListDrawer *buildingListDrawer = game.m_drawManager->getBuildingListDrawer();
+    cBuildingListDrawer *buildingListDrawer = m_drawManager->getBuildingListDrawer();
     cBuildingListItem *item = buildingListDrawer->isOverItemCoordinates(list, event.coords.x, event.coords.y);
     if (item == nullptr) return;
 
@@ -168,7 +175,7 @@ void cSideBar::onMouseClickedLeft(const s_MouseEvent &event)
         if (list->isOverButton(event.coords.x, event.coords.y)) {
             // clicked on it. Set focus on this one
             setSelectedListId(eListTypeFromInt(i));
-            game.playSound(SOUND_BUTTON, 64); // click sound
+            m_gameInterface->playSound(SOUND_BUTTON); // click sound
             break;
         }
     }
@@ -186,14 +193,14 @@ void cSideBar::onMouseClickedLeft(const s_MouseEvent &event)
         return;
     }
 
-    cOrderDrawer *orderDrawer = game.m_drawManager->getOrderDrawer();
+    cOrderDrawer *orderDrawer = m_drawManager->getOrderDrawer();
 
     // allow clicking on the order button, send event through...
     if (list->getType() == eListType::LIST_STARPORT) {
         orderDrawer->onNotify(event);
     }
 
-    cBuildingListDrawer *buildingListDrawer = game.m_drawManager->getBuildingListDrawer();
+    cBuildingListDrawer *buildingListDrawer = m_drawManager->getBuildingListDrawer();
     cBuildingListItem *item = buildingListDrawer->isOverItemCoordinates(list, event.coords.x, event.coords.y);
     if (item == nullptr) return;
 
@@ -236,7 +243,7 @@ void cSideBar::onMouseClickedRight(const s_MouseEvent &event)
     // when mouse pressed, build item if over item
     cBuildingList *list = getList(m_selectedListID);
 
-    cBuildingListDrawer *buildingListDrawer = game.m_drawManager->getBuildingListDrawer();
+    cBuildingListDrawer *buildingListDrawer = m_drawManager->getBuildingListDrawer();
     cBuildingListItem *item = buildingListDrawer->isOverItemCoordinates(list, event.coords.x, event.coords.y);
     if (item == nullptr) return;
 
@@ -289,7 +296,7 @@ void cSideBar::cancelBuildingListItem(cBuildingListItem *item)
                     .buildingListItem = item
                 }
             };
-            game.onNotifyGameEvent(event);
+            m_gameInterface->onNotifyGameEvent(event);
             // else, only the number is decreased (used for queueing)
 
             cItemBuilder *itemBuilder = m_player->getItemBuilder();

--- a/src/sidebar/cSideBar.h
+++ b/src/sidebar/cSideBar.h
@@ -19,6 +19,10 @@
 #include "controls/sMouseEvent.h"
 
 class cPlayer;
+class cGameInterface;
+class cDrawManager;
+class cGameSettings;
+struct sGameServices;
 
 //// List ID's corresponding buttons
 //#define LIST_NONE        0
@@ -95,6 +99,8 @@ public:
     static const int TotalHeightBeforePowerBarStarts =
         TopBarHeight + HeightOfMinimap + HorizontalCandyBarHeight + PowerBarMarginHeight;
 
+    void serviceInit(sGameServices* services);
+
     void onNotifyMouseEvent(const s_MouseEvent &event);
 
     void cancelBuildingListItem(cBuildingListItem *item);
@@ -111,6 +117,9 @@ private:
     // the lists:
     cBuildingList *m_lists[LIST_MAX];
     cPlayer *m_player;
+    cGameInterface* m_gameInterface = nullptr;
+    cDrawManager* m_drawManager = nullptr;
+    cGameSettings* m_settings = nullptr;
 
     bool m_isMouseOverSidebarValue;
 

--- a/src/sidebar/cSideBarFactory.cpp
+++ b/src/sidebar/cSideBarFactory.cpp
@@ -1,13 +1,13 @@
 #include "cSideBarFactory.h"
 #include "cSideBar.h"
 #include "gameobjects/players/cPlayer.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "cBuildingListFactory.h"
+#include "include/sGameServices.h"
 
 #include "include/cAssert.h"
 
-cSideBarFactory::cSideBarFactory()
+cSideBarFactory::cSideBarFactory(cBuildingListFactory* buildingListFactory, sGameServices* services)
+    : m_buildingListFactory(buildingListFactory), m_services(services)
 {}
 
 cSideBarFactory::~cSideBarFactory()
@@ -20,9 +20,10 @@ cSideBar *cSideBarFactory::createSideBar(cPlayer *thePlayer)
     cSideBar *sidebar = new cSideBar(thePlayer);
 
     for (const auto listType : AllListTypes) {
-        cBuildingList *list = game.m_buildingListFactory->createList(listType);
+        cBuildingList *list = m_buildingListFactory->createList(listType);
         sidebar->setList(listType, list);
         list->setItemBuilder(thePlayer->getItemBuilder()); // TODO: this should be easier!?
+        list->serviceInit(m_services);
     }
     return sidebar;
 }

--- a/src/sidebar/cSideBarFactory.h
+++ b/src/sidebar/cSideBarFactory.h
@@ -2,12 +2,15 @@
 
 class cSideBar;
 class cPlayer;
+class cBuildingListFactory;
+struct sGameServices;
 
 class cSideBarFactory {
 public:
-    cSideBar *createSideBar(cPlayer *thePlayer);
-    cSideBarFactory();
+    cSideBarFactory(cBuildingListFactory* buildingListFactory, sGameServices* services);
     ~cSideBarFactory();
+    cSideBar *createSideBar(cPlayer *thePlayer);
 private:
-
+    cBuildingListFactory* m_buildingListFactory;
+    sGameServices* m_services;
 };


### PR DESCRIPTION
## Summary

- `cBuildingListFactory` takes `cGameSettings*` in constructor (replaces `game.m_gameSettings->`)
- `cSideBarFactory` takes `cBuildingListFactory*` and `sGameServices*` in constructor
- `cBuildingList` gains `serviceInit(sGameServices*)`; `item->serviceInit` called from `addItemToList`
- `cBuildingListItem` gains `serviceInit(cInfoContext*, cGameSettings*, cGameInterface*)`; constructor defers `m_timerCap` and `m_creditsPerProgressTime` computation to `serviceInit`; constructor log no longer calls `getNameString()` (which requires `m_info`, only set in `serviceInit`)
- `cBuildingListItem` static methods gain explicit `cInfoContext*` parameter
- `cBuildingListUpdater` gains `serviceInit(sGameServices*)`
- `cSideBar` gains `serviceInit(sGameServices*)` to receive `drawManager`, `gameInterface`, and `settings`
- `cPlayers::setupRuntimePlayerComponents` calls `serviceInit` on `buildingListUpdater` and `sidebar`
- `cGame_logic`: factories created after `m_services` is fully initialised

Part of #1254.

## Test plan

- [x] `./rebuildmacos.sh` passes with zero errors
- [x] `grep -r "game\." src/sidebar/` returns empty
- [x] Skirmish mode no longer crashes on launch (null `m_info` in constructor log fixed)