### PR TITLE
Step 9 of 15: src/gameobjects/players/ has zero game. references

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -282,7 +282,7 @@ void cGame::init()
 
     map->init(64, 64);
 
-    m_players->initPlayers(false, m_gameSettings.get(), m_dataCampaign.get());
+    m_players->initPlayers(false, m_gameSettings.get(), m_dataCampaign.get(), m_services.get());
 
     for (int i = 0; i < m_gameObjectsContext->getUnits()->size(); i++) {
         m_gameObjectsContext->getUnit(i)->init(i);
@@ -334,7 +334,7 @@ void cGame::missionInit()
         bullet.init();
     }
 
-    m_players->initPlayers(true, m_gameSettings.get(), m_dataCampaign.get());
+    m_players->initPlayers(true, m_gameSettings.get(), m_dataCampaign.get(), m_services.get());
 
     m_drawManager->missionInit();
 }
@@ -944,7 +944,7 @@ void cGame::setState(int newState)
                 newStatePtr = pState;
             }
             else if (newState == GAME_SETUPSKIRMISH) {
-                m_players->initPlayers(false, m_gameSettings.get(), m_dataCampaign.get());
+                m_players->initPlayers(false, m_gameSettings.get(), m_dataCampaign.get(), m_services.get());
                 auto previewMaps = m_gameObjectsContext->getPreviewMaps();
                 newStatePtr = new cSetupSkirmishState(m_services.get(), previewMaps, m_dataCampaign.get());
                 playMusicByTypeForStateTransition(MUSIC_MENU);

--- a/src/gameobjects/players/brains/actions/cRespondToThreatAction.cpp
+++ b/src/gameobjects/players/brains/actions/cRespondToThreatAction.cpp
@@ -1,8 +1,6 @@
 #include "cRespondToThreatAction.h"
 
 #include "gameobjects/players/cPlayer.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
 #include "gameobjects/units/cUnits.h"
 #include "context/cInfoContext.h"
@@ -53,7 +51,7 @@ void cRespondToThreatAction::execute()
             int unitsOrdered = 0;
             // find units that can counter-attack an air unit
             for (auto &ufd: units) {
-                cUnit *pUnit = game.m_gameObjectsContext->getUnit(ufd.entityId);
+                cUnit *pUnit = m_player->getObjects()->getUnit(ufd.entityId);
                 if (pUnit->iID == skipThisUnit) continue;
                 if (!pUnit->isIdle()) continue;
                 if (!pUnit->canAttackAirUnits()) continue;
@@ -73,7 +71,7 @@ void cRespondToThreatAction::execute()
     int unitsOrdered = 0;
 
     for (auto &ufd : units) {
-        cUnit *pUnit = game.m_gameObjectsContext->getUnit(ufd.entityId);
+        cUnit *pUnit = m_player->getObjects()->getUnit(ufd.entityId);
         if (pUnit->iID == skipThisUnit) continue;
         if (!pUnit->isIdle()) continue;
         if (!pUnit->isAttackingUnit()) continue; // is a unit that is used generally for attacking

--- a/src/gameobjects/players/brains/cPlayerBrain.cpp
+++ b/src/gameobjects/players/brains/cPlayerBrain.cpp
@@ -1,4 +1,10 @@
 #include "cPlayerBrain.h"
+#include "context/cGameObjectContext.h"
+#include "context/cInfoContext.h"
+#include "game/cGameInterface.h"
+#include "game/cGameSettings.h"
+#include "context/GameContext.hpp"
+#include "include/sGameServices.h"
 #include "include/cAssert.h"
 
 namespace brains {
@@ -6,6 +12,14 @@ namespace brains {
 cPlayerBrain::cPlayerBrain(cPlayer *player) : player(player)
 {
     d2tm_assert(player != nullptr);
+}
+
+void cPlayerBrain::serviceInit(sGameServices* services)
+{
+    m_objects = services->objects;
+    m_info = services->info;
+    m_settings = services->settings;
+    m_interface = services->ctx->getGameInterface();
 }
 
 }

--- a/src/gameobjects/players/brains/cPlayerBrain.h
+++ b/src/gameobjects/players/brains/cPlayerBrain.h
@@ -5,6 +5,11 @@
 
 class cPlayer;
 class cAbstractStructure;
+class cGameObjectContext;
+class cInfoContext;
+class cGameSettings;
+class cGameInterface;
+struct sGameServices;
 
 namespace {
 
@@ -24,6 +29,8 @@ public:
 
     virtual ~cPlayerBrain() = default;
 
+    void serviceInit(sGameServices* services);
+
     /**
      * called, every 100 ms
      */
@@ -38,6 +45,10 @@ public:
 
 protected:
     cPlayer *player;
+    cGameObjectContext *m_objects = nullptr;
+    cInfoContext *m_info = nullptr;
+    cGameSettings *m_settings = nullptr;
+    cGameInterface *m_interface = nullptr;
 
 private:
 

--- a/src/gameobjects/players/brains/cPlayerBrain.h
+++ b/src/gameobjects/players/brains/cPlayerBrain.h
@@ -29,7 +29,7 @@ public:
 
     virtual ~cPlayerBrain() = default;
 
-    void serviceInit(sGameServices* services);
+    virtual void serviceInit(sGameServices* services);
 
     /**
      * called, every 100 ms

--- a/src/gameobjects/players/brains/cPlayerBrainCampaign.cpp
+++ b/src/gameobjects/players/brains/cPlayerBrainCampaign.cpp
@@ -4,8 +4,7 @@
 #include "gameobjects/particles/cParticles.h"
 #include "gameobjects/structures/cStructures.h"
 #include "game/cGameSettings.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
+#include "game/cGameInterface.h"
 #include "gameobjects/map/cMap.h"
 #include "enums.h"
 #include "gameobjects/players/cPlayer.h"
@@ -31,7 +30,7 @@ cPlayerBrainCampaign::cPlayerBrainCampaign(cPlayer *player, s_DataCampaign* data
     // timer is subtracted every 100 ms with 1 (ie, 10 == 10*100 = 1000ms == 1 second)
     // 10*60 -> 1 minute. * 4 -> 4 minutes
     m_TIMER_rest = (10 * 60) * 4;
-    if (game.m_gameSettings->isNoAiRest()) {
+    if (m_settings->isNoAiRest()) {
         m_TIMER_rest = 10;
     }
     m_myBase = std::vector<s_structurePosition>();
@@ -106,16 +105,16 @@ void cPlayerBrainCampaign::addBuildOrder(s_buildOrder order)
         std::string msg;
         if (buildOrder.buildType == eBuildType::UNIT) {
             msg = std::format("[{}] - type = UNIT, buildId = {} (={}), priority = {}, state = {}", id, buildOrder.buildId,
-                              game.m_infoContext->getUnitInfo(buildOrder.buildId).name, buildOrder.priority, eBuildOrderStateString(buildOrder.state));
+                              m_info->getUnitInfo(buildOrder.buildId).name, buildOrder.priority, eBuildOrderStateString(buildOrder.state));
         }
         else if (buildOrder.buildType == eBuildType::STRUCTURE) {
             msg = std::format("[{}] - type = STRUCTURE, buildId = {} (={}), priority = {}, place at {}, state = {}", id,
-                              buildOrder.buildId, game.m_infoContext->getStructureInfo(buildOrder.buildId).name, buildOrder.priority,
+                              buildOrder.buildId, m_info->getStructureInfo(buildOrder.buildId).name, buildOrder.priority,
                               buildOrder.placeAt, eBuildOrderStateString(buildOrder.state));
         }
         else if (buildOrder.buildType == eBuildType::SPECIAL) {
             msg = std::format("[{}] - type = SPECIAL, buildId = {} (={}), priority = {}, state = {}", id, buildOrder.buildId,
-                              game.m_infoContext->getSpecialInfo(buildOrder.buildId).description, buildOrder.priority, eBuildOrderStateString(buildOrder.state));
+                              m_info->getSpecialInfo(buildOrder.buildId).description, buildOrder.priority, eBuildOrderStateString(buildOrder.state));
         }
         else if (buildOrder.buildType == eBuildType::BULLET) {
             msg = std::format("[{}] - type = SPECIAL, buildId = {} (=NOT YET IMPLEMENTED), priority = {}, state = {}", id,
@@ -179,7 +178,7 @@ void cPlayerBrainCampaign::onNotifyGameEvent(const s_GameEvent &event)
 void cPlayerBrainCampaign::onMyStructureCreated(const CommonEvent &event)
 {
     // a structure was created, update our baseplan
-    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
+    cAbstractStructure *pStructure = m_objects->getStructures()[event.entityID];
     int placedAtCell = pStructure->getCell();
     bool foundExistingStructureInBase = false;
     for (auto &structurePosition : m_myBase) {
@@ -243,10 +242,10 @@ void cPlayerBrainCampaign::onMyUnitAttacked(const DamagedEvent &event)
     cUnit *threat = nullptr;
     if (event.originType == eBuildType::UNIT) {
         d2tm_assert(event.originId > -1);
-        threat = game.m_gameObjectsContext->getUnit(event.originId);
+        threat = m_objects->getUnit(event.originId);
     }
 
-    cUnit *victim = game.m_gameObjectsContext->getUnit(event.entityID);
+    cUnit *victim = m_objects->getUnit(event.entityID);
     if (victim->isHarvester()) {
         respondToThreat(threat, victim, event.atCell, 2 + RNG::rnd(4));
     }
@@ -255,9 +254,9 @@ void cPlayerBrainCampaign::onMyUnitAttacked(const DamagedEvent &event)
 void cPlayerBrainCampaign::onMyStructureAttacked(const DamagedEvent &event)
 {
     if (player->hasEnoughCreditsFor(50)) {
-        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
+        cAbstractStructure *pStructure = m_objects->getStructures()[event.entityID];
         if (!pStructure->isRepairing()) {
-            s_StructureInfo &sStructures = game.m_infoContext->getStructureInfo(event.entitySpecificType);
+            s_StructureInfo &sStructures = m_info->getStructureInfo(event.entitySpecificType);
             if (pStructure->getHitPoints() < sStructures.hp * 0.75) {
                 pStructure->startRepairing();
             }
@@ -267,7 +266,7 @@ void cPlayerBrainCampaign::onMyStructureAttacked(const DamagedEvent &event)
     int unitIdThatAttacks = event.originId;
     if (unitIdThatAttacks > -1) {
         // respond to something that attacks us
-        cUnit *originUnit = game.m_gameObjectsContext->getUnit(unitIdThatAttacks);
+        cUnit *originUnit = m_objects->getUnit(unitIdThatAttacks);
         if (originUnit->getPlayer()->isSameTeamAs(player)) {
             // friendly fire, ignore
             log(std::format("Unit {} who damaged my structure is from friendly player, ignoring.", unitIdThatAttacks).c_str());
@@ -282,9 +281,9 @@ void cPlayerBrainCampaign::onMyStructureAttacked(const DamagedEvent &event)
 void cPlayerBrainCampaign::onMyStructureDecayed(const CommonEvent &event)
 {
     if (player->hasEnoughCreditsFor(50)) {
-        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
+        cAbstractStructure *pStructure = m_objects->getStructures()[event.entityID];
         if (!pStructure->isRepairing()) {
-            s_StructureInfo &sStructures = game.m_infoContext->getStructureInfo(event.entitySpecificType);
+            s_StructureInfo &sStructures = m_info->getStructureInfo(event.entitySpecificType);
             if (pStructure->getHitPoints() < sStructures.hp * 0.75) {
                 pStructure->startRepairing();
             }
@@ -1738,20 +1737,20 @@ void cPlayerBrainCampaign::onEntityDiscoveredEvent(const CommonEvent &event)
             if (event.player == player) {
                 // i discovered something
                 if (event.entityType == eBuildType::UNIT) {
-                    cUnit *pUnit = game.m_gameObjectsContext->getUnit(event.entityID);
+                    cUnit *pUnit = m_objects->getUnit(event.entityID);
                     if (pUnit->isValid() && !pUnit->getPlayer()->isSameTeamAs(player)) {
                         // found enemy unit
                         m_state = ePlayerBrainState::PLAYERBRAIN_ENEMY_DETECTED;
                         m_TIMER_rest = 0; // if we where still 'resting' then stop this now.
                         m_discoveredEnemyAtCell.insert(event.atCell);
 
-                        if (m_centerOfBaseCell > -1 && game.m_gameObjectsContext->getMapGeometry()->distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
+                        if (m_centerOfBaseCell > -1 && m_objects->getMapGeometry()->distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
                             respondToThreat(pUnit, nullptr, event.atCell, 2 + RNG::rnd(4));
                         }
                     }
                 }
                 else if (event.entityType == eBuildType::STRUCTURE) {
-                    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
+                    cAbstractStructure *pStructure = m_objects->getStructures()[event.entityID];
                     if (!pStructure->getPlayer()->isSameTeamAs(player)) {
                         // found enemy structure
                         m_state = ePlayerBrainState::PLAYERBRAIN_ENEMY_DETECTED;
@@ -1762,12 +1761,12 @@ void cPlayerBrainCampaign::onEntityDiscoveredEvent(const CommonEvent &event)
             }
             else {
                 // event.player == player who discovered something
-                if (event.player == game.m_gameObjectsContext->getPlayer(AI_WORM)) {
+                if (event.player == m_objects->getPlayer(AI_WORM)) {
                     // ignore anything that the WORM AI player detected.
                 }
                 else if (!event.player->isSameTeamAs(player)) {
                     if (event.entityType == eBuildType::UNIT) {
-                        cUnit *pUnit = game.m_gameObjectsContext->getUnit(event.entityID);
+                        cUnit *pUnit = m_objects->getUnit(event.entityID);
                         // the other player discovered a unit of mine
                         if (pUnit->isValid() && pUnit->getPlayer() == player) {
                             // found my unit
@@ -1777,7 +1776,7 @@ void cPlayerBrainCampaign::onEntityDiscoveredEvent(const CommonEvent &event)
                         }
                     }
                     else if (event.entityType == eBuildType::STRUCTURE) {
-                        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
+                        cAbstractStructure *pStructure = m_objects->getStructures()[event.entityID];
                         // the other player discovered a structure of mine
                         if (pStructure->getPlayer() == player) {
                             // found my structure
@@ -1802,9 +1801,9 @@ void cPlayerBrainCampaign::onEntityDiscoveredEvent(const CommonEvent &event)
             if (event.player == player) {
                 // i discovered something
                 if (event.entityType == eBuildType::UNIT) {
-                    cUnit *pUnit = game.m_gameObjectsContext->getUnit(event.entityID);
+                    cUnit *pUnit = m_objects->getUnit(event.entityID);
                     if (pUnit->isValid() && !pUnit->getPlayer()->isSameTeamAs(player)) {
-                        if (m_centerOfBaseCell > -1 && game.m_gameObjectsContext->getMapGeometry()->distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
+                        if (m_centerOfBaseCell > -1 && m_objects->getMapGeometry()->distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
                             respondToThreat(pUnit, nullptr, event.atCell, 2 + RNG::rnd(4));
                         }
                     }

--- a/src/gameobjects/players/brains/cPlayerBrainCampaign.cpp
+++ b/src/gameobjects/players/brains/cPlayerBrainCampaign.cpp
@@ -5,6 +5,7 @@
 #include "gameobjects/structures/cStructures.h"
 #include "game/cGameSettings.h"
 #include "game/cGameInterface.h"
+#include "include/sGameServices.h"
 #include "gameobjects/map/cMap.h"
 #include "enums.h"
 #include "gameobjects/players/cPlayer.h"
@@ -30,13 +31,18 @@ cPlayerBrainCampaign::cPlayerBrainCampaign(cPlayer *player, s_DataCampaign* data
     // timer is subtracted every 100 ms with 1 (ie, 10 == 10*100 = 1000ms == 1 second)
     // 10*60 -> 1 minute. * 4 -> 4 minutes
     m_TIMER_rest = (10 * 60) * 4;
-    if (m_settings->isNoAiRest()) {
-        m_TIMER_rest = 10;
-    }
     m_myBase = std::vector<s_structurePosition>();
     m_buildOrders = std::vector<s_buildOrder>();
     m_discoveredEnemyAtCell = std::set<int>();
     m_centerOfBaseCell = 0;
+}
+
+void cPlayerBrainCampaign::serviceInit(sGameServices* services)
+{
+    cPlayerBrain::serviceInit(services);
+    if (m_settings->isNoAiRest()) {
+        m_TIMER_rest = 10;
+    }
 }
 
 cPlayerBrainCampaign::~cPlayerBrainCampaign()

--- a/src/gameobjects/players/brains/cPlayerBrainCampaign.h
+++ b/src/gameobjects/players/brains/cPlayerBrainCampaign.h
@@ -25,6 +25,8 @@ public:
 
     ~cPlayerBrainCampaign();
 
+    void serviceInit(sGameServices* services) override;
+
     void think() override;
 
     void thinkFast() override;

--- a/src/gameobjects/players/brains/cPlayerBrainSandworm.cpp
+++ b/src/gameobjects/players/brains/cPlayerBrainSandworm.cpp
@@ -1,9 +1,5 @@
 #include "cPlayerBrainSandworm.h"
-#include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
-
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
 #include "gameobjects/players/cPlayer.h"
 #include "include/cAssert.h"
@@ -31,7 +27,7 @@ void cPlayerBrainSandworm::think()
     // loop through all its worms and move them around
     const std::vector<int> &wormIds = player->getAllMyUnitsForType(SANDWORM);
     for (auto &i : wormIds) {
-        cUnit *pSandWorm = game.m_gameObjectsContext->getUnit(i);
+        cUnit *pSandWorm = m_objects->getUnit(i);
 
         // when on guard
         bool allowedToMove = pSandWorm->movewaitTimer.get() < 1;
@@ -44,7 +40,7 @@ void cPlayerBrainSandworm::think()
 
 void cPlayerBrainSandworm::findRandomValidLocationToMoveToAndGoThere(cUnit *pSandWorm) const
 {
-    int placeToMoveTo = game.m_gameObjectsContext->getMap()->findRandomCellToMoveToForSandworm();
+    int placeToMoveTo = m_objects->getMap()->findRandomCellToMoveToForSandworm();
 
     if (placeToMoveTo > -1) {
         pSandWorm->move_to(placeToMoveTo);

--- a/src/gameobjects/players/brains/cPlayerBrainSkirmish.cpp
+++ b/src/gameobjects/players/brains/cPlayerBrainSkirmish.cpp
@@ -2,14 +2,13 @@
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
 #include "game/cGameSettings.h"
+#include "game/cGameInterface.h"
 #include "actions/cRespondToThreatAction.h"
 //#include "gameobjects/particles/cParticles.h"
 #include "gameobjects/structures/cStructures.h"
 #include "utils/cStructureUtils.h"
 #include "gameobjects/units/cUnits.h"
 #include "enums.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
 #include "gameobjects/players/cPlayer.h"
 #include "gameobjects/players/cPlayers.h"
@@ -32,7 +31,7 @@ cPlayerBrainSkirmish::cPlayerBrainSkirmish(cPlayer *player) :
 //         10*60 -> 1 minute. * 4 -> 4 minutes
 //        m_TIMER_rest = (10 * 60) * 4;
     m_TIMER_rest = RNG::rnd(25); // todo: based on difficulty?
-    if (game.m_gameSettings->isNoAiRest()) {
+    if (m_settings->isNoAiRest()) {
         m_TIMER_rest = 10;
     }
     m_TIMER_produceMissionCooldown = 0;
@@ -126,16 +125,16 @@ void cPlayerBrainSkirmish::addBuildOrder(s_buildOrder order)
         std::string msg;
         if (buildOrder.buildType == eBuildType::UNIT) {
             msg = std::format("[{}] - type = UNIT, buildId = {} (={}), priority = {}, state = {}", id, buildOrder.buildId,
-                              game.m_infoContext->getUnitInfo(buildOrder.buildId).name, buildOrder.priority, eBuildOrderStateString(buildOrder.state));
+                              m_info->getUnitInfo(buildOrder.buildId).name, buildOrder.priority, eBuildOrderStateString(buildOrder.state));
         }
         else if (buildOrder.buildType == eBuildType::STRUCTURE) {
             msg = std::format("[{}] - type = STRUCTURE, buildId = {} (={}), priority = {}, place at {}, state = {}", id,
-                              buildOrder.buildId, game.m_infoContext->getStructureInfo(buildOrder.buildId).name, buildOrder.priority,
+                              buildOrder.buildId, m_info->getStructureInfo(buildOrder.buildId).name, buildOrder.priority,
                               buildOrder.placeAt, eBuildOrderStateString(buildOrder.state));
         }
         else if (buildOrder.buildType == eBuildType::SPECIAL) {
             msg = std::format("[{}] - type = SPECIAL, buildId = {} (={}), priority = {}, state = {}", id, buildOrder.buildId,
-                              game.m_infoContext->getSpecialInfo(buildOrder.buildId).description, buildOrder.priority, eBuildOrderStateString(buildOrder.state));
+                              m_info->getSpecialInfo(buildOrder.buildId).description, buildOrder.priority, eBuildOrderStateString(buildOrder.state));
         }
         else if (buildOrder.buildType == eBuildType::BULLET) {
             msg = std::format("[{}] - type = SPECIAL, buildId = {} (=NOT YET IMPLEMENTED), priority = {}, state = {}", id,
@@ -201,7 +200,7 @@ void cPlayerBrainSkirmish::onNotifyGameEvent(const s_GameEvent &event)
 void cPlayerBrainSkirmish::onMyStructureCreated(const CommonEvent &event)
 {
     // a structure was created, update our baseplan
-    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
+    cAbstractStructure *pStructure = m_objects->getStructures()[event.entityID];
 
     if (event.entitySpecificType == PALACE) {
         // built a palace, create super weapon missions asap!
@@ -271,9 +270,9 @@ void cPlayerBrainSkirmish::onMyStructureDestroyed(const CommonEvent &event)
 void cPlayerBrainSkirmish::onMyStructureAttacked(const DamagedEvent &event)
 {
     if (player->hasEnoughCreditsFor(50)) {
-        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
+        cAbstractStructure *pStructure = m_objects->getStructures()[event.entityID];
         if (!pStructure->isRepairing()) {
-            s_StructureInfo &sStructures = game.m_infoContext->getStructureInfo(event.entitySpecificType);
+            s_StructureInfo &sStructures = m_info->getStructureInfo(event.entitySpecificType);
             if (pStructure->getHitPoints() < sStructures.hp * 0.75) {
                 pStructure->startRepairing();
             }
@@ -283,7 +282,7 @@ void cPlayerBrainSkirmish::onMyStructureAttacked(const DamagedEvent &event)
     int unitIdThatAttacks = event.originId;
     if (unitIdThatAttacks > -1) {
         // respond to something that attacks us
-        cUnit *originUnit = game.m_gameObjectsContext->getUnit(unitIdThatAttacks);
+        cUnit *originUnit = m_objects->getUnit(unitIdThatAttacks);
         if (originUnit->getPlayer()->isSameTeamAs(player)) {
             // friendly fire, ignore
             log(std::format("Unit {} who damaged my structure is from friendly player, ignoring.", unitIdThatAttacks).c_str());
@@ -307,9 +306,9 @@ void cPlayerBrainSkirmish::respondToThreat(cUnit *threat, cUnit *victim, int cel
 void cPlayerBrainSkirmish::onMyStructureDecayed(const CommonEvent &event)
 {
     if (player->hasEnoughCreditsFor(50)) {
-        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
+        cAbstractStructure *pStructure = m_objects->getStructures()[event.entityID];
         if (!pStructure->isRepairing()) {
-            s_StructureInfo &sStructures = game.m_infoContext->getStructureInfo(event.entitySpecificType);
+            s_StructureInfo &sStructures = m_info->getStructureInfo(event.entitySpecificType);
             if (pStructure->getHitPoints() < sStructures.hp * 0.75) {
                 pStructure->startRepairing();
             }
@@ -399,7 +398,7 @@ void cPlayerBrainSkirmish::thinkState_Missions()
 {
     log("thinkState_Missions()");
 
-    if (game.m_gameSettings->isDebugMode()) {
+    if (m_settings->isDebugMode()) {
         log("Missions - before deleting");
         logMissions();
     }
@@ -415,14 +414,14 @@ void cPlayerBrainSkirmish::thinkState_Missions()
     m_missions.end()
     );
 
-    if (game.m_gameSettings->isDebugMode()) {
+    if (m_settings->isDebugMode()) {
         log("Missions - after deleting - before produceMissions()");
         logMissions();
     }
 
     produceMissions();
 
-    if (game.m_gameSettings->isDebugMode()) {
+    if (m_settings->isDebugMode()) {
         log("Missions - after produceMissions()");
         logMissions();
     }
@@ -985,7 +984,7 @@ void cPlayerBrainSkirmish::thinkState_EndGame()
     bool foundIdleUnit = false;
     std::vector<int> ids = player->getAllMyUnits();
     for (auto &id : ids) {
-        cUnit *cUnit = game.m_gameObjectsContext->getUnit(id);
+        cUnit *cUnit = m_objects->getUnit(id);
         if (cUnit->isIdle()) {
             foundIdleUnit = true;
             break;
@@ -998,8 +997,8 @@ void cPlayerBrainSkirmish::thinkState_EndGame()
 
     int cellToAttack = -1;
     if (RNG::rnd(100) < 50) {
-        for (int i = 0; i < game.m_gameObjectsContext->getUnitsSize(); i++) {
-            cUnit *cUnit = game.m_gameObjectsContext->getUnit(i);
+        for (int i = 0; i < m_objects->getUnitsSize(); i++) {
+            cUnit *cUnit = m_objects->getUnit(i);
             if (!cUnit->isValid()) continue;
             if (cUnit->getPlayer()->isSameTeamAs(player)) continue; // skip allies and self
             if (!cUnit->isAttackingUnit()) continue; // skip units that cannot 'attack' stuff
@@ -1012,7 +1011,7 @@ void cPlayerBrainSkirmish::thinkState_EndGame()
     }
     else {
         for (int i = 0; i < MAX_STRUCTURES; i++) {
-            cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
+            cAbstractStructure *theStructure = m_objects->getStructures()[i];
             if (!theStructure) continue;
             if (!theStructure->isValid()) continue;
             if (theStructure->getPlayer()->isSameTeamAs(player)) continue; // skip allies and self
@@ -1026,7 +1025,7 @@ void cPlayerBrainSkirmish::thinkState_EndGame()
 
     if (cellToAttack > -1) {
         for (auto &id : ids) {
-            cUnit *pUnit = game.m_gameObjectsContext->getUnit(id);
+            cUnit *pUnit = m_objects->getUnit(id);
             if (pUnit->isIdle()) {
                 pUnit->attackAt(cellToAttack);
             }
@@ -1107,7 +1106,7 @@ void cPlayerBrainSkirmish::thinkState_ProcessBuildOrders()
                         .entitySpecificType = buildOrder.buildId,
                     }
                 };
-                game.onNotifyGameEvent(event);
+                m_interface->onNotifyGameEvent(event);
             }
         }
         else if (buildOrder.buildType == eBuildType::SPECIAL) {
@@ -1196,7 +1195,7 @@ void cPlayerBrainSkirmish::findNewLocationOrMoveAnyBlockingUnitsOrCancelBuild(s_
     // if there is any enemy player, then find a new place.
     if (!placeResult.unitIds.empty()) {
         for (auto &unitId : placeResult.unitIds) {
-            cUnit *aUnit = game.m_gameObjectsContext->getUnit(unitId);
+            cUnit *aUnit = m_objects->getUnit(unitId);
             if (!aUnit->isValid()) continue;
             if (aUnit->getPlayer() == player) {
                 if (aUnit->isUnableToMove()) {
@@ -1206,7 +1205,7 @@ void cPlayerBrainSkirmish::findNewLocationOrMoveAnyBlockingUnitsOrCancelBuild(s_
                 }
                 // move it when idle, else don't do a thing
                 if (aUnit->isIdle()) {
-                    aUnit->move_to(game.m_gameObjectsContext->getMapGeometry()->getRandomCellFrom(aUnit->getCell(), 3));
+                    aUnit->move_to(m_objects->getMapGeometry()->getRandomCellFrom(aUnit->getCell(), 3));
                 }
             }
             else {
@@ -1264,7 +1263,7 @@ void cPlayerBrainSkirmish::onEntityDiscoveredEvent(const CommonEvent &event)
             if (event.player == player) {
                 // i discovered something
                 if (event.entityType == eBuildType::UNIT) {
-                    cUnit *pUnit = game.m_gameObjectsContext->getUnit(event.entityID);
+                    cUnit *pUnit = m_objects->getUnit(event.entityID);
                     if (pUnit->isValid() && !pUnit->getPlayer()->isSameTeamAs(player)) {
                         // found enemy unit
                         m_TIMER_produceMissionCooldown = 0;
@@ -1272,13 +1271,13 @@ void cPlayerBrainSkirmish::onEntityDiscoveredEvent(const CommonEvent &event)
                         m_TIMER_rest = 0; // if we were still 'resting' then stop this now.
                         m_discoveredEnemyAtCell.insert(event.atCell);
 
-                        if (m_centerOfBaseCell > -1 && game.m_gameObjectsContext->getMapGeometry()->distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
+                        if (m_centerOfBaseCell > -1 && m_objects->getMapGeometry()->distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
                             respondToThreat(pUnit, nullptr, event.atCell, 2 + RNG::rnd(4));
                         }
                     }
                 }
                 else if (event.entityType == eBuildType::STRUCTURE) {
-                    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
+                    cAbstractStructure *pStructure = m_objects->getStructures()[event.entityID];
                     if (!pStructure->getPlayer()->isSameTeamAs(player)) {
                         // found enemy structure
                         m_TIMER_produceMissionCooldown = 0;
@@ -1290,12 +1289,12 @@ void cPlayerBrainSkirmish::onEntityDiscoveredEvent(const CommonEvent &event)
             }
             else {
                 // event.player == player who discovered something
-                if (event.player == game.m_gameObjectsContext->getPlayer(AI_WORM)) {
+                if (event.player == m_objects->getPlayer(AI_WORM)) {
                     // ignore anything that the WORM AI player detected.
                 }
                 else if (!event.player->isSameTeamAs(player)) {
                     if (event.entityType == eBuildType::UNIT) {
-                        cUnit *pUnit = game.m_gameObjectsContext->getUnit(event.entityID);
+                        cUnit *pUnit = m_objects->getUnit(event.entityID);
                         // the other player discovered a unit of mine
                         if (pUnit->isValid() && pUnit->getPlayer() == player) {
                             // found my unit
@@ -1306,7 +1305,7 @@ void cPlayerBrainSkirmish::onEntityDiscoveredEvent(const CommonEvent &event)
                         }
                     }
                     else if (event.entityType == eBuildType::STRUCTURE) {
-                        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[event.entityID];
+                        cAbstractStructure *pStructure = m_objects->getStructures()[event.entityID];
                         // the other player discovered a structure of mine
                         if (pStructure->getPlayer() == player) {
                             // found my structure
@@ -1332,9 +1331,9 @@ void cPlayerBrainSkirmish::onEntityDiscoveredEvent(const CommonEvent &event)
             if (event.player == player) {
                 // i discovered something
                 if (event.entityType == eBuildType::UNIT) {
-                    cUnit *pUnit = game.m_gameObjectsContext->getUnit(event.entityID);
+                    cUnit *pUnit = m_objects->getUnit(event.entityID);
                     if (pUnit->isValid() && !pUnit->getPlayer()->isSameTeamAs(player)) {
-                        if (m_centerOfBaseCell > -1 && game.m_gameObjectsContext->getMapGeometry()->distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
+                        if (m_centerOfBaseCell > -1 && m_objects->getMapGeometry()->distance(m_centerOfBaseCell, event.atCell) < kScanRadius) {
                             respondToThreat(pUnit, nullptr, event.atCell, 2 + RNG::rnd(4));
                         }
                     }
@@ -1636,10 +1635,10 @@ void cPlayerBrainSkirmish::onMyUnitAttacked(const DamagedEvent &event)
     cUnit *threat = nullptr;
     if (event.originType == eBuildType::UNIT) {
         d2tm_assert(event.originId > -1);
-        threat = game.m_gameObjectsContext->getUnit(event.originId);
+        threat = m_objects->getUnit(event.originId);
     }
 
-    cUnit *victim = game.m_gameObjectsContext->getUnit(event.entityID);
+    cUnit *victim = m_objects->getUnit(event.entityID);
     if (victim->isHarvester()) {
         respondToThreat(threat, victim, event.atCell, 2 + RNG::rnd(4));
     }

--- a/src/gameobjects/players/brains/cPlayerBrainSkirmish.cpp
+++ b/src/gameobjects/players/brains/cPlayerBrainSkirmish.cpp
@@ -3,6 +3,7 @@
 #include "context/cGameObjectContext.h"
 #include "game/cGameSettings.h"
 #include "game/cGameInterface.h"
+#include "include/sGameServices.h"
 #include "actions/cRespondToThreatAction.h"
 //#include "gameobjects/particles/cParticles.h"
 #include "gameobjects/structures/cStructures.h"
@@ -31,9 +32,6 @@ cPlayerBrainSkirmish::cPlayerBrainSkirmish(cPlayer *player) :
 //         10*60 -> 1 minute. * 4 -> 4 minutes
 //        m_TIMER_rest = (10 * 60) * 4;
     m_TIMER_rest = RNG::rnd(25); // todo: based on difficulty?
-    if (m_settings->isNoAiRest()) {
-        m_TIMER_rest = 10;
-    }
     m_TIMER_produceMissionCooldown = 0;
     m_TIMER_ai = 0; // increased every 100 ms with 1. (ie 10 ticks is 1 second)
 
@@ -55,6 +53,14 @@ cPlayerBrainSkirmish::cPlayerBrainSkirmish(cPlayer *player) :
     m_economyState = ePlayerBrainSkirmishEconomyState::PLAYERBRAIN_ECONOMY_STATE_NORMAL;
     m_economyScore = 50;
     m_centerOfBaseCell = 0;
+}
+
+void cPlayerBrainSkirmish::serviceInit(sGameServices* services)
+{
+    cPlayerBrain::serviceInit(services);
+    if (m_settings->isNoAiRest()) {
+        m_TIMER_rest = 10;
+    }
 }
 
 cPlayerBrainSkirmish::~cPlayerBrainSkirmish()

--- a/src/gameobjects/players/brains/cPlayerBrainSkirmish.h
+++ b/src/gameobjects/players/brains/cPlayerBrainSkirmish.h
@@ -49,6 +49,8 @@ public:
 
     ~cPlayerBrainSkirmish();
 
+    void serviceInit(sGameServices* services) override;
+
     void think() override;
 
     void thinkFast() override;

--- a/src/gameobjects/players/brains/missions/cPlayerBrainMission.cpp
+++ b/src/gameobjects/players/brains/missions/cPlayerBrainMission.cpp
@@ -8,11 +8,10 @@
 #include "cPlayerBrainMissionKindFremen.h"
 #include "gameobjects/units/cUnits.h"
 #include "sidebar/cSideBar.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
+#include "gameobjects/players/cPlayer.h"
 #include "utils/common.h"
 #include <format>
 #include "include/cAssert.h"
@@ -152,7 +151,7 @@ void cPlayerBrainMission::onNotifyGameEvent(const s_GameEvent &event)
 void cPlayerBrainMission::onEventDeviated(const CommonEvent &event)
 {
     if (event.entityType == UNIT) {
-        cUnit *entityUnit = game.m_gameObjectsContext->getUnit(event.entityID);
+        cUnit *entityUnit = player->getObjects()->getUnit(event.entityID);
         if (entityUnit->getPlayer() != player) {
             // not our unit, if it was in our units list, remove it.
             removeUnitIdFromListIfPresent(event.entityID);
@@ -200,7 +199,7 @@ void cPlayerBrainMission::onEventCreated(const CommonEvent &event)
                 state == PLAYERBRAINMISSION_STATE_PREPARE_GATHER_RESOURCES) {
             // unit got created, not reinforced
             if (event.entityType == UNIT && !event.isReinforce) {
-                cUnit *entityUnit = game.m_gameObjectsContext->getUnit(event.entityID);
+                cUnit *entityUnit = player->getObjects()->getUnit(event.entityID);
 
                 // this unit has not been assigned to a mission yet
                 if (!entityUnit->isAssignedAnyMission()) {
@@ -220,10 +219,10 @@ void cPlayerBrainMission::onEventCreated(const CommonEvent &event)
                         }
                         else if (thingIWant.buildType == eBuildType::SPECIAL) {
                             // or a special kind of thing I ordered should produce a unit
-                            if (game.m_infoContext->getSpecialInfo(thingIWant.type).providesType == eBuildType::UNIT) {
+                            if (player->getInfos()->getSpecialInfo(thingIWant.type).providesType == eBuildType::UNIT) {
                                 // it provides a unit AND the kind of unit it provides matches that what
                                 // has been created... then we *also* are interested.
-                                if (game.m_infoContext->getSpecialInfo(thingIWant.type).providesTypeId == event.entitySpecificType) {
+                                if (player->getInfos()->getSpecialInfo(thingIWant.type).providesTypeId == event.entitySpecificType) {
                                     // in case we have multiple entries with same type we check for produced vs required
 
                                     // do not look at produced property, because we should have only ONE SPECIAL KIND
@@ -260,7 +259,7 @@ void cPlayerBrainMission::removeUnitIdFromListIfPresent(int unitIdToRemove)
         // found unit in our list, so someone of ours got destroyed!
         log(std::format("removeUnitIdFromListIfPresent [{}] has removed unit from the list!", unitIdToRemove).c_str());
         units.erase(position);
-        game.m_gameObjectsContext->getUnit(unitIdToRemove)->unAssignMission();
+        player->getObjects()->getUnit(unitIdToRemove)->unAssignMission();
         log("These units are still available:");
         logUnits();
     }
@@ -296,7 +295,7 @@ void cPlayerBrainMission::thinkState_PrepareGatherResources()
 
                 if (thingIWant.buildType == eBuildType::UNIT) {
                     for (auto &unitId : allMyUnits) {
-                        cUnit *pUnit = game.m_gameObjectsContext->getUnit(unitId);
+                        cUnit *pUnit = player->getObjects()->getUnit(unitId);
                         if (!pUnit->isValid()) continue;
                         if (pUnit->getType() != thingIWant.type) continue;
                         if (!pUnit->isIdle()) continue;
@@ -357,7 +356,7 @@ void cPlayerBrainMission::thinkState_PrepareGatherResources()
                     cSideBar *pSideBar = player->getSideBar();
                     int awaitingResourcesTimeToIncrease = 15;
                     if (thingIWant.buildType == UNIT) {
-                        cBuildingListItem *pItem = pSideBar->getBuildingListItem(game.m_infoContext->getUnitInfo(thingIWant.type).listType,
+                        cBuildingListItem *pItem = pSideBar->getBuildingListItem(player->getInfos()->getUnitInfo(thingIWant.type).listType,
                                                    thingIWant.type);
 
                         if (pItem) {
@@ -449,7 +448,7 @@ void cPlayerBrainMission::thinkState_PrepareGatherResources()
 void cPlayerBrainMission::logUnits()
 {
     for (auto &myUnitId : units) {
-        cUnit *myUnit = game.m_gameObjectsContext->getUnit(myUnitId);
+        cUnit *myUnit = player->getObjects()->getUnit(myUnitId);
         log(std::format("logUnits() : Unit {}, type {} ({})", myUnit->iID, myUnit->iType, myUnit->getUnitInfo().name).c_str());
     }
 }
@@ -506,7 +505,7 @@ void cPlayerBrainMission::thinkState_Execute()
 
     bool teamIsStillAlive = false;
     for (auto &myUnit : units) {
-        cUnit *aUnit = game.m_gameObjectsContext->getUnit(myUnit);
+        cUnit *aUnit = player->getObjects()->getUnit(myUnit);
         if (aUnit->isValid() &&
                 aUnit->isAssignedMission(uniqueIdentifier)) { // in case this unit ID was re-spawned...
             teamIsStillAlive = true;

--- a/src/gameobjects/players/brains/missions/cPlayerBrainMissionKind.cpp
+++ b/src/gameobjects/players/brains/missions/cPlayerBrainMissionKind.cpp
@@ -1,7 +1,5 @@
 #include "gameobjects/players/cPlayer.h"
 #include "cPlayerBrainMission.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
 #include "gameobjects/units/cUnits.h"
 #include "context/cInfoContext.h"
@@ -104,7 +102,7 @@ void cPlayerBrainMissionKind::onExecuteSpecificStateSwitch(const s_GameEvent &ev
     if (const auto *commonEvent = std::get_if<CommonEvent>(&event.data)) {
         // unit got created, not reinforced - add it to the units list (ie saboteur to command)
         if (commonEvent->entityType == UNIT && !commonEvent->isReinforce) {
-            cUnit *entityUnit = game.m_gameObjectsContext->getUnit(commonEvent->entityID);
+            cUnit *entityUnit = player->getObjects()->getUnit(commonEvent->entityID);
 
             // this unit has not been assigned to a mission yet
             if (!entityUnit->isAssignedAnyMission()) {

--- a/src/gameobjects/players/brains/missions/cPlayerBrainMissionKindAttack.cpp
+++ b/src/gameobjects/players/brains/missions/cPlayerBrainMissionKindAttack.cpp
@@ -5,8 +5,6 @@
 #include "gameobjects/units/cUnits.h"
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
 #include "definitions.h"
 #include "utils/d2tm_math.h"
@@ -53,12 +51,12 @@ int cPlayerBrainMissionKindAttack::findEnemyStructure() const
 {
     int target = -1;
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
+        cAbstractStructure *theStructure = player->getObjects()->getStructures()[i];
         if (!theStructure) continue;
         if (!theStructure->isValid()) continue;
         if (theStructure->getPlayer() == player) continue; // skip self
         if (theStructure->getPlayer()->isSameTeamAs(player)) continue; // skip allies
-        if (!game.m_gameObjectsContext->getMap()->isStructureVisible(theStructure, player)) continue; // skip non-visible targets
+        if (!player->getObjects()->getMap()->isStructureVisible(theStructure, player)) continue; // skip non-visible targets
 
         // enemy structure
         target =  theStructure->getStructureId();
@@ -72,12 +70,12 @@ int cPlayerBrainMissionKindAttack::findEnemyStructure() const
 int cPlayerBrainMissionKindAttack::findEnemyUnit() const
 {
     int target = -1;
-    for (int i = 0; i < game.m_gameObjectsContext->getUnitsSize(); i++) {
-        cUnit *pUnit = game.m_gameObjectsContext->getUnit(i);
+    for (int i = 0; i < player->getObjects()->getUnitsSize(); i++) {
+        cUnit *pUnit = player->getObjects()->getUnit(i);
         if (!pUnit->isValid()) continue;
         if (pUnit->getPlayer() == player) continue; // skip self
         if (pUnit->getPlayer()->isSameTeamAs(player)) continue; // skip allies and self
-        if (!game.m_gameObjectsContext->getMap()->isVisible(pUnit->getCell(), player)) continue; // skip non visible targets
+        if (!player->getObjects()->getMap()->isVisible(pUnit->getCell(), player)) continue; // skip non visible targets
         if (pUnit->isSandworm() || pUnit->isAirbornUnit()) continue; // don't attack air units or sandworms
 
         // enemy unit
@@ -97,7 +95,7 @@ void cPlayerBrainMissionKindAttack::think_Execute()
     }
 
     if (targetStructureID > -1) {
-        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[targetStructureID];
+        cAbstractStructure *pStructure = player->getObjects()->getStructures()[targetStructureID];
         if (!pStructure || !pStructure->isValid()) {
             mission->changeState(PLAYERBRAINMISSION_STATE_SELECT_TARGET);
             return;
@@ -105,7 +103,7 @@ void cPlayerBrainMissionKindAttack::think_Execute()
 
         const std::vector<int> &units = mission->getUnits();
         for (auto &myUnit : units) {
-            cUnit *aUnit = game.m_gameObjectsContext->getUnit(myUnit);
+            cUnit *aUnit = player->getObjects()->getUnit(myUnit);
             if (aUnit->isValid() && aUnit->isIdle()) {
                 log("cPlayerBrainMissionKindAttack::thinkState_Execute(): Ordering unit to attack!");
                 aUnit->attackStructure(targetStructureID);
@@ -115,7 +113,7 @@ void cPlayerBrainMissionKindAttack::think_Execute()
     else if (targetUnitID > -1) {
         const std::vector<int> &units = mission->getUnits();
         for (auto &myUnit : units) {
-            cUnit *aUnit = game.m_gameObjectsContext->getUnit(myUnit);
+            cUnit *aUnit = player->getObjects()->getUnit(myUnit);
             if (aUnit->isValid() && aUnit->isIdle()) {
                 log("cPlayerBrainMissionKindAttack::thinkState_Execute(): Ordering unit to attack!");
                 aUnit->attackUnit(targetUnitID);
@@ -149,7 +147,7 @@ void cPlayerBrainMissionKindAttack::onNotifyGameEvent(const s_GameEvent &event)
 void cPlayerBrainMissionKindAttack::onEventDeviated(const CommonEvent &event)
 {
     if (event.entityType == UNIT) {
-        cUnit *entityUnit = game.m_gameObjectsContext->getUnit(event.entityID);
+        cUnit *entityUnit = player->getObjects()->getUnit(event.entityID);
         if (entityUnit->getPlayer() == player) {
             // the unit is ours, if it was a target, then we can forget it.
             if (targetUnitID == event.entityID) {

--- a/src/gameobjects/players/brains/missions/cPlayerBrainMissionKindDeathHand.cpp
+++ b/src/gameobjects/players/brains/missions/cPlayerBrainMissionKindDeathHand.cpp
@@ -6,8 +6,7 @@
 #include "utils/cStructureUtils.h"
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
+#include "game/cGameInterface.h"
 #include "include/sGameEvent.h"
 #include "gameobjects/map/cMap.h"
 #include "definitions.h"
@@ -39,12 +38,12 @@ bool cPlayerBrainMissionKindDeathHand::think_SelectTarget()
 {
     // and execute whatever?? (can merge with select target state?)
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
+        cAbstractStructure *theStructure = player->getObjects()->getStructures()[i];
         if (!theStructure) continue;
         if (!theStructure->isValid()) continue;
         if (theStructure->getPlayer() == player) continue; // skip self
         if (theStructure->getPlayer()->isSameTeamAs(player)) continue; // skip allies
-        if (!game.m_gameObjectsContext->getMap()->isStructureVisible(theStructure, player)) continue; // skip non-visible targets
+        if (!player->getObjects()->getMap()->isStructureVisible(theStructure, player)) continue; // skip non-visible targets
 
         // enemy structure
         target = theStructure->getCell();
@@ -55,12 +54,12 @@ bool cPlayerBrainMissionKindDeathHand::think_SelectTarget()
 
     if (target < 0) {
         // find any unit to attack instead
-        for (int i = 0; i < game.m_gameObjectsContext->getUnitsSize(); i++) {
-            cUnit *pUnit = game.m_gameObjectsContext->getUnit(i);
+        for (int i = 0; i < player->getObjects()->getUnitsSize(); i++) {
+            cUnit *pUnit = player->getObjects()->getUnit(i);
             if (!pUnit->isValid()) continue;
             if (pUnit->getPlayer() == player) continue; // skip self
             if (pUnit->getPlayer()->isSameTeamAs(player)) continue; // skip allies and self
-            if (!game.m_gameObjectsContext->getMap()->isVisible(pUnit->getCell(), player)) continue; // skip non visible targets
+            if (!player->getObjects()->getMap()->isVisible(pUnit->getCell(), player)) continue; // skip non visible targets
             // enemy unit
             target = i;
             if (RNG::rnd(100) < 5) {
@@ -84,7 +83,7 @@ void cPlayerBrainMissionKindDeathHand::think_Execute()
             .playerID = player->getId()
         }
     };
-    game.onNotifyGameEvent(event);
+    player->getInterface()->onNotifyGameEvent(event);
 
     // clear out item
     itemToLaunch = nullptr;

--- a/src/gameobjects/players/brains/missions/cPlayerBrainMissionKindExplore.cpp
+++ b/src/gameobjects/players/brains/missions/cPlayerBrainMissionKindExplore.cpp
@@ -1,9 +1,8 @@
 #include "cPlayerBrainMission.h"
 #include "cPlayerBrainMissionKindExplore.h"
 #include "gameobjects/units/cUnits.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
+#include "gameobjects/players/cPlayer.h"
 #include "include/cAssert.h"
 #include <format>
 
@@ -26,7 +25,7 @@ cPlayerBrainMissionKindExplore::~cPlayerBrainMissionKindExplore()
 
 bool cPlayerBrainMissionKindExplore::think_SelectTarget()
 {
-    targetCell = game.m_gameObjectsContext->getMapGeometry()->getRandomCellWithinMapWithSafeDistanceFromBorder(2);
+    targetCell = player->getObjects()->getMapGeometry()->getRandomCellWithinMapWithSafeDistanceFromBorder(2);
     return true;
 }
 
@@ -34,10 +33,10 @@ void cPlayerBrainMissionKindExplore::think_Execute()
 {
     const std::vector<int> &units = mission->getUnits();
     for (auto &myUnit : units) {
-        cUnit *aUnit = game.m_gameObjectsContext->getUnit(myUnit);
+        cUnit *aUnit = player->getObjects()->getUnit(myUnit);
         if (aUnit->isValid()) {
             if (aUnit->isIdle()) {
-                if (game.m_gameObjectsContext->getMapGeometry()->distance(aUnit->getCell(), targetCell) < 4) {
+                if (player->getObjects()->getMapGeometry()->distance(aUnit->getCell(), targetCell) < 4) {
                     targetCell = -1;
                     mission->changeState(PLAYERBRAINMISSION_STATE_SELECT_TARGET); // select new target
                 }
@@ -46,7 +45,7 @@ void cPlayerBrainMissionKindExplore::think_Execute()
                 }
             }
             else {
-                if (game.m_gameObjectsContext->getMapGeometry()->distance(aUnit->getCell(), targetCell) < 2) {
+                if (player->getObjects()->getMapGeometry()->distance(aUnit->getCell(), targetCell) < 2) {
                     // almost there. Select new target.
                     targetCell = -1;
                     mission->changeState(PLAYERBRAINMISSION_STATE_SELECT_TARGET); // select new target

--- a/src/gameobjects/players/brains/missions/cPlayerBrainMissionKindFremen.cpp
+++ b/src/gameobjects/players/brains/missions/cPlayerBrainMissionKindFremen.cpp
@@ -1,8 +1,5 @@
 #include "cPlayerBrainMission.h"
 #include "cPlayerBrainMissionKindFremen.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
-#include "gameobjects/map/cMap.h"
 #include "gameobjects/players/cPlayer.h"
 #include "gameobjects/players/cPlayers.h"
 #include "context/cInfoContext.h"
@@ -16,9 +13,9 @@ cPlayerBrainMissionKindFremen::cPlayerBrainMissionKindFremen(cPlayer *player, cP
     d2tm_assert(player != nullptr);
     d2tm_assert(mission != nullptr);
     specificEventTypeToGoToSelectTargetState = eGameEventType::GAME_EVENT_CREATED; // fremen created
-    specificBuildTypeToGoToSelectTargetState = game.m_infoContext->getSpecialInfo(SPECIAL_FREMEN).providesType;
-    specificBuildIdToGoToSelectTargetState = game.m_infoContext->getSpecialInfo(SPECIAL_FREMEN).providesTypeId;
-    specificPlayerForEventToGoToSelectTargetState = game.m_gameObjectsContext->getPlayer(AI_CPU5);
+    specificBuildTypeToGoToSelectTargetState = player->getInfos()->getSpecialInfo(SPECIAL_FREMEN).providesType;
+    specificBuildIdToGoToSelectTargetState = player->getInfos()->getSpecialInfo(SPECIAL_FREMEN).providesTypeId;
+    specificPlayerForEventToGoToSelectTargetState = player->getObjects()->getPlayer(AI_CPU5);
 }
 
 cPlayerBrainMissionKindFremen::~cPlayerBrainMissionKindFremen()

--- a/src/gameobjects/players/brains/missions/cPlayerBrainMissionKindSaboteur.cpp
+++ b/src/gameobjects/players/brains/missions/cPlayerBrainMissionKindSaboteur.cpp
@@ -5,9 +5,8 @@
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
 #include "gameobjects/units/cUnits.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
+#include "gameobjects/players/cPlayer.h"
 #include "utils/RNG.hpp"
 #include <format>
 #include "include/cAssert.h"
@@ -20,8 +19,8 @@ cPlayerBrainMissionKindSaboteur::cPlayerBrainMissionKindSaboteur(cPlayer *player
     d2tm_assert(mission != nullptr);
     targetStructureID = -1;
     specificEventTypeToGoToSelectTargetState = eGameEventType::GAME_EVENT_CREATED; // saboteur created
-    specificBuildTypeToGoToSelectTargetState = game.m_infoContext->getSpecialInfo(SPECIAL_SABOTEUR).providesType;
-    specificBuildIdToGoToSelectTargetState = game.m_infoContext->getSpecialInfo(SPECIAL_SABOTEUR).providesTypeId;
+    specificBuildTypeToGoToSelectTargetState = player->getInfos()->getSpecialInfo(SPECIAL_SABOTEUR).providesType;
+    specificBuildIdToGoToSelectTargetState = player->getInfos()->getSpecialInfo(SPECIAL_SABOTEUR).providesTypeId;
 }
 
 cPlayerBrainMissionKindSaboteur::~cPlayerBrainMissionKindSaboteur()
@@ -35,12 +34,12 @@ bool cPlayerBrainMissionKindSaboteur::think_SelectTarget()
 
     // TODO: based on priority?
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
+        cAbstractStructure *theStructure = player->getObjects()->getStructures()[i];
         if (!theStructure) continue;
         if (!theStructure->isValid()) continue;
         if (theStructure->getPlayer() == player) continue; // skip self
         if (theStructure->getPlayer()->isSameTeamAs(player)) continue; // skip allies
-        if (!game.m_gameObjectsContext->getMap()->isStructureVisible(theStructure, player)) continue; // skip non-visible targets
+        if (!player->getObjects()->getMap()->isStructureVisible(theStructure, player)) continue; // skip non-visible targets
 
         // enemy structure
         targetStructureID = theStructure->getStructureId();
@@ -59,12 +58,12 @@ void cPlayerBrainMissionKindSaboteur::think_Execute()
     }
 
     if (targetStructureID > -1) {
-        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[targetStructureID];
+        cAbstractStructure *pStructure = player->getObjects()->getStructures()[targetStructureID];
         d2tm_assert(pStructure != nullptr);
         if (pStructure->isValid()) {
             const std::vector<int> &units = mission->getUnits();
             for (auto &myUnit: units) {
-                cUnit *aUnit = game.m_gameObjectsContext->getUnit(myUnit);
+                cUnit *aUnit = player->getObjects()->getUnit(myUnit);
                 if (aUnit->isValid() && aUnit->isIdle()) {
                     log("cPlayerBrainMissionKindSaboteur::thinkState_Execute(): Ordering unit to attack!");
                     aUnit->attackStructure(targetStructureID);

--- a/src/gameobjects/players/brains/superweapon/cPlayerBrainFremenSuperWeapon.cpp
+++ b/src/gameobjects/players/brains/superweapon/cPlayerBrainFremenSuperWeapon.cpp
@@ -5,8 +5,6 @@
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
 
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
 #include "gameobjects/players/cPlayer.h"
 #include "gameobjects/players/cPlayers.h"
@@ -31,7 +29,7 @@ void cPlayerBrainFremenSuperWeapon::think()
     bool foundIdleUnit = false;
     std::vector<int> ids = player->getAllMyUnits();
     for (auto &id : ids) {
-        cUnit *cUnit = game.m_gameObjectsContext->getUnit(id);
+        cUnit *cUnit = player->getObjects()->getUnit(id);
         if (cUnit->isIdle()) {
             foundIdleUnit = true;
             break;
@@ -51,7 +49,7 @@ void cPlayerBrainFremenSuperWeapon::think()
     std::mt19937 g(rd());
 
     for (int i = 0; i < MAX_PLAYERS; i++) {
-        cPlayer *pPlayer = game.m_gameObjectsContext->getPlayer(i);
+        cPlayer *pPlayer = player->getObjects()->getPlayer(i);
         if (pPlayer == nullptr) continue;
         if (pPlayer == player) continue; // skip self
         if (pPlayer->isSameTeamAs(player)) continue; // skip same team players
@@ -65,7 +63,7 @@ void cPlayerBrainFremenSuperWeapon::think()
         std::vector<int> unitIds = pPlayer->getAllMyUnits();
         if (!unitIds.empty()) {
             std::shuffle(unitIds.begin(), unitIds.end(), g);
-            cellToAttack = game.m_gameObjectsContext->getUnit(unitIds.front())->getCell();
+            cellToAttack = player->getObjects()->getUnit(unitIds.front())->getCell();
             if (RNG::rnd(100) > 30) break;
         }
 
@@ -74,7 +72,7 @@ void cPlayerBrainFremenSuperWeapon::think()
         if (!structureIds.empty()) {
             // pick structure to attack
             std::shuffle(structureIds.begin(), structureIds.end(), g);
-            cellToAttack = game.m_gameObjectsContext->getStructures()[structureIds.front()]->getCell();
+            cellToAttack = player->getObjects()->getStructures()[structureIds.front()]->getCell();
             if (RNG::rnd(100) > 30) break;
         }
     }
@@ -83,7 +81,7 @@ void cPlayerBrainFremenSuperWeapon::think()
 
     // order units to attack!
     for (auto &id : ids) {
-        cUnit *pUnit = game.m_gameObjectsContext->getUnit(id);
+        cUnit *pUnit = player->getObjects()->getUnit(id);
         if (!pUnit->isIdle()) continue;
         pUnit->attackAt(cellToAttack);
     }

--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -77,6 +77,9 @@ void cPlayer::serviceInit(sGameServices* services)
     d2tm_assert(m_interface != nullptr);
     m_gfxdata = services->ctx->getGraphicsContext()->gfxdata.get();
     d2tm_assert(m_gfxdata != nullptr);
+    if (difficultySettings) {
+        difficultySettings->setInfoContext(m_infos);
+    }
     logbook(std::format("MAX_STRUCTURE_BMPS=[{}], sizeof bmp_structure={}, sizeof(SDL_Surface *)={}",
                         MAX_STRUCTURE_BMPS, sizeof(bmp_structure), sizeof(SDL_Surface *)));
 }

--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -225,6 +225,9 @@ void cPlayer::init(int id, std::unique_ptr<brains::cPlayerBrain> brain)
 
     if (difficultySettings) delete difficultySettings;
     difficultySettings = new cPlayerDifficultySettings();
+    if (m_infos) {
+        difficultySettings->setInfoContext(m_infos);
+    }
 
     // Reset structures amount
     for (int i = 0; i < MAX_STRUCTURETYPES; i++) {
@@ -264,6 +267,9 @@ void cPlayer::setHouse(int iHouse)
     }
 
     difficultySettings = cPlayerDifficultySettings::createFromHouse(iHouse);
+    if (m_infos) {
+        difficultySettings->setInfoContext(m_infos);
+    }
 
     if (currentHouse != iHouse) {
         logbook(std::format("cPlayer[{}]::setHouse - Current house differs from iHouse, preparing palette.", this->id));

--- a/src/gameobjects/players/cPlayer.h
+++ b/src/gameobjects/players/cPlayer.h
@@ -166,6 +166,22 @@ public:
         return difficultySettings;
     }
 
+    cGameObjectContext *getObjects() const {
+        return m_objects;
+    }
+
+    cInfoContext *getInfos() const {
+        return m_infos;
+    }
+
+    cGameSettings *getSettings() const {
+        return m_settings;
+    }
+
+    cGameInterface *getInterface() const {
+        return m_interface;
+    }
+
     cItemBuilder *getItemBuilder() const {
         return itemBuilder.get();
     }

--- a/src/gameobjects/players/cPlayerDifficultySettings.cpp
+++ b/src/gameobjects/players/cPlayerDifficultySettings.cpp
@@ -1,9 +1,6 @@
 #include "cPlayerDifficultySettings.h"
 #include "context/cInfoContext.h"
-#include "context/cGameObjectContext.h"
 #include "definitions.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 
 #include <cmath>
 
@@ -35,7 +32,7 @@ cPlayerDifficultySettings::~cPlayerDifficultySettings()
 
 float cPlayerDifficultySettings::getMoveSpeed(int iUnitType, int slowDown)
 {
-    return game.m_infoContext->getUnitInfo(iUnitType).speed + slowDown * m_moveSpeedFactor;
+    return m_info->getUnitInfo(iUnitType).speed + slowDown * m_moveSpeedFactor;
 }
 
 float cPlayerDifficultySettings::getBuildSpeed(int iSpeed)

--- a/src/gameobjects/players/cPlayerDifficultySettings.h
+++ b/src/gameobjects/players/cPlayerDifficultySettings.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+class cInfoContext;
+
 /**
  * This class holds properties for a player which have overall influence on the
  * player performance. Typically, these are characterized as house properties. For instance:
@@ -27,6 +29,8 @@ public:
     cPlayerDifficultySettings(float moveSpeedFactor, float buildSpeedFactor, float harvestSpeedFactor, float dumpSpeedFactor, float inflictDamageFactor);
 
     ~cPlayerDifficultySettings();
+
+    void setInfoContext(cInfoContext* info) { m_info = info; }
 
     // get move speed of a unit
     float getMoveSpeed(int iUnitType, int slowDown);
@@ -53,6 +57,7 @@ public:
 protected:
 
 private:
+    cInfoContext* m_info = nullptr;
     float m_moveSpeedFactor;
     float m_buildSpeedFactor;
     float m_harvestSpeedFactor;

--- a/src/gameobjects/players/cPlayers.cpp
+++ b/src/gameobjects/players/cPlayers.cpp
@@ -16,6 +16,7 @@
 #include "controls/cGameControlsContext.h"
 #include "controls/cMouse.h"
 #include "gameobjects/structures/cOrderProcesser.h"
+#include "brains/cPlayerBrain.h"
 #include "sidebar/cBuildingListUpdater.h"
 #include "sidebar/cSideBar.h"
 #include "sidebar/cSideBarFactory.h"
@@ -152,7 +153,7 @@ void cPlayers::destroyAllegroBitmaps()
     }
 }
 
-void cPlayers::initPlayers(bool rememberHouse, cGameSettings* gameSettings, s_DataCampaign* dataCampaign)
+void cPlayers::initPlayers(bool rememberHouse, cGameSettings* gameSettings, s_DataCampaign* dataCampaign, sGameServices* services)
 {
     int maxThinkingAIs = MAX_PLAYERS_CAPACITY;
     if (gameSettings->isOneAi()) {
@@ -191,6 +192,9 @@ void cPlayers::initPlayers(bool rememberHouse, cGameSettings* gameSettings, s_Da
             }
         }
 
+        if (brain) {
+            brain->serviceInit(services);
+        }
         pPlayer->init(i, std::move(brain));
         pPlayer->setAutoSlabStructures(autoSlabStructures);
         if (rememberHouse) {

--- a/src/gameobjects/players/cPlayers.h
+++ b/src/gameobjects/players/cPlayers.h
@@ -100,7 +100,7 @@ public:
      * @param gameSettings Game settings (for AI and difficulty configuration)
      * @param dataCampaign Campaign data (for campaign-specific AI brain initialization)
      */
-    void initPlayers(bool rememberHouse, cGameSettings* gameSettings, s_DataCampaign* dataCampaign);
+    void initPlayers(bool rememberHouse, cGameSettings* gameSettings, s_DataCampaign* dataCampaign, sGameServices* services);
 
     void setupPlayers(cHousesInfo* housesInfo);
 

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -45,6 +45,7 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
     m_settings(services->settings),
     m_interface(m_ctx->getGameInterface()),
     m_objects(services->objects),
+    m_services(services),
     m_dataCampaign(dataCompaign),
     m_previewMaps(previewMaps),
     m_gfxinter(m_ctx->getGraphicsContext()->gfxinter.get())
@@ -729,11 +730,15 @@ void cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState(in
             pPlayer->init(p, nullptr);
         }
         else if (p == AI_CPU5) {
-            pPlayer->init(p, std::make_unique<brains::cPlayerBrainFremenSuperWeapon>(pPlayer));
+            auto brain = std::make_unique<brains::cPlayerBrainFremenSuperWeapon>(pPlayer);
+            brain->serviceInit(m_services);
+            pPlayer->init(p, std::move(brain));
         }
         else if (p == AI_CPU6) {
             if (!m_settings->isDisableWormAi()) {
-                pPlayer->init(p, std::make_unique<brains::cPlayerBrainSandworm>(pPlayer));
+                auto brain = std::make_unique<brains::cPlayerBrainSandworm>(pPlayer);
+                brain->serviceInit(m_services);
+                pPlayer->init(p, std::move(brain));
             }
             else {
                 pPlayer->init(p, nullptr);
@@ -741,7 +746,9 @@ void cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState(in
         }
         else {
             if (maxThinkingAIs > 0) {
-                pPlayer->init(p, std::make_unique<brains::cPlayerBrainSkirmish>(pPlayer));
+                auto brain = std::make_unique<brains::cPlayerBrainSkirmish>(pPlayer);
+                brain->serviceInit(m_services);
+                pPlayer->init(p, std::move(brain));
                 maxThinkingAIs--;
             }
             else {

--- a/src/gamestates/cSetupSkirmishState.h
+++ b/src/gamestates/cSetupSkirmishState.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "cGameState.h"
+struct sGameServices;
 #include "controls/cKeyboardEvent.h"
 #include "definitions.h"
 #include "controls/sMouseEvent.h"
@@ -51,6 +52,7 @@ private:
     cGameSettings* m_settings = nullptr;
     cGameInterface* m_interface = nullptr;
     cGameObjectContext* m_objects = nullptr;
+    sGameServices* m_services = nullptr;
     s_DataCampaign* m_dataCampaign = nullptr;
     cPreviewMaps* m_previewMaps = nullptr;
     Graphics* m_gfxinter = nullptr;


### PR DESCRIPTION
## Summary

- \`cPlayer\` gains 4 public getters: \`getObjects()\`, \`getInfos()\`, \`getSettings()\`, \`getInterface()\`
- \`cPlayerDifficultySettings\` gains \`m_info\` + \`setInfoContext(cInfoContext*)\`; \`cPlayer::serviceInit\` wires it up
- \`cPlayerBrain\` base gains virtual \`serviceInit(sGameServices*)\` with protected \`m_objects\` / \`m_info\` / \`m_settings\` / \`m_interface\`
- \`cPlayerBrainSkirmish\` and \`cPlayerBrainCampaign\` override \`serviceInit\`: call base first, then apply settings-dependent timer init (both constructors previously accessed \`m_settings\` before it was set)
- \`initPlayers\` gains \`sGameServices*\` param; calls \`brain->serviceInit(services)\` after each brain is created
- \`cSetupSkirmishState\` also calls \`brain->serviceInit(m_services)\` for brains it creates directly (was missing, caused null \`m_objects\` crash)
- \`cPlayerBrainSandworm\` uses inherited service members directly
- Mission and mission-kind classes (\`cPlayerBrainMission\`, \`cPlayerBrainMissionKind*\`) use \`player->getObjects()\` / \`getInfos()\` / \`getInterface()\`
- \`cRespondToThreatAction\` uses \`m_player->getObjects()\`

Part of #1254.

## Test plan

- [x] \`./rebuildmacos.sh\` passes with zero errors
- [x] \`grep -r \"game\.\" src/gameobjects/players/\` returns empty
- [x] Boot no longer segfaults (null \`m_settings\` in brain constructors fixed)
- [x] Skirmish game start no longer crashes (null \`m_objects\` in \`cSetupSkirmishState\` brain creation fixed)