### PR TITLE
CI builds only trigger on relevant file changes

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -4,6 +4,22 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'resources/bin/**'
+      - 'resources/dll/**'
+      - 'resources/game.ini'
+      - 'resources/game.ini.org'
+      - 'CMakeLists.txt'
+      - 'create_release.bat'
+      - 'create_release.sh'
+      - 'install_dependencies_macosx.sh'
+      - 'install_dependencies_ubuntu.sh'
+      - 'rebuildmacos.sh'
+      - 'rebuildwin.bat'
+      - 'rebuildwinrelease.bat'
+      - '.github/workflows/**'
 
 concurrency:
   group: master-builds

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -1,7 +1,23 @@
 name: Build PR's
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'resources/bin/**'
+      - 'resources/dll/**'
+      - 'resources/game.ini'
+      - 'resources/game.ini.org'
+      - 'CMakeLists.txt'
+      - 'create_release.bat'
+      - 'create_release.sh'
+      - 'install_dependencies_macosx.sh'
+      - 'install_dependencies_ubuntu.sh'
+      - 'rebuildmacos.sh'
+      - 'rebuildwin.bat'
+      - 'rebuildwinrelease.bat'
+      - '.github/workflows/**'
 
 jobs:
   MSYS2:


### PR DESCRIPTION
## Summary

Adds `paths` filters to `build_pr.yml` and `build_master.yml` so builds only run when relevant files are changed. Changes to docs, blog posts, or other non-build files will no longer trigger compilation.

Triggers a build when any of these paths change:
- `src/**`, `tests/**`
- `resources/bin/**`, `resources/dll/**`, `resources/game.ini`, `resources/game.ini.org`
- `CMakeLists.txt`
- `create_release.bat`, `create_release.sh`
- `install_dependencies_macosx.sh`, `install_dependencies_ubuntu.sh`
- `rebuildmacos.sh`, `rebuildwin.bat`, `rebuildwinrelease.bat`
- `.github/workflows/**`

`build_manual.yml` is unchanged — it is `workflow_dispatch` triggered so path filters do not apply.

Note: with paths added to `build_master.yml`, a docs-only push to master will no longer produce a bleeding edge release.

Closes #1276

## Test plan

- [ ] Open a PR that only changes a doc file — build should not trigger
- [ ] Open a PR that changes a file in `src/` — build should trigger
- [ ] Open a PR that changes a workflow file — build should trigger