### PR TITLE
Step 10 of 15: src/gameobjects/structures/ has zero game. references

### DIFF
--- a/src/context/cGameObjectContext.cpp
+++ b/src/context/cGameObjectContext.cpp
@@ -163,4 +163,6 @@ void cGameObjectContext::serviceInit(sGameServices* services)
     m_Units->serviceInit(services);
     d2tm_assert(m_particles != nullptr);
     m_particles->serviceInit(services);
+    d2tm_assert(m_structureFactory != nullptr);
+    m_structureFactory->serviceInit(services);
 }

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -182,14 +182,6 @@ public:
     void thinkSlow();
     void thinkCache();
 
-    bool isTurretsDownOnLowPower() {
-        return m_turretsDownOnLowPower;
-    }
-
-    bool isRocketTurretsDownOnLowPower() {
-        return m_rocketTurretsDownOnLowPower;
-    }
-
     void applySettings(std::unique_ptr<InitialGameSettings> gs);
     void changeStateFromMentat();
     void loadMapFromEditor(int map);
@@ -218,11 +210,6 @@ private:
     float m_cameraBorderOrKeyMoveSpeed;     // speed of camera when hitting mouse border or pressing keys (default = 0.5f)
     bool m_cameraEdgeMove;                  // should move map camera when hitting edges of screen
     int m_musicVolume;                      // volume of the music
-
-    // if true, then turrets won't do anything on low power (both gun and rocket turrets)
-    bool m_turretsDownOnLowPower;
-    // if true, rocket turrets will not fire rockets when low power
-    bool m_rocketTurretsDownOnLowPower;
 
     std::string m_gameFilename;
 

--- a/src/game/cGameSettings.h
+++ b/src/game/cGameSettings.h
@@ -33,6 +33,18 @@ public:
     bool isNoAiRest() const {
         return m_noAiRest;
     }
+    bool isTurretsDownOnLowPower() const {
+        return m_turretsDownOnLowPower;
+    }
+    void setTurretsDownOnLowPower(bool value) {
+        m_turretsDownOnLowPower = value;
+    }
+    bool isRocketTurretsDownOnLowPower() const {
+        return m_rocketTurretsDownOnLowPower;
+    }
+    void setRocketTurretsDownOnLowPower(bool value) {
+        m_rocketTurretsDownOnLowPower = value;
+    }
     bool isPlayMusic() const {
         return m_playMusic;
     }
@@ -95,8 +107,10 @@ private:
     bool m_disableReinforcements;
     bool m_drawUsages;           
     bool m_drawUnitDebug;        
-    bool m_noAiRest;             
-    bool m_playMusic;            
+    bool m_noAiRest;
+    bool m_turretsDownOnLowPower = false;
+    bool m_rocketTurretsDownOnLowPower = false;
+    bool m_playMusic;
 
     bool m_playing;
     bool m_skirmish;

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -222,8 +222,8 @@ void cGame::applySettings(std::unique_ptr<InitialGameSettings> gs)
     m_windowed = gs->windowed;
 
     m_gameSettings->m_allowRepeatingReinforcements = gs->allowRepeatingReinforcements;
-    m_turretsDownOnLowPower = gs->turretsDownOnLowPower;
-    m_rocketTurretsDownOnLowPower = gs->rocketTurretsDownOnLowPower;
+    m_gameSettings->setTurretsDownOnLowPower(gs->turretsDownOnLowPower);
+    m_gameSettings->setRocketTurretsDownOnLowPower(gs->rocketTurretsDownOnLowPower);
 
     m_gameSettings->m_playMusic = gs->playMusic;
 

--- a/src/gameobjects/players/cPlayers.cpp
+++ b/src/gameobjects/players/cPlayers.cpp
@@ -123,6 +123,7 @@ void cPlayers::setupRuntimePlayerComponents(cSideBarFactory* sideBarFactory, cMo
         player->setSideBar(sidebar);
 
         auto orderProcesser = std::make_unique<cOrderProcesser>(player);
+        orderProcesser->serviceInit(services);
         player->setOrderProcesser(std::move(orderProcesser));
 
         auto gameControlsContext = std::make_unique<cGameControlsContext>(player, mouse);

--- a/src/gameobjects/structures/cAbstractStructure.cpp
+++ b/src/gameobjects/structures/cAbstractStructure.cpp
@@ -12,18 +12,21 @@
 
 #include "cAbstractStructure.h"
 
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "utils/cLog.h"
+#include "game/cGameInterface.h"
+#include "game/cGameSettings.h"
+#include "include/sGameServices.h"
+#include "context/GameContext.hpp"
+#include "context/cGameObjectContext.h"
+#include "context/cInfoContext.h"
+#include "gameobjects/map/cMapCamera.h"
 #include "data/gfxdata.h"
+#include "include/d2tmc.h"
 #include "drawers/SDLDrawer.hpp"
 #include "gameobjects/particles/cParticle.h"
 #include "gameobjects/particles/cParticles.h"
 #include "gameobjects/structures/cStructures.h"
-#include "context/cInfoContext.h"
-#include "context/cGameObjectContext.h"
 #include "gameobjects/units/cUnits.h"
-#include "gameobjects/map/cMapCamera.h"
 #include "gameobjects/map/cMapEditor.h"
 #include "gameobjects/map/MapGeometry.hpp"
 #include "gameobjects/players/cPlayer.h"
@@ -99,6 +102,15 @@ cAbstractStructure::~cAbstractStructure()
     posY = -1;
 }
 
+void cAbstractStructure::serviceInit(sGameServices *services)
+{
+    m_objects = services->objects;
+    m_info = services->info;
+    m_mapCamera = services->mapCamera;
+    m_settings = services->settings;
+    m_interface = services->ctx->getGameInterface();
+}
+
 int cAbstractStructure::pos_x()
 {
     return posX;
@@ -112,13 +124,13 @@ int cAbstractStructure::pos_y()
 // X drawing position
 int cAbstractStructure::iDrawX()
 {
-    return game.m_mapCamera->getWindowXPosition(pos_x());
+    return m_mapCamera->getWindowXPosition(pos_x());
 }
 
 // Y drawing position
 int cAbstractStructure::iDrawY()
 {
-    return game.m_mapCamera->getWindowYPosition(pos_y());
+    return m_mapCamera->getWindowYPosition(pos_y());
 }
 
 Texture *cAbstractStructure::getBitmap()
@@ -136,32 +148,32 @@ cPlayer *cAbstractStructure::getPlayer()
 {
     d2tm_assert(iPlayer >= HUMAN);
     d2tm_assert(iPlayer < MAX_PLAYERS);
-    return game.m_gameObjectsContext->getPlayer(iPlayer);
+    return m_objects->getPlayer(iPlayer);
 }
 
 int cAbstractStructure::getMaxHP()
 {
     int type = getType();
-    return game.m_infoContext->getStructureInfo(type).hp;
+    return m_info->getStructureInfo(type).hp;
 }
 
 int cAbstractStructure::getCaptureHP()
 {
     int type = getType();
     // TODO: Capture hp threshold (property in structure)
-    return ((float)game.m_infoContext->getStructureInfo(type).hp) * 0.30f;
+    return ((float)m_info->getStructureInfo(type).hp) * 0.30f;
 }
 
 int cAbstractStructure::getSight()
 {
     int type = getType();
-    return game.m_infoContext->getStructureInfo(type).sight;
+    return m_info->getStructureInfo(type).sight;
 }
 
 int cAbstractStructure::getRange()
 {
     int type = getType();
-    return game.m_infoContext->getStructureInfo(type).range;
+    return m_info->getStructureInfo(type).range;
 }
 
 
@@ -176,57 +188,57 @@ void cAbstractStructure::die()
     }
 
     // remove from array
-    game.m_gameObjectsContext->getStructures()[id] = nullptr;
+    m_objects->getStructures()[id] = nullptr;
 
     // Destroy structure, take stuff in effect for the player
     pPlayer->decreaseStructureAmount(getType()); // remove from player building indexes
 
     // UnitID > -1, means the unit inside will die too
     if (iUnitIDWithinStructure > -1) {
-        game.m_gameObjectsContext->getUnit(iUnitIDWithinStructure)->init(iUnitIDWithinStructure); // die here... softly
+        m_objects->getUnit(iUnitIDWithinStructure)->init(iUnitIDWithinStructure); // die here... softly
     }
 
     if (iUnitIDEnteringStructure > -1) {
-        game.m_gameObjectsContext->getUnit(iUnitIDEnteringStructure)->die(true, false);
+        m_objects->getUnit(iUnitIDEnteringStructure)->die(true, false);
     }
 
     if (iUnitIDHeadingForStructure > -1) {
         // reset structure ID
-        game.m_gameObjectsContext->getUnit(iUnitIDHeadingForStructure)->iStructureID = -1;
+        m_objects->getUnit(iUnitIDHeadingForStructure)->iStructureID = -1;
         iUnitIDHeadingForStructure = -1;
     }
 
     int iCll=iCell;
-    int iCX= game.m_gameObjectsContext->getMapGeometry()->getCellX(iCll);
-    int iCY= game.m_gameObjectsContext->getMapGeometry()->getCellY(iCll);
+    int iCX= m_objects->getMapGeometry()->getCellX(iCll);
+    int iCY= m_objects->getMapGeometry()->getCellY(iCll);
 
     // create destroy particles
     for (int w = 0; w < iWidth; w++) {
         for (int h = 0; h < iHeight; h++) {
-            iCll = game.m_gameObjectsContext->getMapGeometry()->makeCell(iCX + w, iCY + h);
+            iCll = m_objects->getMapGeometry()->makeCell(iCX + w, iCY + h);
 
-            game.m_gameObjectsContext->getMap()->cellChangeType(iCll, TERRAIN_ROCK);
-            cMapEditor(game.m_gameObjectsContext->getMap()).smoothAroundCell(iCll);
+            m_objects->getMap()->cellChangeType(iCll, TERRAIN_ROCK);
+            cMapEditor(m_objects->getMap()).smoothAroundCell(iCll);
 
             int half = 16;
-            int posX = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteXPositionFromCell(iCll);
-            int posY = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteYPositionFromCell(iCll);
+            int posX = m_objects->getMapGeometry()->getAbsoluteXPositionFromCell(iCll);
+            int posY = m_objects->getMapGeometry()->getAbsoluteYPositionFromCell(iCll);
 
-            cParticle::create(posX + half, posY + half, D2TM_PARTICLE_OBJECT_BOOM01, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
+            cParticle::create(posX + half, posY + half, D2TM_PARTICLE_OBJECT_BOOM01, -1, -1, m_objects, m_info);
 
             for (int i=0; i < 3; i++) {
-                game.m_gameObjectsContext->getMap()->smudge_increase(SmudgeType::S_ROCK, iCll);
+                m_objects->getMap()->smudge_increase(SmudgeType::S_ROCK, iCll);
 
                 // create particle
                 int iType = D2TM_PARTICLE_EXPLOSION_STRUCTURE01 + RNG::rnd(2);
-                cParticle::create(posX + half, posY + half, iType, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
+                cParticle::create(posX + half, posY + half, iType, -1, -1, m_objects, m_info);
 
                 // create smoke
                 if (RNG::rnd(100) < 15) {
                     int randomX = -8 + RNG::rnd(16);
                     int randomY = -8 + RNG::rnd(16);
 
-                    cParticle::create(posX + half + randomX, posY + half + randomY, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
+                    cParticle::create(posX + half + randomX, posY + half + randomY, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, m_objects, m_info);
                 }
 
                 // create fire
@@ -235,7 +247,7 @@ void cAbstractStructure::die()
                     int randomY = -8 + RNG::rnd(16);
 
                     cParticle::create(posX + half + randomX, posY + half + randomY, D2TM_PARTICLE_EXPLOSION_FIRE, -1,
-                                      -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
+                                      -1, m_objects, m_info);
                 }
 
             }
@@ -243,13 +255,13 @@ void cAbstractStructure::die()
     }
 
     // play sound
-    game.playSoundWithDistance(SOUND_CRUMBLE01 + RNG::rnd(2), distanceBetweenCellAndCenterOfScreen(iCell));
+    m_interface->playSoundWithDistance(SOUND_CRUMBLE01 + RNG::rnd(2), distanceBetweenCellAndCenterOfScreen(iCell));
 
     // remove from the playground
-    game.m_gameObjectsContext->getMap()->remove_id(id, MAPID_STRUCTURES);
+    m_objects->getMap()->remove_id(id, MAPID_STRUCTURES);
 
     // screen shaking
-    game.shakeScreen((iWidth * iHeight) * 20);
+    m_interface->shakeScreen((iWidth * iHeight) * 20);
 
     // eligible for cleanup
     dead = true;
@@ -264,7 +276,7 @@ void cAbstractStructure::die()
             .atCell = iCell
         }
     };
-    game.onNotifyGameEvent(event);
+    m_interface->onNotifyGameEvent(event);
 }
 
 
@@ -283,8 +295,8 @@ void cAbstractStructure::think_prebuild()
 
 std::vector<int> cAbstractStructure::getCellsAroundStructure()
 {
-    int iStartX = game.m_gameObjectsContext->getMapGeometry()->getCellX(iCell);
-    int iStartY = game.m_gameObjectsContext->getMapGeometry()->getCellY(iCell);
+    int iStartX = m_objects->getMapGeometry()->getCellX(iCell);
+    int iStartY = m_objects->getMapGeometry()->getCellY(iCell);
 
     int iEndX = (iStartX + iWidth) + 1;
     int iEndY = (iStartY + iHeight) + 1;
@@ -296,7 +308,7 @@ std::vector<int> cAbstractStructure::getCellsAroundStructure()
 
     for (int x = iStartX; x < iEndX; x++) {
         for (int y = iStartY; y < iEndY; y++) {
-            int cell = game.m_gameObjectsContext->getMapGeometry()->getCellWithMapBorders(x, y);
+            int cell = m_objects->getMapGeometry()->getCellWithMapBorders(x, y);
             if (cell > -1) {
                 cells.push_back(cell);
             }
@@ -312,8 +324,8 @@ std::vector<int> cAbstractStructure::getCellsAroundStructure()
  */
 std::vector<int> cAbstractStructure::getCellsOfStructure()
 {
-    int iStartX = game.m_gameObjectsContext->getMapGeometry()->getCellX(iCell);
-    int iStartY = game.m_gameObjectsContext->getMapGeometry()->getCellY(iCell);
+    int iStartX = m_objects->getMapGeometry()->getCellX(iCell);
+    int iStartY = m_objects->getMapGeometry()->getCellY(iCell);
 
     int iEndX = (iStartX + iWidth);
     int iEndY = (iStartY + iHeight);
@@ -322,7 +334,7 @@ std::vector<int> cAbstractStructure::getCellsOfStructure()
 
     for (int x = iStartX; x < iEndX; x++) {
         for (int y = iStartY; y < iEndY; y++) {
-            int cell = game.m_gameObjectsContext->getMapGeometry()->getCellWithMapBorders(x, y);
+            int cell = m_objects->getMapGeometry()->getCellWithMapBorders(x, y);
             if (cell > -1) {
                 cells.push_back(cell);
             }
@@ -342,7 +354,7 @@ int cAbstractStructure::getNonOccupiedCellAroundStructure()
     const std::vector<int> &cells = getCellsAroundStructure();
 
     for (auto &cll : cells) {
-        if (!game.m_gameObjectsContext->getMap()->occupied(cll)) {
+        if (!m_objects->getMap()->occupied(cll)) {
             return cll;
         }
     }
@@ -432,7 +444,7 @@ void cAbstractStructure::setHeight(int height)
 void cAbstractStructure::setRallyPoint(int cell)
 {
     d2tm_assert(cell > -2); // -1 is allowed (means disable);
-    d2tm_assert(cell < game.m_gameObjectsContext->getMap()->getMaxCells());
+    d2tm_assert(cell < m_objects->getMap()->getMaxCells());
     iRallyPoint = cell;
 }
 
@@ -474,7 +486,7 @@ void cAbstractStructure::decay(int hp)
             .entitySpecificType = getType()
         }
     };
-    game.onNotifyGameEvent(event);
+    m_interface->onNotifyGameEvent(event);
 }
 
 
@@ -510,9 +522,9 @@ void cAbstractStructure::damage(int hp, int originId)
         if (RNG::rnd(100) < iChance) {
             long x = getRandomPosX();
             long y = getRandomPosY();
-            int particleIndex = cParticle::create(x, y, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
+            int particleIndex = cParticle::create(x, y, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, m_objects, m_info);
             if (particleIndex > -1) {
-                TIMER_reduceSmoke = game.m_gameObjectsContext->getParticles()[particleIndex].getTimerDeadInTicks();
+                TIMER_reduceSmoke = m_objects->getParticles()[particleIndex].getTimerDeadInTicks();
                 m_smokeParticlesCreated++;
             }
         }
@@ -528,7 +540,7 @@ void cAbstractStructure::damage(int hp, int originId)
                 .originType = eBuildType::UNIT // TODO: What if another structure damaged me!?
             }
         };
-        game.onNotifyGameEvent(event);
+        m_interface->onNotifyGameEvent(event);
     }
 }
 
@@ -538,7 +550,7 @@ void cAbstractStructure::damage(int hp, int originId)
 void cAbstractStructure::setHitPoints(int hp)
 {
     iHitPoints = hp;
-    int maxHp = game.m_infoContext->getStructureInfo(getType()).hp;
+    int maxHp = m_info->getStructureInfo(getType()).hp;
 
     if (iHitPoints > maxHp) {
         logbook(std::format("setHitpoints({}) while max is {}; capped at max.", hp, maxHp));
@@ -554,8 +566,8 @@ void cAbstractStructure::setHitPoints(int hp)
 void cAbstractStructure::setCell(int cell)
 {
     iCell = cell;
-    posX = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteXPositionFromCell(iCell);
-    posY = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteYPositionFromCell(iCell);
+    posX = m_objects->getMapGeometry()->getAbsoluteXPositionFromCell(iCell);
+    posY = m_objects->getMapGeometry()->getAbsoluteYPositionFromCell(iCell);
 }
 
 void cAbstractStructure::setOwner(int player)
@@ -593,9 +605,9 @@ void cAbstractStructure::think_repair()
 {
     // REPAIRING (from think_fast, so called every 5 ms).
     if (bRepair) {
-        cPlayer *player = game.m_gameObjectsContext->getPlayer(iPlayer);
+        cPlayer *player = m_objects->getPlayer(iPlayer);
         float costToRepair = 1.0f;
-        s_StructureInfo &structureInfo = game.m_infoContext->getStructureInfo(getType());
+        s_StructureInfo &structureInfo = m_info->getStructureInfo(getType());
         if (player->hasEnoughCreditsFor(costToRepair)) {
             TIMER_repair++;
 
@@ -618,7 +630,7 @@ void cAbstractStructure::think_repair()
 
 s_StructureInfo cAbstractStructure::getStructureInfo() const
 {
-    return game.m_infoContext->getStructureInfo(getType());
+    return m_info->getStructureInfo(getType());
 }
 
 int cAbstractStructure::getPercentageNotPaved()
@@ -644,7 +656,7 @@ bool cAbstractStructure::isValid()
     if (dead) // flagged for deletion, so no longer 'valid'
         return false;
 
-    if (!game.m_gameObjectsContext->getMapGeometry()->isValidCell(iCell))
+    if (!m_objects->getMapGeometry()->isValidCell(iCell))
         return false;
 
     return true;
@@ -770,18 +782,18 @@ void cAbstractStructure::enterStructure(int unitId)
     setAnimating(false);
     setFrame(0);
 
-    cUnit *pUnit = game.m_gameObjectsContext->getUnit(unitId);
+    cUnit *pUnit = m_objects->getUnit(unitId);
 
     pUnit->hideUnit();
     pUnit->setCell(getCell());
     pUnit->updateCellXAndY();
 
-    game.m_gameObjectsContext->getMap()->remove_id(unitId, MAPID_UNITS);
+    m_objects->getMap()->remove_id(unitId, MAPID_UNITS);
 }
 
 void cAbstractStructure::unitLeavesStructure()
 {
-    cUnit *unitToLeave = game.m_gameObjectsContext->getUnit(iUnitIDWithinStructure);
+    cUnit *unitToLeave = m_objects->getUnit(iUnitIDWithinStructure);
     int iNewCell = getNonOccupiedCellAroundStructure();
 
     if (iNewCell > -1) {
@@ -809,7 +821,7 @@ void cAbstractStructure::unitLeavesStructure()
         unitToLeave->move_to(getRallyPoint(), -1, -1);
     }
 
-    game.m_gameObjectsContext->getMap()->cellSetIdForLayer(unitToLeave->getCell(), MAPID_UNITS, iUnitIDWithinStructure);
+    m_objects->getMap()->cellSetIdForLayer(unitToLeave->getCell(), MAPID_UNITS, iUnitIDWithinStructure);
 
     setUnitIdWithin(-1);
     setUnitIdHeadingTowards(-1);
@@ -830,7 +842,7 @@ void cAbstractStructure::unitHeadsTowardsStructure(int unitId)
 
 int cAbstractStructure::getRandomStructureCell()
 {
-    return getCell() + RNG::rnd(getWidth()) + (RNG::rnd(getHeight()) * game.m_gameObjectsContext->getMap()->getWidth());
+    return getCell() + RNG::rnd(getWidth()) + (RNG::rnd(getHeight()) * m_objects->getMap()->getWidth());
 }
 
 /**
@@ -903,8 +915,8 @@ void cAbstractStructure::drawWithShadow()
     int drawX = iDrawX();
     int drawY = iDrawY();
 
-    int scaledWidth = game.m_mapCamera->factorZoomLevel(pixelWidth);
-    int scaledHeight = game.m_mapCamera->factorZoomLevel(pixelHeight);
+    int scaledWidth = m_mapCamera->factorZoomLevel(pixelWidth);
+    int scaledHeight = m_mapCamera->factorZoomLevel(pixelHeight);
 
     Texture *bitmapToDraw = getBitmap();
 

--- a/src/gameobjects/structures/cAbstractStructure.h
+++ b/src/gameobjects/structures/cAbstractStructure.h
@@ -20,6 +20,12 @@
 
 class cPlayer;
 class Texture;
+class cGameObjectContext;
+class cInfoContext;
+class cMapCamera;
+class cGameInterface;
+class cGameSettings;
+struct sGameServices;
 
 class cAbstractStructure : public cScenarioObserver {
 
@@ -45,6 +51,12 @@ private:
     int iUnitIDHeadingForStructure;    // >-1 means ID to unit that heads for this structure
 
 protected:
+    cGameObjectContext *m_objects = nullptr;
+    cInfoContext *m_info = nullptr;
+    cMapCamera *m_mapCamera = nullptr;
+    cGameInterface *m_interface = nullptr;
+    cGameSettings *m_settings = nullptr;
+
     bool shouldAnimateWhenUnitHeadsTowardsStructure;
     int id;				// the id within the structure[] array
 
@@ -74,6 +86,8 @@ public:
     cAbstractStructure(); // default constructor
 
     virtual ~cAbstractStructure();
+
+    void serviceInit(sGameServices *services);
 
     float fConcrete;     // how much concrete is *not* beneath this building (percentage)?
     // meaning, when 0% , it is all concrete. But if 10%, it means 10% of the building

--- a/src/gameobjects/structures/cGunTurret.cpp
+++ b/src/gameobjects/structures/cGunTurret.cpp
@@ -1,7 +1,5 @@
 #include "cGunTurret.h"
 
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
 #include "definitions.h"
 #include "gameobjects/particles/cParticle.h"
@@ -14,6 +12,8 @@
 #include "utils/RNG.hpp"
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
+#include "game/cGameSettings.h"
+#include "game/cGameInterface.h"
 
 namespace {
 constexpr auto kTurretFacings = 8;
@@ -40,7 +40,7 @@ int cGunTurret::getType() const
 void cGunTurret::thinkFast()
 {
     bool lowPower = !getPlayer()->bEnoughPower();
-    if (lowPower && game.isTurretsDownOnLowPower()) {
+    if (lowPower && m_settings->isTurretsDownOnLowPower()) {
         // don't do anything when low power and this flag is set
         return;
     }
@@ -66,15 +66,15 @@ void cGunTurret::think_animation()
 
 void cGunTurret::think_attack()
 {
-    cUnit *unitTarget = game.m_gameObjectsContext->getUnit(iTargetID);
+    cUnit *unitTarget = m_objects->getUnit(iTargetID);
     if (unitTarget->isValid() && !unitTarget->isDead()) {
-        int iCellX = game.m_gameObjectsContext->getMapGeometry()->getCellX(getCell());
-        int iCellY = game.m_gameObjectsContext->getMapGeometry()->getCellY(getCell());
+        int iCellX = m_objects->getMapGeometry()->getCellX(getCell());
+        int iCellY = m_objects->getMapGeometry()->getCellY(getCell());
 
         int unitCell = unitTarget->getCell();
 
-        int iTargetX = game.m_gameObjectsContext->getMapGeometry()->getCellX(unitCell);
-        int iTargetY = game.m_gameObjectsContext->getMapGeometry()->getCellY(unitCell);
+        int iTargetX = m_objects->getMapGeometry()->getCellX(unitCell);
+        int iTargetY = m_objects->getMapGeometry()->getCellY(unitCell);
 
         int d = fDegrees(iCellX, iCellY, iTargetX, iTargetY);
         int facingAngle = faceAngle(d, kTurretFacings); // get the angle
@@ -143,11 +143,11 @@ void cGunTurret::think_fire()
 {
     bool lowPower = !getPlayer()->bEnoughPower();
 
-    cUnit *unitTarget = game.m_gameObjectsContext->getUnit(iTargetID);
+    cUnit *unitTarget = m_objects->getUnit(iTargetID);
     if (unitTarget->isValid() && !unitTarget->isDead()) {
         TIMER_fire++;
 
-        int iDistance = game.m_gameObjectsContext->getMapGeometry()->distance(getCell(), unitTarget->getCell());
+        int iDistance = m_objects->getMapGeometry()->distance(getCell(), unitTarget->getCell());
 
         if (iDistance > getRange()) {
             iTargetID = -1;
@@ -182,7 +182,7 @@ void cGunTurret::think_fire()
                     int iShootX = pos_x() + half;
                     int iShootY = pos_y() + half;
                     int bmp_head = convertAngleToDrawIndex(iHeadFacing);
-                    cParticle::create(iShootX, iShootY, D2TM_PARTICLE_TANKSHOOT, -1, bmp_head, game.m_gameObjectsContext.get(), game.m_infoContext.get());
+                    cParticle::create(iShootX, iShootY, D2TM_PARTICLE_TANKSHOOT, -1, bmp_head, m_objects, m_info);
                 }
             }
 
@@ -192,9 +192,9 @@ void cGunTurret::think_fire()
             if (unitTarget->isAirbornUnit()) {
                 if (iBull > -1 && bulletType == ROCKET_RTURRET) {
                     // it is a homing missile!
-                    game.m_gameObjectsContext->getBullets()[iBull].iHoming = iTargetID;
+                    m_objects->getBullets()[iBull].iHoming = iTargetID;
                     // TODO: property for homing?
-                    game.m_gameObjectsContext->getBullets()[iBull].TIMER_homing = 200;
+                    m_objects->getBullets()[iBull].TIMER_homing = 200;
                 }
             }
 
@@ -206,7 +206,7 @@ void cGunTurret::think_fire()
 void cGunTurret::think_guard()
 {
     bool lowPower = !getPlayer()->bEnoughPower();
-    if (lowPower && game.isTurretsDownOnLowPower()) {
+    if (lowPower && m_settings->isTurretsDownOnLowPower()) {
         // don't do anything when low power and this flag is set
         return;
     }
@@ -217,8 +217,8 @@ void cGunTurret::think_guard()
         TIMER_guard=0-RNG::rnd(20);
 
         int c = getCell();
-        int iCellX = game.m_gameObjectsContext->getMapGeometry()->getCellX(c);
-        int iCellY = game.m_gameObjectsContext->getMapGeometry()->getCellY(c);
+        int iCellX = m_objects->getMapGeometry()->getCellX(c);
+        int iCellY = m_objects->getMapGeometry()->getCellY(c);
 
         int iDistance=9999; // closest distance
 
@@ -232,17 +232,17 @@ void cGunTurret::think_guard()
 
         int distanceForAttacking = getRange();
         if (lowPower && getType() == RTURRET) {
-            distanceForAttacking = game.m_infoContext->getStructureInfo(TURRET).range;
+            distanceForAttacking = m_info->getStructureInfo(TURRET).range;
         }
 
         // scan area for units
-        for (int i = 0; i < game.m_gameObjectsContext->getUnits()->size(); i++) {
+        for (int i = 0; i < m_objects->getUnits()->size(); i++) {
             // is valid
-            cUnit *cUnit = game.m_gameObjectsContext->getUnit(i);
+            cUnit *cUnit = m_objects->getUnit(i);
             if (!cUnit->isValid()) continue;
             if (cUnit->iPlayer == getOwner()) continue; // skip own units
             if (cUnit->getPlayer()->isSameTeamAs(getPlayer())) continue; // skip allied units
-            if (!game.m_gameObjectsContext->getMap()->isVisible(cUnit->getCell(), getPlayer())) continue; // skip not visible
+            if (!m_objects->getMap()->isVisible(cUnit->getCell(), getPlayer())) continue; // skip not visible
 
             if (!canAttackAirUnits()) {
                 if (cUnit->isAirbornUnit()) {
@@ -251,7 +251,7 @@ void cGunTurret::think_guard()
             }
             else {
                 // we can attack air units, but we are low on power, hence we don't attack them
-                if (lowPower && game.isRocketTurretsDownOnLowPower()) {
+                if (lowPower && m_settings->isRocketTurretsDownOnLowPower()) {
                     // do not aim for air units when low power
                     if (cUnit->isAirbornUnit()) {
                         continue; // it was airborn, and this turret is down on power, so don't fire air units
@@ -260,7 +260,7 @@ void cGunTurret::think_guard()
             }
 
             int c1 = cUnit->getCell();
-            int distance = ABS_length(iCellX, iCellY, game.m_gameObjectsContext->getMapGeometry()->getCellX(c1), game.m_gameObjectsContext->getMapGeometry()->getCellY(c1));
+            int distance = ABS_length(iCellX, iCellY, m_objects->getMapGeometry()->getCellX(c1), m_objects->getMapGeometry()->getCellY(c1));
 
             if (distance <= distanceForAttacking) {
                 if (cUnit->isAttackableAirUnit()) {
@@ -290,7 +290,7 @@ void cGunTurret::think_guard()
 
         // discovered a new target
         if (iTargetID > -1 && iTargetID != prevTarget) {
-            cUnit *unitToAttack = game.m_gameObjectsContext->getUnit(iTargetID);
+            cUnit *unitToAttack = m_objects->getUnit(iTargetID);
             if (unitToAttack->isValid()) {
                 const s_GameEvent event {
                     .eventType = eGameEventType::GAME_EVENT_DISCOVERED,
@@ -302,7 +302,7 @@ void cGunTurret::think_guard()
                         .atCell = unitToAttack->getCell()
                     }
                 };
-                game.onNotifyGameEvent(event);
+                m_interface->onNotifyGameEvent(event);
             }
         }
     }

--- a/src/gameobjects/structures/cHeavyFactory.cpp
+++ b/src/gameobjects/structures/cHeavyFactory.cpp
@@ -1,8 +1,7 @@
 #include "cHeavyFactory.h"
 
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "definitions.h"
+#include "include/d2tmc.h"
 #include "drawers/SDLDrawer.hpp"
 #include "gameobjects/map/cMapCamera.h"
 #include "gameobjects/players/cPlayer.h"
@@ -89,8 +88,8 @@ void cHeavyFactory::draw()
         int drawX = iDrawX();
         int drawY = iDrawY();
 
-        int scaledWidth = game.m_mapCamera->factorZoomLevel(pixelWidth);
-        int scaledHeight = game.m_mapCamera->factorZoomLevel(pixelHeight);
+        int scaledWidth = m_mapCamera->factorZoomLevel(pixelWidth);
+        int scaledHeight = m_mapCamera->factorZoomLevel(pixelHeight);
 
         Texture *bitmapToDraw = getPlayer()->getStructureBitmapFlash(getType());
         cRectangle src = { 0, iSourceY, pixelWidth, pixelHeight};

--- a/src/gameobjects/structures/cLightFactory.cpp
+++ b/src/gameobjects/structures/cLightFactory.cpp
@@ -1,6 +1,5 @@
 #include "cLightFactory.h"
 
-#include "game/cGame.h"
 #include "include/d2tmc.h"
 #include "drawers/SDLDrawer.hpp"
 #include "definitions.h"
@@ -75,8 +74,8 @@ void cLightFactory::draw()
         int drawX = iDrawX();
         int drawY = iDrawY();
 
-        int scaledWidth = game.m_mapCamera->factorZoomLevel(pixelWidth);
-        int scaledHeight = game.m_mapCamera->factorZoomLevel(pixelHeight);
+        int scaledWidth = m_mapCamera->factorZoomLevel(pixelWidth);
+        int scaledHeight = m_mapCamera->factorZoomLevel(pixelHeight);
 
         Texture *bitmapToDraw = getPlayer()->getStructureBitmapFlash(getType());
         cRectangle src = { 0, iSourceY, pixelWidth, pixelHeight};

--- a/src/gameobjects/structures/cOrderProcesser.cpp
+++ b/src/gameobjects/structures/cOrderProcesser.cpp
@@ -6,11 +6,8 @@
  */
 #include "cOrderProcesser.h"
 #include "utils/RNG.hpp"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "managers/cDrawManager.h"
 #include "gameobjects/players/cPlayer.h"
-#include "utils/cSoundPlayer.h"
 #include "utils/d2tm_math.h"
 #include "gameobjects/structures/cStructures.h"
 #include "gameobjects/units/cUnits.h"
@@ -18,6 +15,10 @@
 #include <format>
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
+#include "context/GameContext.hpp"
+#include "include/sGameServices.h"
+#include "game/cGameInterface.h"
+#include "utils/cStructureUtils.h"
 #include "data/gfxaudio.h"
 
 cOrderProcesser::cOrderProcesser(cPlayer *thePlayer)
@@ -38,6 +39,14 @@ cOrderProcesser::~cOrderProcesser()
 {
     removeAllItems();
     m_player = nullptr;
+}
+
+void cOrderProcesser::serviceInit(sGameServices *services)
+{
+    m_objects = services->objects;
+    m_info = services->info;
+    m_structureUtils = services->structureUtils;
+    m_interface = services->ctx->getGameInterface();
 }
 
 cBuildingListItem *cOrderProcesser::getItemToDeploy()
@@ -103,7 +112,7 @@ void cOrderProcesser::playTMinusSound(int seconds)
     }
 
     if (soundIdToPlay > -1) {
-        game.playSound(soundIdToPlay);
+        m_interface->playSound(soundIdToPlay);
     }
 }
 
@@ -121,10 +130,10 @@ void cOrderProcesser::think()
 
         if (m_secondsUntilArrival == 0) {
             sendFrigate();
-            game.m_drawManager->setMessage("Frigate is arriving...");
+            m_interface->getDrawManager()->setMessage("Frigate is arriving...");
         }
         else {
-            game.m_drawManager->setMessage(msg);
+            m_interface->getDrawManager()->setMessage(msg);
         }
     }
 
@@ -145,7 +154,7 @@ void cOrderProcesser::updatePricesForStarport()
         cBuildingListItem *item = list->getItem(i);
         if (item) {
             int id = item->getBuildId();
-            int originalPrice = game.m_infoContext->getUnitInfo(id).cost;
+            int originalPrice = m_info->getUnitInfo(id).cost;
             int slice = originalPrice / 2;
             int newPrice = (originalPrice - slice) + (RNG::rnd(slice * 2));
             item->setBuildCost(newPrice);
@@ -229,14 +238,14 @@ void cOrderProcesser::sendFrigate()
 {
     // iCll = structure start cell (up left), since we must go to the center
     // of the cell:
-    int structureId = game.m_structureUtils->findStarportToDeployUnit(m_player);
+    int structureId = m_structureUtils->findStarportToDeployUnit(m_player);
 
     if (structureId > -1) {
         // found structure
-        game.m_gameObjectsContext->getStructures()[structureId]->setAnimating(true);
-        int destinationCell = game.m_gameObjectsContext->getStructures()[structureId]->getCell();
+        m_objects->getStructures()[structureId]->setAnimating(true);
+        int destinationCell = m_objects->getStructures()[structureId]->getCell();
 
-        int iStartCell = game.m_gameObjectsContext->getMap()->findCloseMapBorderCellRelativelyToDestinationCel(destinationCell);
+        int iStartCell = m_objects->getMap()->findCloseMapBorderCellRelativelyToDestinationCel(destinationCell);
 
         if (iStartCell < 0) {
             logbook("cOrderProcesser::sendFrigate : unable to find start cell to spawn frigate");
@@ -251,21 +260,21 @@ void cOrderProcesser::sendFrigate()
             }
 
             // STEP 2b: make sure its facing the starport directly
-            int iCellX = game.m_gameObjectsContext->getMapGeometry()->getCellX(iStartCell);
-            int iCellY = game.m_gameObjectsContext->getMapGeometry()->getCellY(iStartCell);
-            int cx = game.m_gameObjectsContext->getMapGeometry()->getCellX(destinationCell);
-            int cy = game.m_gameObjectsContext->getMapGeometry()->getCellY(destinationCell);
+            int iCellX = m_objects->getMapGeometry()->getCellX(iStartCell);
+            int iCellY = m_objects->getMapGeometry()->getCellY(iStartCell);
+            int cx = m_objects->getMapGeometry()->getCellX(destinationCell);
+            int cy = m_objects->getMapGeometry()->getCellY(destinationCell);
 
             int d = fDegrees(iCellX, iCellY, cx, cy);
             Facing f = facingFromInt(faceAngle(d)); // get the angle
 
-            game.m_gameObjectsContext->getUnit(unitId)->rendering.iBodyShouldFace = f;
-            game.m_gameObjectsContext->getUnit(unitId)->rendering.iBodyFacing = f;
-            game.m_gameObjectsContext->getUnit(unitId)->rendering.iHeadShouldFace = f;
-            game.m_gameObjectsContext->getUnit(unitId)->rendering.iHeadFacing = f;
+            m_objects->getUnit(unitId)->rendering.iBodyShouldFace = f;
+            m_objects->getUnit(unitId)->rendering.iBodyFacing = f;
+            m_objects->getUnit(unitId)->rendering.iHeadShouldFace = f;
+            m_objects->getUnit(unitId)->rendering.iHeadFacing = f;
 
             // STEP 3: assign order to frigate (use carryall order function)
-            game.m_gameObjectsContext->getUnit(unitId)->carryall_order(-1, eTransferType::NEW_LEAVE, destinationCell, -1);
+            m_objects->getUnit(unitId)->carryall_order(-1, eTransferType::NEW_LEAVE, destinationCell, -1);
             m_unitIdOfFrigateSent = unitId;
             m_frigateSent = true;
         }

--- a/src/gameobjects/structures/cOrderProcesser.cpp
+++ b/src/gameobjects/structures/cOrderProcesser.cpp
@@ -31,7 +31,6 @@ cOrderProcesser::cOrderProcesser(cPlayer *thePlayer)
     m_secondsUntilNewPricesWillBeCalculated = 1; // initially randomize prices immediately
     memset(m_pricePaidForItem, -1, sizeof(m_pricePaidForItem));
     removeAllItems();
-    updatePricesForStarport();
     m_unitIdOfFrigateSent = -1;
 }
 
@@ -47,6 +46,7 @@ void cOrderProcesser::serviceInit(sGameServices *services)
     m_info = services->info;
     m_structureUtils = services->structureUtils;
     m_interface = services->ctx->getGameInterface();
+    updatePricesForStarport();
 }
 
 cBuildingListItem *cOrderProcesser::getItemToDeploy()

--- a/src/gameobjects/structures/cOrderProcesser.h
+++ b/src/gameobjects/structures/cOrderProcesser.h
@@ -3,6 +3,12 @@
 #include "sidebar/cBuildingListItem.h"
 
 class cPlayer;
+class cGameObjectContext;
+class cInfoContext;
+class cGameInterface;
+class cStructureUtils;
+class cDrawManager;
+struct sGameServices;
 
 class cOrderProcesser {
 private:
@@ -12,6 +18,8 @@ public:
     explicit cOrderProcesser(cPlayer *thePlayer);
 
     ~cOrderProcesser();
+
+    void serviceInit(sGameServices *services);
 
     void think();    // time based (per second)
     void updatePricesForStarport();
@@ -74,6 +82,10 @@ private:
     int m_pricePaidForItem[kMaxItemsToOrder];
 
     cPlayer *m_player;
+    cGameObjectContext *m_objects = nullptr;
+    cInfoContext *m_info = nullptr;
+    cGameInterface *m_interface = nullptr;
+    cStructureUtils *m_structureUtils = nullptr;
 
     bool m_orderPlaced;
 

--- a/src/gameobjects/structures/cRefinery.cpp
+++ b/src/gameobjects/structures/cRefinery.cpp
@@ -1,15 +1,13 @@
 #include "cRefinery.h"
 
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "definitions.h"
 #include "data/gfxaudio.h"
 #include "gameobjects/units/cUnit.h"
 #include "gameobjects/players/cPlayer.h"
-#include "utils/cSoundPlayer.h"
 #include "gameobjects/players/cPlayerDifficultySettings.h"
-#include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
+#include "context/cInfoContext.h"
+#include "game/cGameInterface.h"
 
 cRefinery::cRefinery()
 {
@@ -35,7 +33,7 @@ void cRefinery::thinkFast()
 void cRefinery::think_unit_occupation()
 {
     int iUnitID = getUnitIdWithin();
-    cUnit *cUnit = game.m_gameObjectsContext->getUnit(iUnitID);
+    cUnit *cUnit = m_objects->getUnit(iUnitID);
 
     // the unit id is filled in, that means the unit is IN this structure
     // the TIMER_harvest of the unit will be used to dump the harvest in the
@@ -54,7 +52,7 @@ void cRefinery::think_unit_occupation()
         int iAmount = 5;
 
         // cap at max
-        s_UnitInfo &unitType = game.m_infoContext->getUnitInfo(cUnit->iType);
+        s_UnitInfo &unitType = m_info->getUnitInfo(cUnit->iType);
 
         if (cUnit->iCredits > unitType.credit_capacity) {
             cUnit->iCredits = unitType.credit_capacity;
@@ -78,7 +76,7 @@ void cRefinery::think_unit_occupation()
 
     // let player know...
     if (pPlayer->isHuman()) {
-        game.playVoice(SOUND_VOICE_02_ATR, pPlayer->getId());
+        m_interface->playVoice(SOUND_VOICE_02_ATR, pPlayer->getId());
     }
 
     // perhaps we can find a carryall to help us out
@@ -140,6 +138,6 @@ void cRefinery::think_guard()
 /*  STRUCTURE SPECIFIC FUNCTIONS  */
 int cRefinery::getSpiceSiloCapacity()
 {
-    float percentage = ((float) getHitPoints() / (float) game.m_infoContext->getStructureInfo(getType()).hp);
+    float percentage = ((float) getHitPoints() / (float) m_info->getStructureInfo(getType()).hp);
     return 1000 * percentage;
 }

--- a/src/gameobjects/structures/cRepairFacility.cpp
+++ b/src/gameobjects/structures/cRepairFacility.cpp
@@ -1,11 +1,8 @@
 #include "cRepairFacility.h"
 
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "definitions.h"
 #include "gameobjects/units/cUnit.h"
 #include "gameobjects/players/cPlayer.h"
-#include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
 
 cRepairFacility::cRepairFacility()
@@ -35,7 +32,7 @@ void cRepairFacility::thinkFast()
 void cRepairFacility::think_repairUnit()  // must repair...
 {
     int iUnitID = getUnitIdWithin();
-    cUnit *unitToRepair = game.m_gameObjectsContext->getUnit(iUnitID);
+    cUnit *unitToRepair = m_objects->getUnit(iUnitID);
 //    int maxHpForUnitType = game.m_infoContext->getUnitInfo(unitToRepair->iType).hp;
 
     if (unitToRepair->requiresRepairing()) {

--- a/src/gameobjects/structures/cSpiceSilo.cpp
+++ b/src/gameobjects/structures/cSpiceSilo.cpp
@@ -1,8 +1,5 @@
 #include "cSpiceSilo.h"
 #include "context/cInfoContext.h"
-#include "context/cGameObjectContext.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "definitions.h"
 
 cSpiceSilo::cSpiceSilo()
@@ -38,6 +35,6 @@ void cSpiceSilo::think_guard()
 /*  STRUCTURE SPECIFIC FUNCTIONS  */
 int cSpiceSilo::getSpiceSiloCapacity()
 {
-    float percentage = ((float) getHitPoints() / (float) game.m_infoContext->getStructureInfo(getType()).hp);
+    float percentage = ((float) getHitPoints() / (float) m_info->getStructureInfo(getType()).hp);
     return 1000 * percentage;
 }

--- a/src/gameobjects/structures/cStarPort.cpp
+++ b/src/gameobjects/structures/cStarPort.cpp
@@ -1,18 +1,15 @@
 #include "cStarPort.h"
 
 #include "cOrderProcesser.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
 #include "definitions.h"
 #include "data/gfxaudio.h"
 #include "gameobjects/players/cPlayer.h"
 #include "gameobjects/players/cPlayers.h"
-#include "utils/cSoundPlayer.h"
 #include "gameobjects/units/cReinforcements.h"
 #include "gameobjects/units/cUnits.h"
-#include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
+#include "game/cGameInterface.h"
 
 cStarPort::cStarPort()
 {
@@ -78,7 +75,7 @@ void cStarPort::think_deploy()
         if (TIMER_deploy < 0) {
             TIMER_deploy = 1;
             // deploy unit
-            cOrderProcesser *orderProcesser = game.m_gameObjectsContext->getPlayer(iPlayer)->getOrderProcesser();
+            cOrderProcesser *orderProcesser = m_objects->getPlayer(iPlayer)->getOrderProcesser();
             cBuildingListItem *item = orderProcesser->getItemToDeploy();
             if (item) {
                 int cellToDeployTo = getNonOccupiedCellAroundStructure();
@@ -89,9 +86,9 @@ void cStarPort::think_deploy()
                 if (cellToDeployTo >= 0) {
                     int id = cUnits::unitCreate(cellToDeployTo, item->getBuildId(), iPlayer, true);
                     if (rallyPoint > -1) {
-                        game.m_gameObjectsContext->getUnit(id)->move_to(rallyPoint, -1, -1);
+                        m_objects->getUnit(id)->move_to(rallyPoint, -1, -1);
                     }
-                    game.playVoice(SOUND_VOICE_05_ATR, iPlayer); // unit deployed
+                    m_interface->playVoice(SOUND_VOICE_05_ATR, iPlayer); // unit deployed
                 }
                 else {
                     // could not find cell to deploy to, reinforce it
@@ -104,7 +101,7 @@ void cStarPort::think_deploy()
                         // assume that the cell to drop is the location of the structure itself
                         cellToDeployTo = getCell();
                     }
-                    int cellAtBorderOfMap = game.m_gameObjectsContext->getMap()->findCloseMapBorderCellRelativelyToDestinationCel(cellToDeployTo);
+                    int cellAtBorderOfMap = m_objects->getMap()->findCloseMapBorderCellRelativelyToDestinationCel(cellToDeployTo);
                     REINFORCE(iPlayer, item->getBuildId(), cellToDeployTo, cellAtBorderOfMap);
                 }
             }

--- a/src/gameobjects/structures/cStructureFactory.cpp
+++ b/src/gameobjects/structures/cStructureFactory.cpp
@@ -4,6 +4,12 @@
 #include "gameobjects/structures/cStructures.h"
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
+#include "context/GameContext.hpp"
+#include "include/sGameServices.h"
+#include "game/cGameInterface.h"
+#include "game/cGameSettings.h"
+#include "utils/cStructureUtils.h"
+#include "gameobjects/map/cMapCamera.h"
 
 #include "cBarracks.h"
 #include "cConstYard.h"
@@ -21,12 +27,9 @@
 #include "cStarPort.h"
 #include "cWindTrap.h"
 #include "cWor.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "data/gfxdata.h"
 #include "gameobjects/map/cMapEditor.h"
 #include "gameobjects/map/MapGeometry.hpp"
-#include "utils/cStructureUtils.h"
 #include "gameobjects/players/cPlayer.h"
 #include "gameobjects/players/cPlayers.h"
 #include "utils/cLog.h"
@@ -35,6 +38,17 @@
 
 cStructureFactory::cStructureFactory()
 {
+}
+
+void cStructureFactory::serviceInit(sGameServices *services)
+{
+    m_services = services;
+    m_objects = services->objects;
+    m_info = services->info;
+    m_mapCamera = services->mapCamera;
+    m_settings = services->settings;
+    m_structureUtils = services->structureUtils;
+    m_interface = services->ctx->getGameInterface();
 }
 
 cStructureFactory::~cStructureFactory()
@@ -68,7 +82,7 @@ cAbstractStructure *cStructureFactory::createStructureInstance(int type)
 void cStructureFactory::deleteStructureInstance(cAbstractStructure *pStructure)
 {
     // delete memory acquired
-    game.m_gameObjectsContext->getStructures()[pStructure->getStructureId()] = nullptr;
+    m_objects->getStructures()[pStructure->getStructureId()] = nullptr;
     delete pStructure;
 }
 
@@ -104,7 +118,7 @@ cAbstractStructure *cStructureFactory::createStructure(int iCell, int iStructure
 
     float fPercent = (float)iPercent/100; // divide by 100 (to make it 0.x)
 
-    s_StructureInfo &structureInfo = game.m_infoContext->getStructureInfo(iStructureType);
+    s_StructureInfo &structureInfo = m_info->getStructureInfo(iStructureType);
     int hp = structureInfo.hp;
     if (hp < 0) {
         cLogger::getInstance()->log(LOG_INFO, COMP_STRUCTURES, "create structure", "Structure to create has no hp, aborting creation.");
@@ -126,8 +140,8 @@ cAbstractStructure *cStructureFactory::createStructure(int iCell, int iStructure
         return nullptr; // fail
     }
 
-    cPoint absTopLeft = game.m_gameObjectsContext->getMapGeometry()->getAbsolutePositionFromCell(iCell);
-    cPlayer *player = game.m_gameObjectsContext->getPlayer(iPlayer);
+    cPoint absTopLeft = m_objects->getMapGeometry()->getAbsolutePositionFromCell(iCell);
+    cPlayer *player = m_objects->getPlayer(iPlayer);
 
     for (auto flag : structureInfo.flags) {
         cPoint pos = cPoint(
@@ -136,10 +150,10 @@ cAbstractStructure *cStructureFactory::createStructure(int iCell, int iStructure
                      );
 
         if (flag.big) {
-            str->addFlag(cFlag::createBigFlag(player, pos, game.m_mapCamera, game.m_gameSettings.get()));
+            str->addFlag(cFlag::createBigFlag(player, pos, m_mapCamera, m_settings));
         }
         else {
-            str->addFlag(cFlag::createSmallFlag(player, pos, game.m_mapCamera, game.m_gameSettings.get()));
+            str->addFlag(cFlag::createSmallFlag(player, pos, m_mapCamera, m_settings));
         }
     }
 
@@ -152,7 +166,8 @@ cAbstractStructure *cStructureFactory::createStructure(int iCell, int iStructure
     int structureSize = structureInfo.bmp_width * structureInfo.bmp_height;
 
     // assign to array
-    game.m_gameObjectsContext->getStructures()[iNewId] = str;
+    str->serviceInit(m_services);
+    m_objects->getStructures()[iNewId] = str;
 
     // Now set it up for location & player
     str->setCell(iCell);
@@ -175,7 +190,7 @@ cAbstractStructure *cStructureFactory::createStructure(int iCell, int iStructure
         REINFORCE(iPlayer, HARVESTER, iCell, -1);
     }
 
-    game.m_structureUtils->putStructureOnDimension(MAPID_STRUCTURES, str);
+    m_structureUtils->putStructureOnDimension(MAPID_STRUCTURES, str);
 
     // handle update
     const s_GameEvent event {
@@ -187,7 +202,7 @@ cAbstractStructure *cStructureFactory::createStructure(int iCell, int iStructure
             .entitySpecificType = iStructureType
         }
     };
-    game.onNotifyGameEvent(event);
+    m_interface->onNotifyGameEvent(event);
 
     return str;
 }
@@ -200,10 +215,10 @@ cAbstractStructure *cStructureFactory::createStructure(int iCell, int iStructure
 void cStructureFactory::updatePlayerCatalogAndPlaceNonStructureTypeIfApplicable(int iCell, int iStructureType, int iPlayer)
 {
     // add this structure to the array of the player (for some score management)
-    cPlayer *cPlayer = game.m_gameObjectsContext->getPlayer(iPlayer);
+    cPlayer *cPlayer = m_objects->getPlayer(iPlayer);
     cPlayer->increaseStructureAmount(iStructureType);
 
-    auto mapEditor = cMapEditor(game.m_gameObjectsContext->getMap());
+    auto mapEditor = cMapEditor(m_objects->getMap());
 
     if (iStructureType == SLAB1) {
         mapEditor.createCell(iCell, TERRAIN_SLAB, 0);
@@ -211,29 +226,29 @@ void cStructureFactory::updatePlayerCatalogAndPlaceNonStructureTypeIfApplicable(
     }
 
     if (iStructureType == SLAB4) {
-        if (game.m_gameObjectsContext->getMap()->occupiedByUnit(iCell) == false) {
-            if (game.m_gameObjectsContext->getMap()->getCellType(iCell) == TERRAIN_ROCK) {
+        if (m_objects->getMap()->occupiedByUnit(iCell) == false) {
+            if (m_objects->getMap()->getCellType(iCell) == TERRAIN_ROCK) {
                 mapEditor.createCell(iCell, TERRAIN_SLAB, 0);
             }
         }
 
-        int cellRight = game.m_gameObjectsContext->getMapGeometry()->getCellRight(iCell);
-        if (game.m_gameObjectsContext->getMap()->occupiedByUnit(cellRight) == false) {
-            if (game.m_gameObjectsContext->getMap()->getCellType(cellRight) == TERRAIN_ROCK) {
+        int cellRight = m_objects->getMapGeometry()->getCellRight(iCell);
+        if (m_objects->getMap()->occupiedByUnit(cellRight) == false) {
+            if (m_objects->getMap()->getCellType(cellRight) == TERRAIN_ROCK) {
                 mapEditor.createCell(cellRight, TERRAIN_SLAB, 0);
             }
         }
 
-        int oneRowBelowCell = game.m_gameObjectsContext->getMapGeometry()->getCellBelow(iCell);
-        if (game.m_gameObjectsContext->getMap()->occupiedByUnit(oneRowBelowCell) == false) {
-            if (game.m_gameObjectsContext->getMap()->getCellType(oneRowBelowCell) == TERRAIN_ROCK) {
+        int oneRowBelowCell = m_objects->getMapGeometry()->getCellBelow(iCell);
+        if (m_objects->getMap()->occupiedByUnit(oneRowBelowCell) == false) {
+            if (m_objects->getMap()->getCellType(oneRowBelowCell) == TERRAIN_ROCK) {
                 mapEditor.createCell(oneRowBelowCell, TERRAIN_SLAB, 0);
             }
         }
 
-        int rightToRowBelowCell = game.m_gameObjectsContext->getMapGeometry()->getCellRight(oneRowBelowCell);
-        if (game.m_gameObjectsContext->getMap()->occupiedByUnit(rightToRowBelowCell) == false) {
-            if (game.m_gameObjectsContext->getMap()->getCellType(rightToRowBelowCell) == TERRAIN_ROCK) {
+        int rightToRowBelowCell = m_objects->getMapGeometry()->getCellRight(oneRowBelowCell);
+        if (m_objects->getMap()->occupiedByUnit(rightToRowBelowCell) == false) {
+            if (m_objects->getMap()->getCellType(rightToRowBelowCell) == TERRAIN_ROCK) {
                 mapEditor.createCell(rightToRowBelowCell, TERRAIN_SLAB, 0);
             }
         }
@@ -260,7 +275,7 @@ void cStructureFactory::clearFogForStructureType(int iCell, cAbstractStructure *
         return;
     }
 
-    clearFogForStructureType(iCell, str->getType(), game.m_infoContext->getStructureInfo(str->getType()).sight, str->getOwner());
+    clearFogForStructureType(iCell, str->getType(), m_info->getStructureInfo(str->getType()).sight, str->getOwner());
 }
 
 /**
@@ -269,17 +284,17 @@ void cStructureFactory::clearFogForStructureType(int iCell, cAbstractStructure *
 **/
 void cStructureFactory::clearFogForStructureType(int iCell, int iStructureType, int iSight, int iPlayer)
 {
-    int iWidth = game.m_infoContext->getStructureInfo(iStructureType).bmp_width / 32;;
-    int iHeight = game.m_infoContext->getStructureInfo(iStructureType).bmp_height / 32;
+    int iWidth = m_info->getStructureInfo(iStructureType).bmp_width / 32;;
+    int iHeight = m_info->getStructureInfo(iStructureType).bmp_height / 32;
 
-    int iCellX = game.m_gameObjectsContext->getMapGeometry()->getCellX(iCell);
-    int iCellY = game.m_gameObjectsContext->getMapGeometry()->getCellY(iCell);
+    int iCellX = m_objects->getMapGeometry()->getCellX(iCell);
+    int iCellY = m_objects->getMapGeometry()->getCellY(iCell);
     int iCellXMax = iCellX + iWidth;
     int iCellYMax = iCellY + iHeight;
 
     for (int x = iCellX; x < iCellXMax; x++) {
         for (int y = iCellY; y < iCellYMax; y++) {
-            game.m_gameObjectsContext->getMap()->clearShroud(game.m_gameObjectsContext->getMapGeometry()->makeCell(x, y), iSight, iPlayer);
+            m_objects->getMap()->clearShroud(m_objects->getMapGeometry()->makeCell(x, y), iSight, iPlayer);
         }
     }
 }
@@ -290,7 +305,7 @@ void cStructureFactory::clearFogForStructureType(int iCell, int iStructureType, 
 int cStructureFactory::getFreeSlot()
 {
     for (int i=0; i < MAX_STRUCTURES; i++) {
-        if (game.m_gameObjectsContext->getStructures()[i] == nullptr) {
+        if (m_objects->getStructures()[i] == nullptr) {
             return i;
         }
     }
@@ -313,27 +328,27 @@ int cStructureFactory::getFreeSlot()
 **/
 int cStructureFactory::getSlabStatus(int iCell, int iStructureType)
 {
-    if (!game.m_gameObjectsContext->getMapGeometry()->isValidCell(iCell)) return 0;
+    if (!m_objects->getMapGeometry()->isValidCell(iCell)) return 0;
 
     // checks if this structure can be placed on this cell
-    int w = game.m_infoContext->getStructureInfo(iStructureType).bmp_width / TILESIZE_WIDTH_PIXELS;
-    int h = game.m_infoContext->getStructureInfo(iStructureType).bmp_height / TILESIZE_HEIGHT_PIXELS;
+    int w = m_info->getStructureInfo(iStructureType).bmp_width / TILESIZE_WIDTH_PIXELS;
+    int h = m_info->getStructureInfo(iStructureType).bmp_height / TILESIZE_HEIGHT_PIXELS;
 
     int slabs = 0;
 
-    int x = game.m_gameObjectsContext->getMapGeometry()->getCellX(iCell);
-    int y = game.m_gameObjectsContext->getMapGeometry()->getCellY(iCell);
+    int x = m_objects->getMapGeometry()->getCellX(iCell);
+    int y = m_objects->getMapGeometry()->getCellY(iCell);
 
     for (int cx = 0; cx < w; cx++) {
         for (int cy = 0; cy < h; cy++) {
-            int cll = game.m_gameObjectsContext->getMapGeometry()->getCellWithMapBorders(cx + x, cy + y);
+            int cll = m_objects->getMapGeometry()->getCellWithMapBorders(cx + x, cy + y);
 
             if (cll < 0) {
                 continue;
             }
 
             // If the 'terrain' type is 'slab' increase value of found slabs.
-            if (game.m_gameObjectsContext->getMap()->getCellType(cll) == TERRAIN_SLAB) {
+            if (m_objects->getMap()->getCellType(cll) == TERRAIN_SLAB) {
                 slabs++;
             }
         }
@@ -347,18 +362,18 @@ void cStructureFactory::createSlabForStructureType(int iCell, int iStructureType
     // DUPLICATED BY slabStructure?
     d2tm_assert(iCell > -1);
 
-    int height = game.m_infoContext->getStructureInfo(iStructureType).bmp_height / 32;
-    int width = game.m_infoContext->getStructureInfo(iStructureType).bmp_width / 32;
+    int height = m_info->getStructureInfo(iStructureType).bmp_height / 32;
+    int width = m_info->getStructureInfo(iStructureType).bmp_width / 32;
 
-    int cellX = game.m_gameObjectsContext->getMapGeometry()->getCellX(iCell);
-    int cellY = game.m_gameObjectsContext->getMapGeometry()->getCellY(iCell);
+    int cellX = m_objects->getMapGeometry()->getCellX(iCell);
+    int cellY = m_objects->getMapGeometry()->getCellY(iCell);
 
     int endCellX = cellX + width;
     int endCellY = cellY + height;
-    auto mapEditor = cMapEditor(game.m_gameObjectsContext->getMap());
+    auto mapEditor = cMapEditor(m_objects->getMap());
     for (int y = cellY; y < endCellY; y++) {
         for (int x = cellX; x < endCellX; x++) {
-            int cell = game.m_gameObjectsContext->getMapGeometry()->getCellWithMapDimensions(x, y);
+            int cell = m_objects->getMapGeometry()->getCellWithMapDimensions(x, y);
             mapEditor.createCell(cell, TERRAIN_SLAB, 0);
         }
     }
@@ -366,35 +381,35 @@ void cStructureFactory::createSlabForStructureType(int iCell, int iStructureType
 
 void cStructureFactory::deleteAllExistingStructures()
 {
-    if (game.m_gameObjectsContext == nullptr)
+    if (m_objects == nullptr)
         return;
     for (int i=0; i < MAX_STRUCTURES; i++) {
         // clear out all structures
-        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[i];
+        cAbstractStructure *pStructure = m_objects->getStructures()[i];
         if (pStructure) {
             delete pStructure;
         }
         // clear pointer
-        game.m_gameObjectsContext->getStructures()[i] = nullptr;
+        m_objects->getStructures()[i] = nullptr;
     }
 }
 
 void cStructureFactory::slabStructure(int iCll, int iStructureType, int iPlayer)
 {
-    const s_StructureInfo &sStructures = game.m_infoContext->getStructureInfo(iStructureType);
+    const s_StructureInfo &sStructures = m_info->getStructureInfo(iStructureType);
 
     int width = sStructures.bmp_width / TILESIZE_WIDTH_PIXELS;
     int height = sStructures.bmp_height / TILESIZE_HEIGHT_PIXELS;
 
-    int x = game.m_gameObjectsContext->getMapGeometry()->getCellX(iCll);
-    int y = game.m_gameObjectsContext->getMapGeometry()->getCellY(iCll);
+    int x = m_objects->getMapGeometry()->getCellX(iCll);
+    int y = m_objects->getMapGeometry()->getCellY(iCll);
 
     int endX = x + width;
     int endY = y + height;
 
     for (int sx = x; sx < endX; sx++) {
         for (int sy = y; sy < endY; sy++) {
-            createStructure(game.m_gameObjectsContext->getMapGeometry()->getCellWithMapBorders(sx, sy), SLAB1, iPlayer);
+            createStructure(m_objects->getMapGeometry()->getCellWithMapBorders(sx, sy), SLAB1, iPlayer);
         }
     }
 }

--- a/src/gameobjects/structures/cStructureFactory.h
+++ b/src/gameobjects/structures/cStructureFactory.h
@@ -14,11 +14,21 @@
 
 #include "cAbstractStructure.h"
 
+class cGameObjectContext;
+class cInfoContext;
+class cMapCamera;
+class cGameInterface;
+class cGameSettings;
+class cStructureUtils;
+struct sGameServices;
+
 class cStructureFactory {
 public:
     cStructureFactory();
 
     ~cStructureFactory();
+
+    void serviceInit(sGameServices *services);
 
     void deleteStructureInstance(cAbstractStructure *pStructure);
 
@@ -43,5 +53,13 @@ public:
     void slabStructure(int iCll, int iStructureType, int iPlayer);
 
 private:
+    cGameObjectContext *m_objects = nullptr;
+    cInfoContext *m_info = nullptr;
+    cMapCamera *m_mapCamera = nullptr;
+    cGameInterface *m_interface = nullptr;
+    cGameSettings *m_settings = nullptr;
+    cStructureUtils *m_structureUtils = nullptr;
+    sGameServices *m_services = nullptr;
+
     cAbstractStructure *createStructureInstance(int type);
 };

--- a/src/gameobjects/structures/cWindTrap.cpp
+++ b/src/gameobjects/structures/cWindTrap.cpp
@@ -1,13 +1,10 @@
 #include "cWindTrap.h"
 
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "utils/cLog.h"
 #include "definitions.h"
 #include "gameobjects/players/cPlayer.h"
 #include "utils/RNG.hpp"
 #include "context/cInfoContext.h"
-#include "context/cGameObjectContext.h"
 #include <format>
 
 // Constructor
@@ -70,7 +67,7 @@ void cWindTrap::think_guard()
 /*  STRUCTURE SPECIFIC FUNCTIONS  */
 int cWindTrap::getPowerOut() const
 {
-    float percentage = ((float) getHitPoints() / (float) game.m_infoContext->getStructureInfo(getType()).hp);
+    float percentage = ((float) getHitPoints() / (float) m_info->getStructureInfo(getType()).hp);
     return getMaxPowerOut() * percentage;
 }
 


### PR DESCRIPTION
## Summary

- \`cAbstractStructure\` gains \`serviceInit(sGameServices*)\` with protected \`m_objects\`, \`m_info\`, \`m_mapCamera\`, \`m_settings\`, \`m_interface\` members; all subclasses (\`cGunTurret\`, \`cRefinery\`, \`cStarPort\`, \`cWindTrap\`, \`cHeavyFactory\`, \`cLightFactory\`, \`cSpiceSilo\`, \`cRepairFacility\`) inherit and use them directly
- \`cStructureFactory\` gains \`serviceInit\`; calls \`str->serviceInit(m_services)\` on each newly created structure; wired from \`cGameObjectContext::serviceInit\`
- \`cOrderProcesser\` gains \`serviceInit\`; wired from \`cPlayers::setupRuntimePlayerComponents\`
- \`isTurretsDownOnLowPower\` / \`isRocketTurretsDownOnLowPower\` moved from \`cGame\` member variables into \`cGameSettings\` getters/setters (the values are game config, not game state)

Part of #1254.

## Test plan

- [x] \`./rebuildmacos.sh\` passes with zero errors, 43/43 tests pass
- [x] \`grep -rn "game\\." src/gameobjects/structures/\` returns empty