### PR TITLE
Step 11 of 15: src/gameobjects/units/ and src/gameobjects/projectiles/ have zero game. references

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,7 @@ set(D2TM_SOURCES
     gameobjects/players/cPlayers.cpp
     gameobjects/players/cPlayerStatistics.cpp
     gameobjects/projectiles/bullet.cpp
+    gameobjects/projectiles/cBullets.cpp
     gameobjects/structures/cAbstractStructure.cpp
     gameobjects/structures/cBarracks.cpp
     gameobjects/structures/cConstYard.cpp

--- a/src/building/cItemBuilder.cpp
+++ b/src/building/cItemBuilder.cpp
@@ -254,7 +254,7 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                 if (structureToDeployUnit > -1) {
                     cAbstractStructure *pStructureToDeploy = m_services->objects->getStructures()[structureToDeployUnit];
                     pStructureToDeploy->setAnimating(true); // animate
-                    int unitId = cUnits::unitCreate(pStructureToDeploy->getCell(), buildId, m_player->getId(), false);
+                    int unitId = cUnits::unitCreate(m_services->objects, m_services->info, m_services->ctx->getGameInterface(), pStructureToDeploy->getCell(), buildId, m_player->getId(), false);
                     if (unitId > -1) {
                         int rallyPoint = pStructureToDeploy->getRallyPoint();
                         if (rallyPoint > -1) {
@@ -301,10 +301,10 @@ void cItemBuilder::itemIsDoneBuildingLogic(cBuildingListItem *item)
                             bool passable = m_services->objects->getMap()->isCellPassableForFootUnits(iCll);
 
                             if (passable) {
-                                cUnits::unitCreate(iCll, special.providesTypeId, FREMEN, false);
+                                cUnits::unitCreate(m_services->objects, m_services->info, m_services->ctx->getGameInterface(), iCll, special.providesTypeId, FREMEN, false);
                             }
                             else {
-                                REINFORCE(FREMEN, special.providesTypeId, iCll, -1);
+                                REINFORCE(m_services->objects, m_services->info, m_services->ctx->getGameInterface(), FREMEN, special.providesTypeId, iCll, -1);
                             }
 
                             int x = m_services->objects->getMapGeometry()->getCellX(iCll);
@@ -414,7 +414,7 @@ void cItemBuilder::deployUnit(cBuildingListItem *item, int buildId) const
         int cell = pStructureToDeploy->getNonOccupiedCellAroundStructure();
         if (cell > -1) {
             pStructureToDeploy->setAnimating(true); // animate
-            int unitId = cUnits::unitCreate(cell, buildIdToProduce, m_player->getId(), false);
+            int unitId = cUnits::unitCreate(m_services->objects, m_services->info, m_services->ctx->getGameInterface(), cell, buildIdToProduce, m_player->getId(), false);
             if (unitId > -1) {
                 int rallyPoint = pStructureToDeploy->getRallyPoint();
                 if (rallyPoint > -1) {
@@ -448,7 +448,7 @@ void cItemBuilder::deployUnit(cBuildingListItem *item, int buildId) const
             if (pStructureToDeploy->getRallyPoint() > -1) {
                 cellToDeploy = pStructureToDeploy->getRallyPoint();
             }
-            REINFORCE(m_player->getId(), buildIdToProduce, cellToDeploy, -1, false);
+            REINFORCE(m_services->objects, m_services->info, m_services->ctx->getGameInterface(), m_player->getId(), buildIdToProduce, cellToDeploy, -1, false);
         }
     }
 }

--- a/src/context/cGameObjectContext.cpp
+++ b/src/context/cGameObjectContext.cpp
@@ -165,4 +165,6 @@ void cGameObjectContext::serviceInit(sGameServices* services)
     m_particles->serviceInit(services);
     d2tm_assert(m_structureFactory != nullptr);
     m_structureFactory->serviceInit(services);
+    d2tm_assert(m_Bullets != nullptr);
+    m_Bullets->serviceInit(services);
 }

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -610,6 +610,7 @@ bool cGame::setupGame()
     std::shared_ptr<cIniFile> gamesCfg = std::make_shared<cIniFile>(m_gameFilename);
 
     m_reinforcements = std::make_unique<cReinforcements>();
+    m_reinforcements->serviceInit(m_services.get());
     m_gameObjectsContext->getMap()->setReinforcements(m_reinforcements.get());
 
     init(); // Must be first! (loads ini file at the end, which is required before going on...)

--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -2265,7 +2265,7 @@ void cPlayer::reinforceHarvesterIfNeeded(int cell)
 
             // found a refinery, deliver harvester to that
             if (refinery) {
-                REINFORCE(id, HARVESTER, refinery->getCell(), -1);
+                REINFORCE(m_objects, m_infos, m_interface, id, HARVESTER, refinery->getCell(), -1);
             }
         }
     }

--- a/src/gameobjects/projectiles/bullet.cpp
+++ b/src/gameobjects/projectiles/bullet.cpp
@@ -12,8 +12,8 @@
 
 #include "bullet.h"
 #include "game/cGameSettings.h"
+#include "game/cGameInterface.h"
 #include "data/gfxdata.h"
-#include "game/cGame.h"
 #include "include/d2tmc.h"
 #include "drawers/SDLDrawer.hpp"
 #include "gameobjects/particles/cParticle.h"
@@ -26,6 +26,7 @@
 #include "gameobjects/players/cPlayers.h"
 #include "utils/cSoundPlayer.h"
 #include "include/Texture.hpp"
+#include "include/sGameServices.h"
 #include "utils/RNG.hpp"
 #include "utils/d2tm_math.h"
 #include <format>
@@ -34,6 +35,7 @@
 #include "data/gfxaudio.h"
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
+#include "context/GameContext.hpp"
 
 static constexpr auto ANIMATION_SPEED = 12;
 
@@ -63,6 +65,15 @@ void cBullet::init()
     TIMER_homing = 0;   // when timer set, > 0 means homing
 }
 
+void cBullet::serviceInit(sGameServices *services)
+{
+    m_objects = services->objects;
+    m_info = services->info;
+    m_settings = services->settings;
+    m_interface = services->ctx->getGameInterface();
+    m_mapCamera = m_interface->getMapCamera();
+}
+
 int cBullet::pos_x() const
 {
     return posX;
@@ -76,13 +87,13 @@ int cBullet::pos_y() const
 int cBullet::draw_x()
 {
     int bmpOffset = (getBulletBmpWidth()/2) * -1;
-    return game.m_mapCamera->getWindowXPositionWithOffset(pos_x(), bmpOffset);
+    return m_mapCamera->getWindowXPositionWithOffset(pos_x(), bmpOffset);
 }
 
 int cBullet::draw_y()
 {
     int bmpOffset = (getBulletBmpHeight()/2) * -1;
-    return game.m_mapCamera->getWindowYPositionWithOffset(pos_y(), bmpOffset);
+    return m_mapCamera->getWindowYPositionWithOffset(pos_y(), bmpOffset);
 }
 
 // draw the bullet
@@ -91,10 +102,10 @@ void cBullet::draw()
     int x = draw_x();
     int y = draw_y();
 
-    if (x < -getBulletBmpWidth() || x > (game.m_gameSettings->getScreenW() + getBulletBmpWidth()))
+    if (x < -getBulletBmpWidth() || x > (m_settings->getScreenW() + getBulletBmpWidth()))
         return;
 
-    if (y < getBulletBmpHeight() || y > game.m_gameSettings->getScreenH() + getBulletBmpHeight())
+    if (y < getBulletBmpHeight() || y > m_settings->getScreenH() + getBulletBmpHeight())
         return;
 
     int ba = bullet_face_angle(fDegrees(posX, posY, targetX, targetY));
@@ -137,16 +148,16 @@ void cBullet::draw()
         return;
     }
 
-    if (game.m_infoContext->getBulletInfo(iType).bmp != nullptr) {
+    if (m_info->getBulletInfo(iType).bmp != nullptr) {
         cRectangle src = {sx,sy, bmp_width, bmp_width};
-        cRectangle dest = {x,y, static_cast<int>(round(game.m_mapCamera->factorZoomLevel(bmp_width))), static_cast<int>(round(game.m_mapCamera->factorZoomLevel(bmp_width)))};
-        global_renderDrawer->renderStrechSprite(game.m_infoContext->getBulletInfo(iType).bmp, src, dest);
+        cRectangle dest = {x,y, static_cast<int>(round(m_mapCamera->factorZoomLevel(bmp_width))), static_cast<int>(round(m_mapCamera->factorZoomLevel(bmp_width)))};
+        global_renderDrawer->renderStrechSprite(m_info->getBulletInfo(iType).bmp, src, dest);
     }
 }
 
 int cBullet::getBulletBmpWidth() const
 {
-    return game.m_infoContext->getBulletInfo(iType).bmp_width;
+    return m_info->getBulletInfo(iType).bmp_width;
 }
 
 int cBullet::getBulletBmpHeight() const
@@ -173,7 +184,7 @@ void cBullet::thinkFast()
             if (smokeParticle > -1) {
                 long x = pos_x();
                 long y = pos_y();
-                cParticle::create(x, y, smokeParticle, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
+                cParticle::create(x, y, smokeParticle, -1, -1, m_objects, m_info);
             }
 
             TIMER_frame = 0;
@@ -185,10 +196,10 @@ void cBullet::thinkFast()
         TIMER_homing--;
 
         if (iHoming > -1) {
-            if (game.m_gameObjectsContext->getUnit(iHoming)->isValid()) {
-                int cll = game.m_gameObjectsContext->getUnit(iHoming)->getCell();
-                targetX = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteXPositionFromCell(cll);
-                targetY = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteYPositionFromCell(cll);
+            if (m_objects->getUnit(iHoming)->isValid()) {
+                int cll = m_objects->getUnit(iHoming)->getCell();
+                targetX = m_objects->getMapGeometry()->getAbsoluteXPositionFromCell(cll);
+                targetY = m_objects->getMapGeometry()->getAbsoluteYPositionFromCell(cll);
             }
         }
     }
@@ -199,13 +210,13 @@ void cBullet::thinkFast()
 
 void cBullet::think_move()
 {
-    iCell = game.m_mapCamera->getCellFromAbsolutePosition(posX, posY);
+    iCell = m_mapCamera->getCellFromAbsolutePosition(posX, posY);
 
-    int iCellX = game.m_gameObjectsContext->getMapGeometry()->getCellX(iCell);
-    int iCellY = game.m_gameObjectsContext->getMapGeometry()->getCellY(iCell);
+    int iCellX = m_objects->getMapGeometry()->getCellX(iCell);
+    int iCellY = m_objects->getMapGeometry()->getCellY(iCell);
 
     // out of bounds somehow; then die
-    if (!game.m_gameObjectsContext->getMapGeometry()->isWithinBoundaries(iCellX, iCellY)) {
+    if (!m_objects->getMapGeometry()->isWithinBoundaries(iCellX, iCellY)) {
         die();
         return;
     }
@@ -218,8 +229,8 @@ void cBullet::think_move()
         return;
     }
 
-    int idOfStructureAtCell = game.m_gameObjectsContext->getMap()->getCellIdStructuresLayer(iCell);
-    int cellTypeAtCell = game.m_gameObjectsContext->getMap()->getCellType(iCell);
+    int idOfStructureAtCell = m_objects->getMap()->getCellIdStructuresLayer(iCell);
+    int cellTypeAtCell = m_objects->getMap()->getCellType(iCell);
 
     if (!isGroundBullet()) {
         return;
@@ -254,7 +265,7 @@ void cBullet::think_move()
             }
             else {
                 // do not hit own or allied structures
-                if (!game.m_gameObjectsContext->getStructures()[id]->getPlayer()->isSameTeamAs(getPlayer())) {
+                if (!m_objects->getStructures()[id]->getPlayer()->isSameTeamAs(getPlayer())) {
                     bHitsEnemyBuilding = true;
                 }
             }
@@ -282,8 +293,8 @@ void cBullet::arrivedAtDestinationLogic()
     const s_BulletInfo &sBullet = gets_Bullet();
 
     // damage is inflicted to size of explosion
-    int x = game.m_gameObjectsContext->getMapGeometry()->getCellX(iCell);
-    int y = game.m_gameObjectsContext->getMapGeometry()->getCellY(iCell);
+    int x = m_objects->getMapGeometry()->getCellX(iCell);
+    int y = m_objects->getMapGeometry()->getCellY(iCell);
 
     int halfExplosionSize = std::round((float)(sBullet.explosionSize / 2));
     int startX = (x - halfExplosionSize);
@@ -294,7 +305,7 @@ void cBullet::arrivedAtDestinationLogic()
     float maxDistanceFromCenter = halfExplosionSize + 0.5f;
     for (int sx = startX; sx < endX; sx++) {
         for (int sy = startY; sy < endY; sy++) {
-            int cellToDamage = game.m_gameObjectsContext->getMapGeometry()->getCellWithMapBorders(sx, sy);
+            int cellToDamage = m_objects->getMapGeometry()->getCellWithMapBorders(sx, sy);
             if (cellToDamage < 0) continue;
 
             float actualDistance = ABS_length(sx, sy, x, y);
@@ -308,8 +319,8 @@ void cBullet::arrivedAtDestinationLogic()
             int half = 16;
             int randomX = -8 + RNG::rnd(half);
             int randomY = -8 + RNG::rnd(half);
-            int posX = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteXPositionFromCellCentered(cellToDamage) + randomX;
-            int posY = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteYPositionFromCellCentered(cellToDamage) + randomY;
+            int posX = m_objects->getMapGeometry()->getAbsoluteXPositionFromCellCentered(cellToDamage) + randomX;
+            int posY = m_objects->getMapGeometry()->getAbsoluteYPositionFromCellCentered(cellToDamage) + randomY;
 
             logbook(std::format(
                         "iCell {} : cellToDamage : {} : ExplosionSize is {}, maxDistanceFromCenter is {} , actualDistance = {}, x={}, y={} and factor = {}",
@@ -331,18 +342,20 @@ void cBullet::arrivedAtDestinationLogic()
             // create particle of explosion
             if (sBullet.deathParticle > -1) {
                 // depending on 'explosion size'
-                cParticle::create(posX, posY, sBullet.deathParticle, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
+                cParticle::create(posX, posY, sBullet.deathParticle, -1, -1, m_objects, m_info);
             }
 
             if (iType == ROCKET_BIG) {
                 // HACK HACK: produce sounds here... should be taken from bullet data structure; or via events
                 // so that elsewhere this can be handled.
                 if (RNG::rnd(100) < 35) {
-                    game.playSoundWithDistance(SOUND_TANKDIE + RNG::rnd(2),
-                                               distanceBetweenCellAndCenterOfScreen(cellToDamage));
+                    m_interface->playSoundWithDistance(SOUND_TANKDIE + RNG::rnd(2),
+                                               ABS_length(m_mapCamera->getViewportCenterX(), m_mapCamera->getViewportCenterY(),
+                                                          m_objects->getMapGeometry()->getAbsoluteXPositionFromCell(cellToDamage),
+                                                          m_objects->getMapGeometry()->getAbsoluteYPositionFromCell(cellToDamage)));
                 }
                 if (RNG::rnd(100) < 20) {
-                    cParticle::create(posX, posY, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
+                    cParticle::create(posX, posY, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, m_objects, m_info);
                 }
             }
 
@@ -351,7 +364,7 @@ void cBullet::arrivedAtDestinationLogic()
     }
 
     if (iType == ROCKET_BIG) {
-        game.shakeScreen(40);
+        m_interface->shakeScreen(40);
     }
 
     die();
@@ -364,21 +377,21 @@ void cBullet::arrivedAtDestinationLogic()
  */
 void cBullet::damageTerrain(int cell, double factor) const
 {
-    if (!game.m_gameObjectsContext->getMapGeometry()->isValidCell(cell)) return;
+    if (!m_objects->getMapGeometry()->isValidCell(cell)) return;
     if (!canDamageGround()) return;
 
     float iDamage = getDamageToInflictToNonInfantry() * factor;
 
-    int idOfStructureAtCell = game.m_gameObjectsContext->getMap()->getCellIdStructuresLayer(cell);
-    int cellTypeAtCell = game.m_gameObjectsContext->getMap()->getCellType(cell);
+    int idOfStructureAtCell = m_objects->getMap()->getCellIdStructuresLayer(cell);
+    int cellTypeAtCell = m_objects->getMap()->getCellType(cell);
 
-    game.m_gameObjectsContext->getMap()->cellTakeDamage(cell, iDamage);
+    m_objects->getMap()->cellTakeDamage(cell, iDamage);
 
     if (cellTypeAtCell == TERRAIN_SLAB) {
         // change into rock, get destroyed. But only when we did not hit a structure.
         if (idOfStructureAtCell < 0) {
-            game.m_gameObjectsContext->getMap()->cellChangeType(cell, TERRAIN_ROCK);
-            cMapEditor(game.m_gameObjectsContext->getMap()).smoothAroundCell(cell);
+            m_objects->getMap()->cellChangeType(cell, TERRAIN_ROCK);
+            cMapEditor(m_objects->getMap()).smoothAroundCell(cell);
         }
     }
 }
@@ -404,7 +417,7 @@ bool cBullet::doesAirUnitTakeDamage(int unitIdOnAirLayer) const
     if (unitIdOnAirLayer < 0) return false;
     if (iOwnerUnit > 0 && unitIdOnAirLayer == iOwnerUnit) return false; // do not damage self
 
-    cUnit *airUnit = game.m_gameObjectsContext->getUnit(unitIdOnAirLayer);
+    cUnit *airUnit = m_objects->getUnit(unitIdOnAirLayer);
     if (!airUnit->isValid()) {
         return false;
     }
@@ -414,7 +427,7 @@ bool cBullet::doesAirUnitTakeDamage(int unitIdOnAirLayer) const
         return true;
     }
 
-    cUnit *ownerUnit = game.m_gameObjectsContext->getUnit(iOwnerUnit);
+    cUnit *ownerUnit = m_objects->getUnit(iOwnerUnit);
     if (!ownerUnit->isValid()) {
         return true;
     }
@@ -432,15 +445,15 @@ bool cBullet::doesAirUnitTakeDamage(int unitIdOnAirLayer) const
  */
 bool cBullet::damageAirUnit(int cell) const
 {
-    if (!game.m_gameObjectsContext->getMapGeometry()->isValidCell(cell)) return false;
+    if (!m_objects->getMapGeometry()->isValidCell(cell)) return false;
     if (!canDamageAirUnits()) return false;
-    int unitIdOnAirLayer = game.m_gameObjectsContext->getMap()->getCellIdAirUnitLayer(cell);
+    int unitIdOnAirLayer = m_objects->getMap()->getCellIdAirUnitLayer(cell);
 
     float iDamage = getDamageToInflictToNonInfantry();
 
     if (doesAirUnitTakeDamage(unitIdOnAirLayer)) {
-        cUnit *airUnit = game.m_gameObjectsContext->getUnit(unitIdOnAirLayer);
-        int originUnitId = (iOwnerUnit > -1 && game.m_gameObjectsContext->getUnit(iOwnerUnit)->isValid()) ? iOwnerUnit : -1;
+        cUnit *airUnit = m_objects->getUnit(unitIdOnAirLayer);
+        int originUnitId = (iOwnerUnit > -1 && m_objects->getUnit(iOwnerUnit)->isValid()) ? iOwnerUnit : -1;
         airUnit->takeDamage(iDamage, originUnitId, iOwnerStructure);
         return true;
     }
@@ -455,16 +468,16 @@ bool cBullet::damageAirUnit(int cell) const
  */
 bool cBullet::damageGroundUnit(int cell, double factor) const
 {
-    if (!game.m_gameObjectsContext->getMapGeometry()->isValidCell(cell)) return false;
-    int id = game.m_gameObjectsContext->getMap()->getCellIdUnitLayer(cell);
+    if (!m_objects->getMapGeometry()->isValidCell(cell)) return false;
+    int id = m_objects->getMap()->getCellIdUnitLayer(cell);
     if (id < 0) return false;
     if (iOwnerUnit >= 0 && id == iOwnerUnit) return false; // do not damage self
 
-    cUnit *groundUnitTakingDamage = game.m_gameObjectsContext->getUnit(id);
+    cUnit *groundUnitTakingDamage = m_objects->getUnit(id);
     if (!groundUnitTakingDamage->isValid()) return false;
 
     float iDamage = getDamageToInflictToUnit(*groundUnitTakingDamage) * factor;
-    int originUnitId = (iOwnerUnit > -1 && game.m_gameObjectsContext->getUnit(iOwnerUnit)->isValid()) ? iOwnerUnit : -1;
+    int originUnitId = (iOwnerUnit > -1 && m_objects->getUnit(iOwnerUnit)->isValid()) ? iOwnerUnit : -1;
     groundUnitTakingDamage->takeDamage(iDamage, originUnitId, iOwnerStructure);
 
     // this unit will think what to do now (he got hit ouchy!)
@@ -474,11 +487,11 @@ bool cBullet::damageGroundUnit(int cell, double factor) const
     if (groundUnitTakingDamage->isDead()) {
         // who is to blame for killing this unit?
         if (originUnitId > -1) {
-            cUnit *ownerUnit = game.m_gameObjectsContext->getUnit(originUnitId);
+            cUnit *ownerUnit = m_objects->getUnit(originUnitId);
             if (ownerUnit->isValid()) {
                 // TODO: update statistics
 
-                if (game.m_infoContext->getUnitInfo(groundUnitTakingDamage->iType).infantry) {
+                if (m_info->getUnitInfo(groundUnitTakingDamage->iType).infantry) {
                     ownerUnit->fExperience += 0.25; // 4 kills = 1 star
                 }
                 else {
@@ -493,11 +506,14 @@ bool cBullet::damageGroundUnit(int cell, double factor) const
 
         // TODO: Stefan: is this needed?!- aren't we playing sound effects in a more generic way?
         // TODO: impact sound effect should be configured!?
-        game.playSoundWithDistance(SOUND_GAS, distanceBetweenCellAndCenterOfScreen(cell));
+        m_interface->playSoundWithDistance(SOUND_GAS,
+                                           ABS_length(m_mapCamera->getViewportCenterX(), m_mapCamera->getViewportCenterY(),
+                                                      m_objects->getMapGeometry()->getAbsoluteXPositionFromCell(cell),
+                                                      m_objects->getMapGeometry()->getAbsoluteYPositionFromCell(cell)));
 
         // take over unit
         if (RNG::rnd(100) < gets_Bullet().deviateProbability) {
-            cUnit *ownerUnit = game.m_gameObjectsContext->getUnit(iOwnerUnit);
+            cUnit *ownerUnit = m_objects->getUnit(iOwnerUnit);
             if (ownerUnit->isValid()) {
                 groundUnitTakingDamage->iPlayer = ownerUnit->iPlayer;
                 groundUnitTakingDamage->iGroups.fill(false);
@@ -512,7 +528,7 @@ bool cBullet::damageGroundUnit(int cell, double factor) const
                         .entitySpecificType = groundUnitTakingDamage->iType
                     }
                 };
-                game.onNotifyGameEvent(event);
+                m_interface->onNotifyGameEvent(event);
             }
         }
     }
@@ -536,10 +552,10 @@ float cBullet::getDamageToInflictToInfantry() const
 {
     cPlayerDifficultySettings *difficultySettings = getDifficultySettings();
 
-    float result = difficultySettings->getInflictDamage(game.m_infoContext->getBulletInfo(iType).damage_infantry);
+    float result = difficultySettings->getInflictDamage(m_info->getBulletInfo(iType).damage_infantry);
 
     if (iOwnerUnit > -1) {
-        float fDam = game.m_gameObjectsContext->getUnit(iOwnerUnit)->fExpDamage() * result;
+        float fDam = m_objects->getUnit(iOwnerUnit)->fExpDamage() * result;
         result += fDam;
     }
     return result;
@@ -552,18 +568,18 @@ float cBullet::getDamageToInflictToInfantry() const
  */
 void cBullet::detonateSpiceBloom(int cell) const
 {
-    game.m_gameObjectsContext->getMap()->detonateSpiceBloom(cell);
+    m_objects->getMap()->detonateSpiceBloom(cell);
 }
 
 void cBullet::damageSandworm(int cell, double factor) const
 {
-    if (!game.m_gameObjectsContext->getMapGeometry()->isValidCell(cell)) return;
-    int id = game.m_gameObjectsContext->getMap()->getCellIdWormsLayer(cell);
+    if (!m_objects->getMapGeometry()->isValidCell(cell)) return;
+    int id = m_objects->getMap()->getCellIdWormsLayer(cell);
     if (id < 0) return; // bail
 
-    cUnit *worm = game.m_gameObjectsContext->getUnit(id);
+    cUnit *worm = m_objects->getUnit(id);
     float damage = getDamageToInflictToNonInfantry() * factor;
-    int originUnitId = (iOwnerUnit > -1 && game.m_gameObjectsContext->getUnit(iOwnerUnit)->isValid()) ? iOwnerUnit : -1;
+    int originUnitId = (iOwnerUnit > -1 && m_objects->getUnit(iOwnerUnit)->isValid()) ? iOwnerUnit : -1;
     worm->takeDamage(damage, originUnitId, iOwnerStructure);
 }
 
@@ -584,20 +600,20 @@ bool cBullet::isAtDestination() const
  */
 void cBullet::damageWall(int cell, double factor) const
 {
-    if (!game.m_gameObjectsContext->getMapGeometry()->isValidCell(cell)) return;
-    int cellTypeAtCell = game.m_gameObjectsContext->getMap()->getCellType(cell);
+    if (!m_objects->getMapGeometry()->isValidCell(cell)) return;
+    int cellTypeAtCell = m_objects->getMap()->getCellType(cell);
     if (cellTypeAtCell != TERRAIN_WALL) return;
 
     float iDamage = getDamageToInflictToNonInfantry() * factor;
 
-    game.m_gameObjectsContext->getMap()->cellTakeDamage(cell, iDamage);
+    m_objects->getMap()->cellTakeDamage(cell, iDamage);
 
-    if (game.m_gameObjectsContext->getMap()->getCellHealth(cell) < 0) {
+    if (m_objects->getMap()->getCellHealth(cell) < 0) {
         // remove wall, turn into smudge:
-        auto mapEditor = cMapEditor(game.m_gameObjectsContext->getMap());
+        auto mapEditor = cMapEditor(m_objects->getMap());
         mapEditor.createCell(cell, TERRAIN_ROCK, 0);
         mapEditor.smoothAroundCell(cell);
-        game.m_gameObjectsContext->getMap()->smudge_increase(SmudgeType::S_WALL, cell);
+        m_objects->getMap()->smudge_increase(SmudgeType::S_WALL, cell);
     }
 }
 
@@ -632,7 +648,7 @@ float cBullet::getDamageToInflictToNonInfantry() const
     // increase damage by experience of unit
     if (iOwnerUnit > -1) {
         // extra damage by experience:
-        cUnit *cUnit = game.m_gameObjectsContext->getUnit(iOwnerUnit);
+        cUnit *cUnit = m_objects->getUnit(iOwnerUnit);
         if (cUnit->isValid()) { // in case the unit died while firing
             float iDam = (cUnit->fExpDamage() * iDamage);
             iDamage = iDamage + iDam;
@@ -651,12 +667,12 @@ cPlayerDifficultySettings *cBullet::getDifficultySettings() const
 
 s_BulletInfo cBullet::gets_Bullet() const
 {
-    return game.m_infoContext->getBulletInfo(iType);
+    return m_info->getBulletInfo(iType);
 }
 
 cPlayer *cBullet::getPlayer() const
 {
-    return game.m_gameObjectsContext->getPlayer(iPlayer);
+    return m_objects->getPlayer(iPlayer);
 }
 
 /**
@@ -667,19 +683,19 @@ cPlayer *cBullet::getPlayer() const
  */
 void cBullet::damageStructure(int idOfStructureAtCell, double factor)
 {
-    if (!game.m_gameObjectsContext->getMapGeometry()->isValidCell(idOfStructureAtCell)) return;
-    int id = game.m_gameObjectsContext->getMap()->getCellIdStructuresLayer(idOfStructureAtCell);
+    if (!m_objects->getMapGeometry()->isValidCell(idOfStructureAtCell)) return;
+    int id = m_objects->getMap()->getCellIdStructuresLayer(idOfStructureAtCell);
     if (id < 0) return; // bail
 
     cPlayerDifficultySettings *difficultySettings = getDifficultySettings();
 
-    float iDamage = difficultySettings->getInflictDamage(game.m_infoContext->getBulletInfo(iType).damage_vehicles) * factor;
+    float iDamage = difficultySettings->getInflictDamage(m_info->getBulletInfo(iType).damage_vehicles) * factor;
 
     cUnit *pUnit = nullptr;
     int originId = -1;
     if (iOwnerUnit > -1) {
-        if (game.m_gameObjectsContext->getUnit(iOwnerUnit)->isValid()) {
-            pUnit = game.m_gameObjectsContext->getUnit(iOwnerUnit);
+        if (m_objects->getUnit(iOwnerUnit)->isValid()) {
+            pUnit = m_objects->getUnit(iOwnerUnit);
             originId = iOwnerUnit;
         }
     }
@@ -689,7 +705,7 @@ void cBullet::damageStructure(int idOfStructureAtCell, double factor)
         iDamage += iDam;
     }
 
-    cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[id];
+    cAbstractStructure *pStructure = m_objects->getStructures()[id];
     if (pStructure == nullptr) {
         return; // invalid pointer!
     }

--- a/src/gameobjects/projectiles/bullet.h
+++ b/src/gameobjects/projectiles/bullet.h
@@ -4,14 +4,20 @@
 #include "gameobjects/players/cPlayerDifficultySettings.h"
 #include "gameobjects/projectiles/cBulletInfos.h"
 
-
 class cPlayer;
+class cGameObjectContext;
+class cInfoContext;
+class cMapCamera;
+class cGameInterface;
+class cGameSettings;
+struct sGameServices;
 
 class cBullet {
 
 public:
 
     void init();
+    void serviceInit(sGameServices *services);
 
     void draw();
 
@@ -104,4 +110,10 @@ private:
     cPlayerDifficultySettings *getDifficultySettings() const;
 
     bool canDamageGround() const;
+
+    cGameObjectContext *m_objects = nullptr;
+    cInfoContext *m_info = nullptr;
+    cMapCamera *m_mapCamera = nullptr;
+    cGameInterface *m_interface = nullptr;
+    cGameSettings *m_settings = nullptr;
 };

--- a/src/gameobjects/projectiles/cBullets.cpp
+++ b/src/gameobjects/projectiles/cBullets.cpp
@@ -1,0 +1,9 @@
+#include "cBullets.h"
+#include "include/sGameServices.h"
+
+void cBullets::serviceInit(sGameServices *services)
+{
+    for (auto &bullet : m_values) {
+        bullet.serviceInit(services);
+    }
+}

--- a/src/gameobjects/projectiles/cBullets.h
+++ b/src/gameobjects/projectiles/cBullets.h
@@ -6,6 +6,8 @@
 #include "definitions.h"
 #include "gameobjects/projectiles/bullet.h"
 
+struct sGameServices;
+
 /**
  * Container wrapper for the global g_Bullet array
  * Provides safe indexed access and standard container interface
@@ -13,6 +15,7 @@
 class cBullets {
 public:
     cBullets() = default;
+    void serviceInit(sGameServices *services);
 
     cBullet &operator[](std::size_t index) {
         d2tm_assert(index < MAX_BULLETS && "Index out of bounds for g_Bullet");

--- a/src/gameobjects/structures/cOrderProcesser.cpp
+++ b/src/gameobjects/structures/cOrderProcesser.cpp
@@ -253,7 +253,7 @@ void cOrderProcesser::sendFrigate()
         }
         else {
             // STEP 2: create frigate
-            int unitId = cUnits::unitCreate(iStartCell, FRIGATE, m_player->getId(), true);
+            int unitId = cUnits::unitCreate(m_objects, m_info, m_interface, iStartCell, FRIGATE, m_player->getId(), true);
             if (unitId < 0) {
                 logbook("cOrderProcesser::sendFrigate : unable to spawn frigate");
                 return;

--- a/src/gameobjects/structures/cRefinery.cpp
+++ b/src/gameobjects/structures/cRefinery.cpp
@@ -80,10 +80,10 @@ void cRefinery::think_unit_occupation()
     }
 
     // perhaps we can find a carryall to help us out
-    int iHarvestCell = cUnit::findHarvestSpot(iUnitID);
+    int iHarvestCell = cUnit::findHarvestSpot(iUnitID, m_objects);
 
     if (iHarvestCell > -1) {
-        int iCarry = cUnit::carryallTransfer(iUnitID, iHarvestCell);
+        int iCarry = cUnit::carryallTransfer(iUnitID, iHarvestCell, m_objects);
 
         if (iCarry > -1) {
             cUnit->movewaitTimer.reset(500);

--- a/src/gameobjects/structures/cStarPort.cpp
+++ b/src/gameobjects/structures/cStarPort.cpp
@@ -84,7 +84,7 @@ void cStarPort::think_deploy()
                 int rallyPoint = getRallyPoint();
 
                 if (cellToDeployTo >= 0) {
-                    int id = cUnits::unitCreate(cellToDeployTo, item->getBuildId(), iPlayer, true);
+                    int id = cUnits::unitCreate(m_objects, m_info, m_interface, cellToDeployTo, item->getBuildId(), iPlayer, true);
                     if (rallyPoint > -1) {
                         m_objects->getUnit(id)->move_to(rallyPoint, -1, -1);
                     }
@@ -102,7 +102,7 @@ void cStarPort::think_deploy()
                         cellToDeployTo = getCell();
                     }
                     int cellAtBorderOfMap = m_objects->getMap()->findCloseMapBorderCellRelativelyToDestinationCel(cellToDeployTo);
-                    REINFORCE(iPlayer, item->getBuildId(), cellToDeployTo, cellAtBorderOfMap);
+                    REINFORCE(m_objects, m_info, m_interface, iPlayer, item->getBuildId(), cellToDeployTo, cellAtBorderOfMap);
                 }
             }
             else {

--- a/src/gameobjects/structures/cStructureFactory.cpp
+++ b/src/gameobjects/structures/cStructureFactory.cpp
@@ -187,7 +187,7 @@ cAbstractStructure *cStructureFactory::createStructure(int iCell, int iStructure
 
     // additional forces: (UNITS)
     if (iStructureType == REFINERY) {
-        REINFORCE(iPlayer, HARVESTER, iCell, -1);
+        REINFORCE(m_objects, m_info, m_interface, iPlayer, HARVESTER, iCell, -1);
     }
 
     m_structureUtils->putStructureOnDimension(MAPID_STRUCTURES, str);

--- a/src/gameobjects/units/cReinforcements.cpp
+++ b/src/gameobjects/units/cReinforcements.cpp
@@ -1,5 +1,3 @@
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
 #include "cReinforcements.h"
 #include "gameobjects/units/cUnits.h"
@@ -8,8 +6,11 @@
 #include "gameobjects/players/cPlayers.h"
 #include "utils/RNG.hpp"
 #include "utils/d2tm_math.h"
-#include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
+#include "context/cInfoContext.h"
+#include "context/GameContext.hpp"
+#include "game/cGameInterface.h"
+#include "include/sGameServices.h"
 #include <algorithm>
 #include <format>
 
@@ -69,10 +70,10 @@ bool cReinforcement::isReady() const
     return m_delayInSeconds < 0;
 }
 
-void cReinforcement::execute() const
+void cReinforcement::execute(cGameObjectContext* objects, cInfoContext* infos, cGameInterface* iface) const
 {
-    int focusCell = game.m_gameObjectsContext->getPlayer(m_playerId)->getFocusCell();
-    REINFORCE(m_playerId, m_unitType, m_cell, focusCell, true);
+    int focusCell = objects->getPlayer(m_playerId)->getFocusCell();
+    REINFORCE(objects, infos, iface, m_playerId, m_unitType, m_cell, focusCell, true);
 }
 
 /// Reinforcements container class
@@ -86,6 +87,13 @@ cReinforcements::cReinforcements()
 void cReinforcements::init()
 {
     reinforcements.clear();
+}
+
+void cReinforcements::serviceInit(sGameServices* services)
+{
+    m_objects = services->objects;
+    m_infos = services->info;
+    m_interface = services->ctx->getGameInterface();
 }
 
 void cReinforcements::addReinforcement(int playerId, int unitType, int targetCell, int delayInSeconds, bool repeat)
@@ -109,7 +117,7 @@ void cReinforcements::thinkSlow()
     for (auto &reinforcement : reinforcements) {
         if (reinforcement.isReady()) {
             reinforcement.repeatOrMarkForDeletion();
-            REINFORCE(reinforcement);
+            REINFORCE(m_objects, m_infos, m_interface, reinforcement);
         }
     }
 
@@ -130,45 +138,37 @@ void cReinforcements::thinkSlow()
  * Assumes this is a 'real' reinforcement. (ie triggered by map)
  * create a new unit by sending it.
  *
+ * @param objects game object context
  * @param iPlr player index
  * @param iTpe unit type
  * @param iCll location where to bring it
  * @param iStart where to start from
 
  */
-void REINFORCE(int iPlr, int iTpe, int iCll, int iStart)
+void REINFORCE(cGameObjectContext* objects, cInfoContext* infos, cGameInterface* iface, int iPlr, int iTpe, int iCll, int iStart)
 {
-    REINFORCE(iPlr, iTpe, iCll, iStart, true);
+    REINFORCE(objects, infos, iface, iPlr, iTpe, iCll, iStart, true);
 }
 
 /**
  * Same as above REINFORCE function, but takes sReinforcement. if iCell is < 0 then it will do nothing.
- * @param reinforcement
  */
-void REINFORCE(const cReinforcement &reinforcement)
+void REINFORCE(cGameObjectContext* objects, cInfoContext* infos, cGameInterface* iface, const cReinforcement &reinforcement)
 {
     if (!reinforcement.isValid()) return; // bail, invalid reinforcement given
-    reinforcement.execute();
+    reinforcement.execute(objects, infos, iface);
 }
 
 /**
- * Spawns a carryAll that brings a unit (part of a reinforcement) to the map. It has a flag 'reinforcement' so that
- * we can distinguish (for now) between "mission reinforcements" and "carry-all brings harvester by building refinery"
- * use-cases.
- *
- * @param iPlr
- * @param iTpe
- * @param iCll
- * @param iStart
- * @param isReinforcement
+ * Spawns a carryAll that brings a unit (part of a reinforcement) to the map.
  */
-void REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement)
+void REINFORCE(cGameObjectContext* objects, cInfoContext* infos, cGameInterface* iface, int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement)
 {
     // handle invalid arguments
     if (iPlr < 0 || iTpe < 0)
         return;
 
-    if (game.m_gameObjectsContext->getMapGeometry()->isValidCell(iCll) == false)
+    if (objects->getMapGeometry()->isValidCell(iCll) == false)
         return;
 
     if (iStart < 0)
@@ -178,7 +178,7 @@ void REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement)
 
     if (iStartCell < 0) {
         iStart += RNG::rnd(64);
-        if (iStart >= game.m_gameObjectsContext->getMap()->getMaxCells())
+        if (iStart >= objects->getMap()->getMaxCells())
             iStart -= 64;
 
         iStartCell = iFindCloseBorderCell(iStart);
@@ -193,7 +193,7 @@ void REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement)
                         iTpe, iPlr, iStartCell, iCll));
 
     // STEP 2: create carryall
-    int iUnit = cUnits::unitCreate(iStartCell, CARRYALL, iPlr, true, isReinforcement);
+    int iUnit = cUnits::unitCreate(objects, infos, iface, iStartCell, CARRYALL, iPlr, true, isReinforcement);
     if (iUnit < 0) {
         // cannot create carry-all!
         logbook("ERROR (reinforce): Cannot create CARRYALL unit.");
@@ -201,15 +201,15 @@ void REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement)
     }
 
     // STEP 3: assign order to carryall
-    int iCellX = game.m_gameObjectsContext->getMapGeometry()->getCellX(iStartCell);
-    int iCellY = game.m_gameObjectsContext->getMapGeometry()->getCellY(iStartCell);
-    int cx = game.m_gameObjectsContext->getMapGeometry()->getCellX(iCll);
-    int cy = game.m_gameObjectsContext->getMapGeometry()->getCellY(iCll);
+    int iCellX = objects->getMapGeometry()->getCellX(iStartCell);
+    int iCellY = objects->getMapGeometry()->getCellY(iStartCell);
+    int cx = objects->getMapGeometry()->getCellX(iCll);
+    int cy = objects->getMapGeometry()->getCellY(iCll);
 
     int d = fDegrees(iCellX, iCellY, cx, cy);
     Facing f = facingFromInt(faceAngle(d)); // get the angle
 
-    cUnit *carryall = game.m_gameObjectsContext->getUnit(iUnit);
+    cUnit *carryall = objects->getUnit(iUnit);
     carryall->rendering.iBodyShouldFace = f;
     carryall->rendering.iBodyFacing = f;
     carryall->rendering.iHeadShouldFace = f;

--- a/src/gameobjects/units/cReinforcements.h
+++ b/src/gameobjects/units/cReinforcements.h
@@ -2,6 +2,11 @@
 
 #include <vector>
 
+class cGameObjectContext;
+class cInfoContext;
+class cGameInterface;
+struct sGameServices;
+
 class cReinforcement {
 public:
     cReinforcement();
@@ -13,7 +18,7 @@ public:
     [[nodiscard]] bool isValid() const;
     [[nodiscard]] bool canBeRemoved() const;
     void repeatOrMarkForDeletion();
-    void execute() const;
+    void execute(cGameObjectContext* objects, cInfoContext* infos, cGameInterface* iface) const;
 
 private:
     int m_delayInSeconds = -1;
@@ -30,6 +35,7 @@ public:
     explicit cReinforcements();
 
     void init();
+    void serviceInit(sGameServices* services);
 
     void addReinforcement(int playerId, int unitType, int targetCell, int delayInSeconds, bool repeat);
 
@@ -38,20 +44,18 @@ public:
 private:
     void substractSecondFromValidReinforcements();
 
+    cGameObjectContext* m_objects = nullptr;
+    cInfoContext* m_infos = nullptr;
+    cGameInterface* m_interface = nullptr;
     std::vector<cReinforcement> reinforcements;
 };
 
 
-void REINFORCE(int iPlr, int iTpe, int iCll, int iStart);
-void REINFORCE(const cReinforcement &reinforcement);
+void REINFORCE(cGameObjectContext* objects, cInfoContext* infos, cGameInterface* iface, int iPlr, int iTpe, int iCll, int iStart);
+void REINFORCE(cGameObjectContext* objects, cInfoContext* infos, cGameInterface* iface, const cReinforcement &reinforcement);
 
 /**
  * Allows overriding reinforcement flag, ie used when a unit is reinforced by construction or other way, rather
  * than a 'real' reinforcement.
- * @param iPlr
- * @param iTpe
- * @param iCll
- * @param iStart
- * @param isReinforcement
  */
-void REINFORCE(int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement);
+void REINFORCE(cGameObjectContext* objects, cInfoContext* infos, cGameInterface* iface, int iPlr, int iTpe, int iCll, int iStart, bool isReinforcement);

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -2621,7 +2621,7 @@ void cUnit::thinkFast_move()
                             iStructureID = -1;
 
                             // random move around
-                            int iF = freeAroundMove(iID);
+                            int iF = cUnit::freeAroundMove(iID, m_objects);
 
                             if (iF > -1) {
                                 move_to(iF);
@@ -3454,7 +3454,7 @@ eHeadTowardsStructureResult cUnit::findBestStructureCandidateAndHeadTowardsItOrW
 
 bool cUnit::findAndOrderCarryAllToBringMeToStructureAtCell(cAbstractStructure *candidate, int destCell)
 {
-    int r = carryallFreeForTransfer(iPlayer);
+    int r = cUnit::carryallFreeForTransfer(iPlayer, m_objects);
     if (r < 0) {
         return false;
     }
@@ -3828,7 +3828,7 @@ void cUnit::think_harvester()
             // not on spice, find a new location
             if (iCredits < getUnitInfo().credit_capacity) {
                 // find harvest cell
-                move_to(findHarvestSpot(iID), -1, -1);
+                move_to(cUnit::findHarvestSpot(iID, m_objects), -1, -1);
             }
             else {
                 rendering.iFrame = 0;
@@ -3866,7 +3866,7 @@ void cUnit::think_harvester()
                         m_map->cellChangeTile(position.iCell, 0);
                     }
 
-                    move_to(findHarvestSpot(iID), -1, -1);
+                    move_to(cUnit::findHarvestSpot(iID, m_objects), -1, -1);
 
                     cMapEditor(m_map).smoothAroundCell(position.iCell);
                 }
@@ -3982,40 +3982,40 @@ bool cUnit::canUnload()
     return iCredits > 0;
 }
 
-int cUnit::findHarvestSpot(int id)
+int cUnit::findHarvestSpot(int id, cGameObjectContext* objects)
 {
     // finds the closest harvest spot
-    cUnit *cUnit = game.m_gameObjectsContext->getUnit(id);
+    cUnit *cUnit = objects->getUnit(id);
     cUnit->updateCellXAndY();
 
     // First attempt: only look around remembered harvest cell (max radius 2),
     // then fall back to the old global search.
     int rememberedHarvestCell = cUnit->iHarvestCellMemory;
     if (rememberedHarvestCell > -1 &&
-            game.m_gameObjectsContext->getMapGeometry()->isValidCell(rememberedHarvestCell)) {
+            objects->getMapGeometry()->isValidCell(rememberedHarvestCell)) {
 
         auto canUseHarvestCell = [&](int candidateCell) {
             if (candidateCell < 0) return false;
-            if (!game.m_gameObjectsContext->getMapGeometry()->isValidCell(candidateCell)) return false;
-            if (game.m_gameObjectsContext->getMap()->getCellCredits(candidateCell) <= 0) return false;
+            if (!objects->getMapGeometry()->isValidCell(candidateCell)) return false;
+            if (objects->getMap()->getCellCredits(candidateCell) <= 0) return false;
 
-            int cellType = game.m_gameObjectsContext->getMap()->getCellType(candidateCell);
+            int cellType = objects->getMap()->getCellType(candidateCell);
             if (cellType != TERRAIN_SPICE && cellType != TERRAIN_SPICEHILL) return false;
 
-            int candidateDx = game.m_gameObjectsContext->getMapGeometry()->getCellX(candidateCell);
-            int candidateDy = game.m_gameObjectsContext->getMapGeometry()->getCellY(candidateCell);
-            if (!game.m_gameObjectsContext->getMapGeometry()->isWithinBoundaries(candidateDx, candidateDy)) return false;
+            int candidateDx = objects->getMapGeometry()->getCellX(candidateCell);
+            int candidateDy = objects->getMapGeometry()->getCellY(candidateCell);
+            if (!objects->getMapGeometry()->isWithinBoundaries(candidateDx, candidateDy)) return false;
 
             if (candidateCell != cUnit->getCell()) {
-                int idOfUnitAtCandidateCell = game.m_gameObjectsContext->getMap()->getCellIdUnitLayer(candidateCell);
-                if (idOfUnitAtCandidateCell > -1 || game.m_gameObjectsContext->getMap()->occupied(candidateCell, id)) return false;
+                int idOfUnitAtCandidateCell = objects->getMap()->getCellIdUnitLayer(candidateCell);
+                if (idOfUnitAtCandidateCell > -1 || objects->getMap()->occupied(candidateCell, id)) return false;
             }
 
             return true;
         };
 
-        int rememberedDx = game.m_gameObjectsContext->getMapGeometry()->getCellX(rememberedHarvestCell);
-        int rememberedDy = game.m_gameObjectsContext->getMapGeometry()->getCellY(rememberedHarvestCell);
+        int rememberedDx = objects->getMapGeometry()->getCellX(rememberedHarvestCell);
+        int rememberedDy = objects->getMapGeometry()->getCellY(rememberedHarvestCell);
 
         // Radius 0 checks remembered cell first, then ring 1 and ring 2.
         for (int searchRadius = 0; searchRadius <= 2; searchRadius++) {
@@ -4026,9 +4026,9 @@ int cUnit::findHarvestSpot(int id)
                     int candidateDx = rememberedDx + dx;
                     int candidateDy = rememberedDy + dy;
 
-                    if (!game.m_gameObjectsContext->getMapGeometry()->isWithinBoundaries(candidateDx, candidateDy)) continue;
+                    if (!objects->getMapGeometry()->isWithinBoundaries(candidateDx, candidateDy)) continue;
 
-                    int candidateCell = game.m_gameObjectsContext->getMapGeometry()->getCellWithMapDimensions(candidateDx, candidateDy);
+                    int candidateCell = objects->getMapGeometry()->getCellWithMapDimensions(candidateDx, candidateDy);
                     if (!canUseHarvestCell(candidateCell)) continue;
 
                     cUnit->iHarvestCellMemory = candidateCell;
@@ -4049,14 +4049,14 @@ int cUnit::findHarvestSpot(int id)
     int TargetSpiceDistance = 40;
     int TargetSpiceHillDistance = 40;
 
-    for (int i = 0; i < game.m_gameObjectsContext->getMap()->getMaxCells(); i++)
-        if (game.m_gameObjectsContext->getMap()->getCellCredits(i) > 0 && i != cUnit->getCell()) {
+    for (int i = 0; i < objects->getMap()->getMaxCells(); i++)
+        if (objects->getMap()->getCellCredits(i) > 0 && i != cUnit->getCell()) {
             // check if its not out of reach
-            int dx = game.m_gameObjectsContext->getMapGeometry()->getCellX(i);
-            int dy = game.m_gameObjectsContext->getMapGeometry()->getCellY(i);
+            int dx = objects->getMapGeometry()->getCellX(i);
+            int dy = objects->getMapGeometry()->getCellY(i);
 
             // skip bordered ones
-            if (game.m_gameObjectsContext->getMapGeometry()->isWithinBoundaries(dx, dy) == false)
+            if (objects->getMapGeometry()->isWithinBoundaries(dx, dy) == false)
                 continue;
 
             /*
@@ -4069,16 +4069,16 @@ int cUnit::findHarvestSpot(int id)
             if (dy >= (game.map_height-1))
               continue;*/
 
-            int idOfUnitAtCell = game.m_gameObjectsContext->getMap()->getCellIdUnitLayer(i);
+            int idOfUnitAtCell = objects->getMap()->getCellIdUnitLayer(i);
             if (idOfUnitAtCell > -1)
                 continue;
 
-            if (game.m_gameObjectsContext->getMap()->occupied(i, id))
+            if (objects->getMap()->occupied(i, id))
                 continue; // occupied
 
-            int d = ABS_length(cx, cy, game.m_gameObjectsContext->getMapGeometry()->getCellX(i), game.m_gameObjectsContext->getMapGeometry()->getCellY(i));
+            int d = ABS_length(cx, cy, objects->getMapGeometry()->getCellX(i), objects->getMapGeometry()->getCellY(i));
 
-            int cellType = game.m_gameObjectsContext->getMap()->getCellType(i);
+            int cellType = objects->getMap()->getCellType(i);
             if (cellType == TERRAIN_SPICE) {
                 if (d < TargetSpiceDistance) {
                     TargetSpice = i;
@@ -4113,11 +4113,11 @@ int cUnit::findHarvestSpot(int id)
     return chosenCell;
 }
 
-int cUnit::carryallFreeForTransfer(int iPlayer)
+int cUnit::carryallFreeForTransfer(int iPlayer, cGameObjectContext* objects)
 {
     // find a free carry all
-    for (int i = 0; i < game.m_gameObjectsContext->getUnitsSize(); i++) {
-        cUnit *cUnit = game.m_gameObjectsContext->getUnit(i);
+    for (int i = 0; i < objects->getUnitsSize(); i++) {
+        cUnit *cUnit = objects->getUnit(i);
         if (!cUnit->isValid()) continue;
         if (cUnit->iPlayer != iPlayer) continue;
         if (cUnit->iType != CARRYALL) continue; // skip non-carry-all units
@@ -4135,24 +4135,24 @@ int cUnit::carryallFreeForTransfer(int iPlayer)
  * @param iGoal
  * @return
  */
-int cUnit::carryallTransfer(int iuID, int iGoal)
+int cUnit::carryallTransfer(int iuID, int iGoal, cGameObjectContext* objects)
 {
-    int carryAllUnitId = carryallFreeForTransfer(game.m_gameObjectsContext->getUnit(iuID)->iPlayer);
+    int carryAllUnitId = carryallFreeForTransfer(objects->getUnit(iuID)->iPlayer, objects);
     if (carryAllUnitId > -1) {
-        cUnit *cUnit = game.m_gameObjectsContext->getUnit(carryAllUnitId);
+        cUnit *cUnit = objects->getUnit(carryAllUnitId);
         cUnit->carryall_order(iuID, eTransferType::PICKUP, iGoal, -1);
     }
     return carryAllUnitId;
 }
 
-int cUnit::freeAroundMove(int iUnit)
+int cUnit::freeAroundMove(int iUnit, cGameObjectContext* objects)
 {
     if (iUnit < 0) {
         logbook("Invalid unit");
         return -1;
     }
 
-    cUnit *cUnit = game.m_gameObjectsContext->getUnit(iUnit);
+    cUnit *cUnit = objects->getUnit(iUnit);
 
     cUnit->updateCellXAndY();
     int iStartX = cUnit->getCellX();
@@ -4175,9 +4175,9 @@ int cUnit::freeAroundMove(int iUnit)
 
     for (int x = iStartX; x < iEndX; x++) {
         for (int y = iStartY; y < iEndY; y++) {
-            int cll = game.m_gameObjectsContext->getMapGeometry()->getCellWithMapBorders(x, y);
+            int cll = objects->getMapGeometry()->getCellWithMapBorders(x, y);
 
-            if (cll > -1 && !game.m_gameObjectsContext->getMap()->occupied(cll)) {
+            if (cll > -1 && !objects->getMap()->occupied(cll)) {
                 iClls[foundCoordinates] = cll;
                 foundCoordinates++;
             }

--- a/src/gameobjects/units/cUnit.h
+++ b/src/gameobjects/units/cUnit.h
@@ -477,9 +477,9 @@ public:
 
     bool canUnload();
 
-    static int findHarvestSpot(int id);
-    static int carryallTransfer(int iuID, int iGoal);
-    static int freeAroundMove(int iUnit);
+    static int findHarvestSpot(int id, cGameObjectContext* objects);
+    static int carryallTransfer(int iuID, int iGoal, cGameObjectContext* objects);
+    static int freeAroundMove(int iUnit, cGameObjectContext* objects);
 
 private:
     cGameSettings *m_settings = nullptr;
@@ -602,5 +602,5 @@ private:
     void setAction(eActionType action);
     void setGoalCell(int goalCell);
 
-    static int carryallFreeForTransfer(int iPlayer);
+    static int carryallFreeForTransfer(int iPlayer, cGameObjectContext* objects);
 };

--- a/src/gameobjects/units/cUnits.cpp
+++ b/src/gameobjects/units/cUnits.cpp
@@ -15,10 +15,9 @@
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
 #include "gameobjects/map/cMap.h"
-#include "include/d2tmc.h"
 #include "utils/common.h"
-#include "game/cGame.h"
-#include "utils/cLog.h"
+#include "game/cGameInterface.h"
+#include "utils/Log.h"
 #include "utils/RNG.hpp"
 #include "include/sGameServices.h"
 #include "context/GameContext.hpp"
@@ -112,11 +111,10 @@ int cUnits::getValidUnitsCount() const {
     return count;
 }
 
-// return new valid ID
-static int unitNewID()
+static int unitNewID(cGameObjectContext *objects)
 {
-    for (int i = 0; i < game.m_gameObjectsContext->getUnits()->size(); i++)
-        if (!game.m_gameObjectsContext->getUnit(i)->isValid())
+    for (int i = 0; i < (int)objects->getUnits()->size(); i++)
+        if (!objects->getUnit(i)->isValid())
             return i;
 
     return -1; // NONE
@@ -127,16 +125,16 @@ static int unitNewID()
 //     return unitCreate(iCll, unitType, iPlayer, bOnStart, false);
 // }
 
-int cUnits::unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool isReinforcement, float hpPercentage) {
-    if (!game.m_gameObjectsContext->getMapGeometry()->isValidCell(iCll)) {
+int cUnits::unitCreate(cGameObjectContext* objects, cInfoContext* infos, cGameInterface* iface, int iCll, int unitType, int iPlayer, bool bOnStart, bool isReinforcement, float hpPercentage) {
+    if (!objects->getMapGeometry()->isValidCell(iCll)) {
         logbook("UNIT_CREATE: Invalid cell as param");
         return -1;
     }
 
-    s_UnitInfo &sUnitType = game.m_infoContext->getUnitInfo(unitType);
+    s_UnitInfo &sUnitType = infos->getUnitInfo(unitType);
 
     // check if unit already exists on location
-    if (!sUnitType.airborn && game.m_gameObjectsContext->getMap()->cellGetIdFromLayer(iCll, MAPID_STRUCTURES) > -1) {
+    if (!sUnitType.airborn && objects->getMap()->cellGetIdFromLayer(iCll, MAPID_STRUCTURES) > -1) {
         return -1; // cannot place unit, structure exists at location
     }
 
@@ -149,30 +147,30 @@ int cUnits::unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool 
     }
 
     // check if unit already exists on location
-    if (game.m_gameObjectsContext->getMap()->cellGetIdFromLayer(iCll, mapIdIndex) > -1) {
+    if (objects->getMap()->cellGetIdFromLayer(iCll, mapIdIndex) > -1) {
         return -1; // cannot place unit
     }
 
     // check if placed on invalid terrain type
     if (unitType == SANDWORM) {
-        if (!game.m_gameObjectsContext->getMap()->isCellPassableForWorm(iCll)) {
+        if (!objects->getMap()->isCellPassableForWorm(iCll)) {
             return -1;
         }
     }
 
-    bool validCell = game.m_gameObjectsContext->getMap()->canDeployUnitTypeAtCell(iCll, unitType);
+    bool validCell = objects->getMap()->canDeployUnitTypeAtCell(iCll, unitType);
     if (!validCell) {
         return -1;
     }
 
-    int iNewId = unitNewID();
+    int iNewId = unitNewID(objects);
 
     if (iNewId < 0) {
         logbook("UNIT_CREATE:Could not find new unit index");
         return -1;
     }
 
-    cUnit *newUnit = game.m_gameObjectsContext->getUnit(iNewId);
+    cUnit *newUnit = objects->getUnit(iNewId);
     newUnit->init(iNewId);
 
     newUnit->setCell(iCll);
@@ -191,7 +189,7 @@ int cUnits::unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool 
 
     // newUnit->TIMER_bored = RNG::rnd(3000);
     newUnit->boredTimer.reset(RNG::rnd(3000));
-    
+
     // newUnit->TIMER_guard = 20 + RNG::rnd(70);
     newUnit->guardTimer.reset(20 + RNG::rnd(70));
     newUnit->recreateDimensions();
@@ -206,20 +204,20 @@ int cUnits::unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool 
 
     // AI player immediately moves unit away
     if (iPlayer > 0 && iPlayer < AI_WORM && !sUnitType.airborn && !bOnStart) {
-        int iF = cUnit::freeAroundMove(iNewId);
+        int iF = cUnit::freeAroundMove(iNewId, objects);
 
         if (iF > -1) {
             newUnit->log("Order move #2");
-            game.m_gameObjectsContext->getUnit(iNewId)->move_to(iF);
+            objects->getUnit(iNewId)->move_to(iF);
         }
     }
 
     // Put on map too!:
-    game.m_gameObjectsContext->getMap()->cellSetIdForLayer(iCll, mapIdIndex, iNewId);
+    objects->getMap()->cellSetIdForLayer(iCll, mapIdIndex, iNewId);
 
     newUnit->updateCellXAndY();
 
-    game.m_gameObjectsContext->getMap()->clearShroud(iCll, sUnitType.sight, iPlayer);
+    objects->getMap()->clearShroud(iCll, sUnitType.sight, iPlayer);
 
     const s_GameEvent event {
         .eventType = eGameEventType::GAME_EVENT_CREATED,
@@ -231,7 +229,7 @@ int cUnits::unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool 
             .isReinforce = isReinforcement
         }
     };
-    game.onNotifyGameEvent(event);
+    iface->onNotifyGameEvent(event);
 
     return iNewId;
 }

--- a/src/gameobjects/units/cUnits.cpp
+++ b/src/gameobjects/units/cUnits.cpp
@@ -113,7 +113,7 @@ int cUnits::getValidUnitsCount() const {
 
 static int unitNewID(cGameObjectContext *objects)
 {
-    for (int i = 0; i < (int)objects->getUnits()->size(); i++)
+    for (int i = 0; i < objects->getUnits()->size(); i++)
         if (!objects->getUnit(i)->isValid())
             return i;
 

--- a/src/gameobjects/units/cUnits.h
+++ b/src/gameobjects/units/cUnits.h
@@ -129,7 +129,7 @@ public:
      * @param isReinforement flag to set on event
      * @return
      */
-    static int unitCreate(int iCll, int unitType, int iPlayer, bool bOnStart, bool isReinforcement = false, float hpPercentage =1.0f);
+    static int unitCreate(cGameObjectContext* objects, cInfoContext* infos, cGameInterface* iface, int iCll, int unitType, int iPlayer, bool bOnStart, bool isReinforcement = false, float hpPercentage = 1.0f);
 
 
 private:

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -680,12 +680,12 @@ void cGamePlaying::onKeyDownDebugMode(const cKeyboardEvent &event)
 
     if (event.isAction(eKeyAction::DEBUG_SPAWN_ORNITHOPTER)) {
         int mc = m_controlledPlayer->getGameControlsContext()->getMouseCell();
-        cUnits::unitCreate(mc, ORNITHOPTER, m_controlledPlayer->getId(), false, false);
+        cUnits::unitCreate(m_objects, m_info, m_interface, mc, ORNITHOPTER, m_controlledPlayer->getId(), false, false);
     }
 
     if (event.isAction(eKeyAction::DEBUG_SPAWN_WORM)) {
         int mc = humanPlayer->getGameControlsContext()->getMouseCell();
-        cUnits::unitCreate(mc, SANDWORM, AI_WORM, false, false);
+        cUnits::unitCreate(m_objects, m_info, m_interface, mc, SANDWORM, AI_WORM, false, false);
     }
 }
 
@@ -716,6 +716,7 @@ void cGamePlaying::onEventEntityDestroyed(const CommonEvent &event)
         int randomX = cellX + RNG::genIntMaxExcl(0, widthInCells);
         int randomY = cellY + RNG::genIntMaxExcl(0, heightInCells);
         cUnits::unitCreate(
+            m_objects, m_info, m_interface,
             m_objects->getMapGeometry()->makeCell(randomX, randomY),
             unitTypeToSpawn,
             event.player->getId(),
@@ -733,6 +734,7 @@ void cGamePlaying::onEventCreateUnit(const DeployUnitEvent &event)
     }
 
     int id = cUnits::unitCreate(
+        m_objects, m_info, m_interface,
         event.iCell,
         event.unitType,
         event.iPlayer,

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -827,7 +827,7 @@ void cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState(in
                        maxRange,
                        iPlayerUnitType);
 
-            cUnits::unitCreate(cell, iPlayerUnitType, p, true);
+            cUnits::unitCreate(m_objects, m_services->info, m_interface, cell, iPlayerUnitType, p, true);
 
             cLogger::getInstance()->log(LOG_TRACE, COMP_SKIRMISHSETUP, "Creating units",
                                         std::format("Wants {} amount of units; amount created {}", pSkirmishPlayer.startingUnits, u),

--- a/src/utils/ini.cpp
+++ b/src/utils/ini.cpp
@@ -37,6 +37,7 @@
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
 #include "include/sGameServices.h"
+#include "context/GameContext.hpp"
 #include "game/cGameInterface.h"
 #include "game/cGameSettings.h"
 #include <format>
@@ -368,6 +369,7 @@ cIni::cIni(sGameServices* services)
     m_settings = services->settings;
     m_objects = services->objects;
     m_infos = services->info;
+    m_interface = services->ctx->getGameInterface();
 }
 
 /**
@@ -1188,7 +1190,7 @@ bool cIni::INI_Scenario_Section_Units(int iHumanID, bool bSetUpPlayers, const in
     }
 
     if (iController > -1) {
-        cUnits::unitCreate(iCell, iType, iController, true);
+        cUnits::unitCreate(m_objects, m_infos, m_interface, iCell, iType, iController, true);
     }
     return bSetUpPlayers;
 }

--- a/src/utils/ini.h
+++ b/src/utils/ini.h
@@ -23,6 +23,7 @@ struct s_DataCampaign;
 class cGameSettings;
 class cGameObjectContext;
 class cInfoContext;
+class cGameInterface;
 struct sGameServices;
 
 // public stuff
@@ -64,6 +65,7 @@ private:
     cGameSettings* m_settings = nullptr;
     cGameObjectContext* m_objects = nullptr;
     cInfoContext* m_infos = nullptr;
+    cGameInterface* m_interface = nullptr;
 };
 
 


### PR DESCRIPTION
## Summary

- `cBullet`/`cBullets`: `serviceInit` wired; all `game.*` replaced with injected `m_objects`, `m_info`, `m_settings`, `m_interface`, `m_mapCamera`
- `cUnit`: `findHarvestSpot`, `carryallTransfer`, `freeAroundMove`, `carryallFreeForTransfer` remain **static**; `cGameObjectContext*` passed as explicit last parameter instead of reaching into `game.`
- `cUnits`: `unitCreate` remains **static**; `cGameObjectContext*`, `cInfoContext*`, `cGameInterface*` passed as explicit first params instead of `game.*`
- `cReinforcements`: `serviceInit` added (stores `m_objects`, `m_infos`, `m_interface`); `execute()` and all three `REINFORCE` overloads now take all three context pointers instead of reaching into `game.`
- All callers updated: `cStarPort`, `cStructureFactory`, `cPlayer`, `cItemBuilder`, `cRefinery`, `cOrderProcesser`, `cGamePlaying`, `cSetupSkirmishState`, `ini.cpp`
- `cBullets.cpp` added to `CMakeLists.txt`

## Test plan

- [x] Build passes (`./rebuildmacos.sh`) with zero errors
- [x] All 43 tests pass
- [ ] `grep -rn "game\." src/gameobjects/units/ src/gameobjects/projectiles/` returns empty (only commented-out lines remain)
- [ ] Test skirmish game: place refinery, harvester deploys and mines spice correctly
- [ ] Test reinforcements arrive via carryall