### PR TITLE
PRs with no build-relevant changes can be merged

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -4,30 +4,43 @@ on:
   push:
     branches:
       - master
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'resources/bin/**'
-      - 'resources/dll/**'
-      - 'resources/game.ini'
-      - 'resources/game.ini.org'
-      - 'CMakeLists.txt'
-      - 'create_release.bat'
-      - 'create_release.sh'
-      - 'install_dependencies_macosx.sh'
-      - 'install_dependencies_ubuntu.sh'
-      - 'rebuildmacos.sh'
-      - 'rebuildwin.bat'
-      - 'rebuildwinrelease.bat'
-      - '.github/workflows/**'
 
 concurrency:
   group: master-builds
   cancel-in-progress: false   # wait until the current run finishes
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'src/**'
+              - 'tests/**'
+              - 'resources/bin/**'
+              - 'resources/dll/**'
+              - 'resources/game.ini'
+              - 'resources/game.ini.org'
+              - 'CMakeLists.txt'
+              - 'create_release.bat'
+              - 'create_release.sh'
+              - 'install_dependencies_macosx.sh'
+              - 'install_dependencies_ubuntu.sh'
+              - 'rebuildmacos.sh'
+              - 'rebuildwin.bat'
+              - 'rebuildwinrelease.bat'
+              - '.github/workflows/**'
+
   MSYS2:
     name: Windows-msys2-mingw64
+    needs: [changes]
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: [ windows-latest ]
     defaults:
       run:

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -1,27 +1,40 @@
 name: Build PR's
 
 on:
-  pull_request:
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'resources/bin/**'
-      - 'resources/dll/**'
-      - 'resources/game.ini'
-      - 'resources/game.ini.org'
-      - 'CMakeLists.txt'
-      - 'create_release.bat'
-      - 'create_release.sh'
-      - 'install_dependencies_macosx.sh'
-      - 'install_dependencies_ubuntu.sh'
-      - 'rebuildmacos.sh'
-      - 'rebuildwin.bat'
-      - 'rebuildwinrelease.bat'
-      - '.github/workflows/**'
+  pull_request: {}
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'src/**'
+              - 'tests/**'
+              - 'resources/bin/**'
+              - 'resources/dll/**'
+              - 'resources/game.ini'
+              - 'resources/game.ini.org'
+              - 'CMakeLists.txt'
+              - 'create_release.bat'
+              - 'create_release.sh'
+              - 'install_dependencies_macosx.sh'
+              - 'install_dependencies_ubuntu.sh'
+              - 'rebuildmacos.sh'
+              - 'rebuildwin.bat'
+              - 'rebuildwinrelease.bat'
+              - '.github/workflows/**'
+
   MSYS2:
     name: Windows-msys2-mingw64
+    needs: [changes]
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: [windows-latest]
     defaults:
       run:
@@ -59,6 +72,8 @@ jobs:
           ctest --output-on-failure
   Ubuntu:
     name: Ubuntu (x86)
+    needs: [changes]
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Set up GCC
@@ -92,6 +107,8 @@ jobs:
           ctest --output-on-failure
   MACOSX:
     name: Mac OS X (Arm64)
+    needs: [changes]
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: [ macos-15 ]
     steps:
       - name: Checkout
@@ -117,6 +134,8 @@ jobs:
           ctest --output-on-failure
   MACOSX_INTEL:
     name: Mac OS X (Intel)
+    needs: [changes]
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: [ macos-15-intel ]
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Fixes the issue where PRs touching only non-build files (docs, blog posts, etc.) could not be merged because required build checks never ran.

**Root cause:** Path filters on the `on:` trigger prevent the workflow from starting at all. GitHub sees required checks as perpetually pending, blocking the merge.

**Fix:** Move path filtering from the workflow trigger to a `changes` job using `dorny/paths-filter`. Build jobs are then gated with `if: needs.changes.outputs.relevant == 'true'`. When nothing relevant changed, build jobs are *skipped* — and GitHub treats skipped jobs as passing for branch protection purposes.

No changes to GitHub branch protection settings required.

## Changes

- `build_pr.yml`: removes `paths:` from trigger, adds `changes` job, gates all four build jobs individually (they are independent)
- `build_master.yml`: same, but only MSYS2 needs the condition — Ubuntu, MACOSX and Cleanup cascade through `needs:` automatically

Closes #1284 (unblocks the PR)