### PR TITLE
Step 12 of 15: src/utils/common.cpp and cStructureUtils.cpp have zero game. references

### DIFF
--- a/src/drawers/cPlaceItDrawer.cpp
+++ b/src/drawers/cPlaceItDrawer.cpp
@@ -1,4 +1,5 @@
 #include "cPlaceItDrawer.h"
+#include "utils/cStructureUtils.h"
 
 #include "game/cGame.h"
 #include "include/d2tmc.h"
@@ -18,7 +19,7 @@
 
 #include "include/cAssert.h"
 
-cPlaceItDrawer::cPlaceItDrawer(GameContext *ctx, cPlayer *thePlayer) : m_player(thePlayer), m_ctx(ctx), m_renderDrawer(ctx->getSDLDrawer())
+cPlaceItDrawer::cPlaceItDrawer(GameContext *ctx, cPlayer *thePlayer, cStructureUtils *structureUtils) : m_structureUtils(structureUtils), m_player(thePlayer), m_ctx(ctx), m_renderDrawer(ctx->getSDLDrawer())
 {
     d2tm_assert(thePlayer != nullptr);
     d2tm_assert(ctx != nullptr);
@@ -54,8 +55,8 @@ void cPlaceItDrawer::drawStatusOfStructureAtCell(cBuildingListItem *itemToPlace,
     d2tm_assert(structureId > -1);
 
     bool bWithinBuildDistance = false;
-    int cellWidth = m_structureUtils.getWidthOfStructureTypeInCells(structureId);
-    int cellHeight = m_structureUtils.getHeightOfStructureTypeInCells(structureId);
+    int cellWidth = m_structureUtils->getWidthOfStructureTypeInCells(structureId);
+    int cellHeight = m_structureUtils->getHeightOfStructureTypeInCells(structureId);
 
 #define SCANWIDTH	1
 

--- a/src/drawers/cPlaceItDrawer.h
+++ b/src/drawers/cPlaceItDrawer.h
@@ -1,16 +1,16 @@
 #pragma once
 
 #include "sidebar/cBuildingListItem.h"
-#include "utils/cStructureUtils.h"
 
 class GameContext;
 class cPlayer;
 class Graphics;
 class SDLDrawer;
+class cStructureUtils;
 
 class cPlaceItDrawer {
 public:
-    explicit cPlaceItDrawer(GameContext *ctx, cPlayer *thePlayer);
+    explicit cPlaceItDrawer(GameContext *ctx, cPlayer *thePlayer, cStructureUtils *structureUtils);
 
     ~cPlaceItDrawer();
 
@@ -22,7 +22,7 @@ protected:
     void drawStatusOfStructureAtCell(cBuildingListItem *itemToPlace, int mouseCell);
 
 private:
-    cStructureUtils m_structureUtils;
+    cStructureUtils* m_structureUtils = nullptr;
     cPlayer *m_player;
     GameContext *m_ctx;
     SDLDrawer *m_renderDrawer;

--- a/src/drawers/cStructureDrawer.cpp
+++ b/src/drawers/cStructureDrawer.cpp
@@ -27,11 +27,12 @@
 #include <SDL3/SDL.h>
 #include "include/cAssert.h"
 
-cStructureDrawer::cStructureDrawer(GameContext *ctx, cPlayer *player) :
+cStructureDrawer::cStructureDrawer(GameContext *ctx, cPlayer *player, cStructureUtils *structureUtils) :
     m_renderDrawer(ctx->getSDLDrawer()),
     m_textDrawer(ctx->getTextContext()->getBeneTextDrawer()),
     m_gfxinter(ctx->getGraphicsContext()->gfxinter.get()),
     m_gfxdata(ctx->getGraphicsContext()->gfxdata.get()),
+    m_structureUtils(structureUtils),
     m_player(player)
 {
     d2tm_assert(ctx != nullptr);
@@ -338,7 +339,7 @@ void cStructureDrawer::drawStructuresForLayer(int layer)
 
         if (!theStructure) continue;
 
-        if (m_structureUtils.isStructureVisibleOnScreen(theStructure)) {
+        if (m_structureUtils->isStructureVisibleOnScreen(theStructure)) {
             // draw
             drawStructureForLayer(theStructure, layer);
 

--- a/src/drawers/cStructureDrawer.h
+++ b/src/drawers/cStructureDrawer.h
@@ -12,7 +12,7 @@ class cPlayer;
 
 class cStructureDrawer {
 public:
-    explicit cStructureDrawer(GameContext *ctx, cPlayer *player);
+    explicit cStructureDrawer(GameContext *ctx, cPlayer *player, cStructureUtils *structureUtils);
     ~cStructureDrawer() = default;
     void setPlayer(cPlayer *pPlayer) { m_player = pPlayer; }
     void drawStructuresFirstLayer();
@@ -36,7 +36,7 @@ private:
     cTextDrawer* m_textDrawer;
     Graphics *m_gfxinter;
     Graphics *m_gfxdata;
-    cStructureUtils m_structureUtils;
+    cStructureUtils* m_structureUtils = nullptr;
     cPlayer *m_player;
 
     void renderIconOfUnitBeingRepaired(cAbstractStructure *structure) const;

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -76,6 +76,7 @@
 #include "utils/InitialGameSettings.hpp"
 #include "game/cGameSettings.h"
 #include "utils/Graphics.hpp"
+#include "utils/common.h"
 #include "utils/ini.h"
 #include "utils/RNG.hpp"
 
@@ -201,6 +202,7 @@ cGame::cGame()
     m_services->info = m_infoContext.get();
     m_services->settings = m_gameSettings.get();
     m_services->structureUtils = m_structureUtils.get();
+    initLogbook(m_gameSettings.get());
     m_services->m_log = nullptr;
     m_services->eventEmitter = m_eventEmitter.get();
 
@@ -750,6 +752,7 @@ bool cGame::setupGame()
 
     m_mapCamera = new cMapCamera(m_gameObjectsContext->getMap(), m_cameraDragMoveSpeed, m_cameraBorderOrKeyMoveSpeed, m_cameraEdgeMove, m_gameSettings.get(), m_mouse);
     m_services->mapCamera = m_mapCamera;
+    m_structureUtils->serviceInit(m_services.get());
 
     m_cIni->installGame(m_gameFilename);
     // Now we are ready for the menu state

--- a/src/gameobjects/players/brains/cPlayerBrainSkirmish.cpp
+++ b/src/gameobjects/players/brains/cPlayerBrainSkirmish.cpp
@@ -883,7 +883,7 @@ void cPlayerBrainSkirmish::addMission(ePlayerBrainMissionKind kind, std::vector<
             if (!player->canBuildUnitBool(item.type)) {
                 item.required = 0; // set it to required 0, so it won't be built
                 log(std::format("addMission - cannot build unit [{}] so setting required to 0, for mission kind [{}].",
-                                toStringBuildTypeSpecificType(eBuildType::UNIT, item.type),
+                                toStringBuildTypeSpecificType(eBuildType::UNIT, item.type, m_info),
                                 ePlayerBrainMissionKindString(kind))
                    );
             }

--- a/src/gameobjects/players/brains/missions/cPlayerBrainMission.cpp
+++ b/src/gameobjects/players/brains/missions/cPlayerBrainMission.cpp
@@ -76,7 +76,7 @@ cPlayerBrainMission::cPlayerBrainMission(cPlayer *player, const ePlayerBrainMiss
     log("Items to produce for mission:");
     for (auto &item : group) {
         log(std::format("Item buildType [{}], type/buildId[{}={}], amount required [{}]",
-                        eBuildTypeString(item.buildType), item.type, toStringBuildTypeSpecificType(item.buildType, item.type), item.required).c_str());
+                        eBuildTypeString(item.buildType), item.type, toStringBuildTypeSpecificType(item.buildType, item.type, player->getInfos()), item.required).c_str());
         d2tm_assert(item.type > -1 && "type/buildId must be > -1 !");
     }
 }
@@ -409,7 +409,7 @@ void cPlayerBrainMission::thinkState_PrepareGatherResources()
         }
         else {
             log(std::format("Produced all required [{}] for type {}", thingIWant.produced,
-                            toStringBuildTypeSpecificType(thingIWant.buildType, thingIWant.type)).c_str());
+                            toStringBuildTypeSpecificType(thingIWant.buildType, thingIWant.type, player->getInfos())).c_str());
         }
     }
 
@@ -663,7 +663,7 @@ void cPlayerBrainMission::onEventCannotBuild(const CommonEvent &event)
                     // set to same value, so we don't want to produce it anymore.
                     thingIWant.produced = thingIWant.required;
                     log(std::format("Cannot build [{}, {}], found a match and removed it from things I want.",
-                                    event.entitySpecificType, toStringBuildTypeSpecificType(event.entityType, event.entitySpecificType)).c_str());
+                                    event.entitySpecificType, toStringBuildTypeSpecificType(event.entityType, event.entitySpecificType, player->getInfos())).c_str());
                 }
             }
         }

--- a/src/gameobjects/structures/cAbstractStructure.cpp
+++ b/src/gameobjects/structures/cAbstractStructure.cpp
@@ -255,7 +255,7 @@ void cAbstractStructure::die()
     }
 
     // play sound
-    m_interface->playSoundWithDistance(SOUND_CRUMBLE01 + RNG::rnd(2), distanceBetweenCellAndCenterOfScreen(iCell));
+    m_interface->playSoundWithDistance(SOUND_CRUMBLE01 + RNG::rnd(2), distanceBetweenCellAndCenterOfScreen(iCell, m_objects, m_mapCamera));
 
     // remove from the playground
     m_objects->getMap()->remove_id(id, MAPID_STRUCTURES);

--- a/src/gameobjects/structures/cGunTurret.cpp
+++ b/src/gameobjects/structures/cGunTurret.cpp
@@ -186,7 +186,7 @@ void cGunTurret::think_fire()
                 }
             }
 
-            int iBull = createBullet(bulletType, getCell(), iTargetCell, -1, id);
+            int iBull = createBullet(bulletType, getCell(), iTargetCell, -1, id, m_objects, m_info, m_interface, m_mapCamera);
 
             // only rockets are homing
             if (unitTarget->isAirbornUnit()) {

--- a/src/gameobjects/units/cReinforcements.cpp
+++ b/src/gameobjects/units/cReinforcements.cpp
@@ -174,14 +174,14 @@ void REINFORCE(cGameObjectContext* objects, cInfoContext* infos, cGameInterface*
     if (iStart < 0)
         iStart = iCll;
 
-    int iStartCell = iFindCloseBorderCell(iStart);
+    int iStartCell = iFindCloseBorderCell(iStart, objects);
 
     if (iStartCell < 0) {
         iStart += RNG::rnd(64);
         if (iStart >= objects->getMap()->getMaxCells())
             iStart -= 64;
 
-        iStartCell = iFindCloseBorderCell(iStart);
+        iStartCell = iFindCloseBorderCell(iStart, objects);
     }
 
     if (iStartCell < 0) {

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -272,11 +272,11 @@ void cUnit::createSquishedParticle()
     if (iType == SOLDIER || iType == TROOPER || iType == UNIT_FREMEN_ONE) {
         int iType1 = D2TM_PARTICLE_SQUISH01 + RNG::rnd(2);
         cParticle::create(iDieX, iDieY, iType1, iPlayer, rendering.iFrame, m_objects, m_infos);
-        m_interface->playSoundWithDistance(SOUND_SQUISH, distanceBetweenCellAndCenterOfScreen(position.iCell));
+        m_interface->playSoundWithDistance(SOUND_SQUISH, distanceBetweenCellAndCenterOfScreen(position.iCell, m_objects, m_mapCamera));
     }
     else if (iType == TROOPERS || iType == INFANTRY || iType == UNIT_FREMEN_THREE) {
         cParticle::create(iDieX, iDieY, D2TM_PARTICLE_SQUISH03, iPlayer, rendering.iFrame, m_objects, m_infos);
-        m_interface->playSoundWithDistance(SOUND_SQUISH, distanceBetweenCellAndCenterOfScreen(position.iCell));
+        m_interface->playSoundWithDistance(SOUND_SQUISH, distanceBetweenCellAndCenterOfScreen(position.iCell, m_objects, m_mapCamera));
     }
 }
 
@@ -290,7 +290,7 @@ void cUnit::createExplosionParticle()
     if (iType == TRIKE || iType == RAIDER || iType == QUAD) {
         // play quick 'boom' sound and show animation
         cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_TRIKE, -1, -1, m_objects, m_infos);
-        m_interface->playSoundWithDistance(SOUND_TRIKEDIE, distanceBetweenCellAndCenterOfScreen(position.iCell));
+        m_interface->playSoundWithDistance(SOUND_TRIKEDIE, distanceBetweenCellAndCenterOfScreen(position.iCell, m_objects, m_mapCamera));
 
         if (RNG::rnd(100) < 30) {
             cParticle::create(iDieX, iDieY - 24, D2TM_PARTICLE_SMOKE_WITH_SHADOW, -1, -1, m_objects, m_infos);
@@ -309,11 +309,11 @@ void cUnit::createExplosionParticle()
         // play quick 'boom' sound and show animation
         if (RNG::rnd(100) < 50) {
             cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_TANK_ONE, -1, -1, m_objects, m_infos);
-            m_interface->playSoundWithDistance(SOUND_TANKDIE2, distanceBetweenCellAndCenterOfScreen(position.iCell));
+            m_interface->playSoundWithDistance(SOUND_TANKDIE2, distanceBetweenCellAndCenterOfScreen(position.iCell, m_objects, m_mapCamera));
         }
         else {
             cParticle::create(iDieX, iDieY, D2TM_PARTICLE_EXPLOSION_TANK_TWO, -1, -1, m_objects, m_infos);
-            m_interface->playSoundWithDistance(SOUND_TANKDIE, distanceBetweenCellAndCenterOfScreen(position.iCell));
+            m_interface->playSoundWithDistance(SOUND_TANKDIE, distanceBetweenCellAndCenterOfScreen(position.iCell, m_objects, m_mapCamera));
         }
 
         if (RNG::rnd(100) < 30) {
@@ -356,7 +356,7 @@ void cUnit::createExplosionParticle()
                 }
 
                 if (RNG::rnd(100) < 35)
-                    m_interface->playSoundWithDistance(SOUND_TANKDIE + RNG::rnd(2), distanceBetweenCellAndCenterOfScreen(position.iCell));
+                    m_interface->playSoundWithDistance(SOUND_TANKDIE + RNG::rnd(2), distanceBetweenCellAndCenterOfScreen(position.iCell, m_objects, m_mapCamera));
 
                 // calculate cell and damage stuff around this
                 int cll = m_objects->getMapGeometry()->getCellWithMapBorders((position.iCellX - 1) + cx, (position.iCellY - 1) + cy);
@@ -457,7 +457,7 @@ void cUnit::createExplosionParticle()
 
         cParticle::create(iDieX, iDieY, D2TM_PARTICLE_DEADINF02, iPlayer, -1, m_objects, m_infos);
 
-        m_interface->playSoundWithDistance(SOUND_DIE01 + RNG::rnd(5), distanceBetweenCellAndCenterOfScreen(position.iCell));
+        m_interface->playSoundWithDistance(SOUND_DIE01 + RNG::rnd(5), distanceBetweenCellAndCenterOfScreen(position.iCell, m_objects, m_mapCamera));
     }
 
     if (iType == TROOPERS || iType == INFANTRY || iType == UNIT_FREMEN_THREE) {
@@ -465,7 +465,7 @@ void cUnit::createExplosionParticle()
 
         cParticle::create(iDieX, iDieY, D2TM_PARTICLE_DEADINF01, iPlayer, -1, m_objects, m_infos);
 
-        m_interface->playSoundWithDistance(SOUND_DIE01 + RNG::rnd(5), distanceBetweenCellAndCenterOfScreen(position.iCell));
+        m_interface->playSoundWithDistance(SOUND_DIE01 + RNG::rnd(5), distanceBetweenCellAndCenterOfScreen(position.iCell, m_objects, m_mapCamera));
     }
 }
 
@@ -1659,7 +1659,7 @@ void cUnit::thinkFast_move_airUnit()
                 int iStrucId = m_map->getCellIdStructuresLayer(position.iCell);
 
                 if (iStrucId > -1) {
-                    setGoalCell(iFindCloseBorderCell(position.iCell));
+                    setGoalCell(iFindCloseBorderCell(position.iCell, m_objects));
                     m_transferType = eTransferType::DIE;
 
                     m_objects->getStructure(iStrucId)->setFrame(4); // show package on this structure
@@ -1718,7 +1718,7 @@ void cUnit::thinkFast_move_airUnit()
                     m_transferType = eTransferType::DIE;
 
                     // find a new border cell close to us... to die
-                    setGoalCell(iFindCloseBorderCell(position.iCell));
+                    setGoalCell(iFindCloseBorderCell(position.iCell, m_objects));
                     return;
                 }
                 else if (m_transferType == eTransferType::NEW_STAY) {
@@ -2010,7 +2010,7 @@ void cUnit::shoot(int iTargetCell)
 
     if (bulletType < 0) return; // no bullet type to spawn
 
-    int iBull = createBullet(bulletType, position.iCell, iTargetCell, iID, -1);
+    int iBull = createBullet(bulletType, position.iCell, iTargetCell, iID, -1, m_objects, m_infos, m_interface, m_mapCamera);
 
     cUnit *attackUnit = nullptr;
     if (combat.iAttackUnit > -1) {
@@ -2196,7 +2196,7 @@ void cUnit::think_hit(int iShotUnit, int iShotStructure)
                 cParticle::create(iDieX, iDieY, D2TM_PARTICLE_DEADINF01, iPlayer, -1, m_objects, m_infos);
 
                 m_interface->playSoundWithDistance(SOUND_DIE01 + RNG::rnd(5),
-                                           distanceBetweenCellAndCenterOfScreen(position.iCell));
+                                           distanceBetweenCellAndCenterOfScreen(position.iCell, m_objects, m_mapCamera));
 
             }
         }
@@ -2382,7 +2382,7 @@ void cUnit::think_attack_sandworm()
         long x = pos_x_centered();
         long y = pos_y_centered();
         cParticle::create(x, y, D2TM_PARTICLE_WORMEAT, -1, -1, m_objects, m_infos);
-        m_interface->playSoundWithDistance(SOUND_WORM, distanceBetweenCellAndCenterOfScreen(position.iCell));
+        m_interface->playSoundWithDistance(SOUND_WORM, distanceBetweenCellAndCenterOfScreen(position.iCell, m_objects, m_mapCamera));
         actionGuard();
         movewaitTimer.reset((1000/5) * 4); // wait for 4 seconds before moving again
         guardTimer.reset((1000/5) * 4); // timer guard works other way around..
@@ -3900,7 +3900,7 @@ void cUnit::setAction(eActionType action)
 void cUnit::retreatToMapEdge()
 {
     m_transferType = eTransferType::DIE;
-    setGoalCell(iFindCloseBorderCell(position.iCell));
+    setGoalCell(iFindCloseBorderCell(position.iCell, m_objects));
 }
 
 void cUnit::retreatToNearbyBase()

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -791,7 +791,7 @@ void cGamePlaying::onEventSpecialLaunch(const LaunchDeathHandEvent &event)
                 cAbstractStructure *pStructure = m_objects->getStructures()[structureId];
                 if (pStructure && pStructure->isValid()) {
                     m_interface->playSound(SOUND_PLACE);
-                    createBullet(special.providesTypeId, pStructure->getCell(), deployCell, -1, structureId);
+                    createBullet(special.providesTypeId, pStructure->getCell(), deployCell, -1, structureId, m_objects, m_info, m_interface, m_mapCamera);
 
                     const s_GameEvent launchedEvent{
                         .eventType = eGameEventType::GAME_EVENT_SPECIAL_LAUNCHED,

--- a/src/managers/cDrawManager.cpp
+++ b/src/managers/cDrawManager.cpp
@@ -39,7 +39,8 @@ cDrawManager::cDrawManager(GameContext *ctx, cPlayer *thePlayer, sGameServices *
     m_gameInterface(ctx->getGameInterface()),
     m_objects(services->objects),
     m_mapCamera(services->mapCamera),
-    m_gameSettings(services->settings)
+    m_gameSettings(services->settings),
+    m_structureUtils(services->structureUtils)
 {
     d2tm_assert(m_player!=nullptr);
     d2tm_assert(ctx != nullptr);
@@ -64,8 +65,8 @@ void cDrawManager::reset()
     m_miniMapDrawer = std::make_unique<cMiniMapDrawer>(m_ctx, m_objects->getMap(), m_player, m_mapCamera);
     m_particleDrawer = std::make_unique<cParticleDrawer>();
     m_messageDrawer = std::make_unique<cMessageDrawer>(m_ctx);
-    m_placeitDrawer = std::make_unique<cPlaceItDrawer>(m_ctx,m_player);
-    m_structureDrawer = std::make_unique<cStructureDrawer>(m_ctx, m_player);
+    m_placeitDrawer = std::make_unique<cPlaceItDrawer>(m_ctx, m_player, m_structureUtils);
+    m_structureDrawer = std::make_unique<cStructureDrawer>(m_ctx, m_player, m_structureUtils);
     m_btnOptions = createPlayerTextureFromIndexedSurfaceWithPalette(
         m_player, m_gfxinter->getSurface(BTN_OPTIONS), TransparentColorIndex
     );

--- a/src/managers/cDrawManager.h
+++ b/src/managers/cDrawManager.h
@@ -30,6 +30,7 @@ class cGameInterface;
 class cGameObjectContext;
 class cMapCamera;
 class cGameSettings;
+class cStructureUtils;
 struct sGameServices;
 
 /**
@@ -137,6 +138,7 @@ private:
     cGameObjectContext* m_objects = nullptr;
     cMapCamera* m_mapCamera = nullptr;
     cGameSettings* m_gameSettings = nullptr;
+    cStructureUtils* m_structureUtils = nullptr;
 
     void onKeyDown(const cKeyboardEvent &event);
 

--- a/src/utils/cStructureUtils.cpp
+++ b/src/utils/cStructureUtils.cpp
@@ -1,7 +1,6 @@
 #include "cStructureUtils.h"
 #include "game/cGameSettings.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
+#include "include/sGameServices.h"
 #include "utils/common.h"
 #include "utils/cLog.h"
 #include "gameobjects/structures/cRefinery.h"
@@ -26,18 +25,26 @@ cStructureUtils::~cStructureUtils()
 {
 }
 
+void cStructureUtils::serviceInit(sGameServices* services)
+{
+    m_objects = services->objects;
+    m_infos = services->info;
+    m_mapCamera = services->mapCamera;
+    m_settings = services->settings;
+}
+
 int cStructureUtils::getHeightOfStructureTypeInCells(int structureType)
 {
     d2tm_assert(structureType >= 0);
     d2tm_assert(structureType < MAX_STRUCTURETYPES);
-    return game.m_infoContext->getStructureInfo(structureType).bmp_height / TILESIZE_HEIGHT_PIXELS;
+    return m_infos->getStructureInfo(structureType).bmp_height / TILESIZE_HEIGHT_PIXELS;
 }
 
 int cStructureUtils::getWidthOfStructureTypeInCells(int structureType)
 {
     d2tm_assert(structureType >= 0);
     d2tm_assert(structureType < MAX_STRUCTURETYPES);
-    return game.m_infoContext->getStructureInfo(structureType).bmp_width / TILESIZE_WIDTH_PIXELS;
+    return m_infos->getStructureInfo(structureType).bmp_width / TILESIZE_WIDTH_PIXELS;
 }
 
 
@@ -55,7 +62,7 @@ int cStructureUtils::findStarportToDeployUnit(cPlayer *pPlayer)
     int primaryBuildingOfStructureType = pPlayer->getPrimaryStructureForStructureType(STARPORT);
 
     if (primaryBuildingOfStructureType > -1) {
-        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[primaryBuildingOfStructureType];
+        cAbstractStructure *theStructure = m_objects->getStructures()[primaryBuildingOfStructureType];
         if (theStructure && theStructure->getNonOccupiedCellAroundStructure() > -1) {
             return primaryBuildingOfStructureType;
         }
@@ -66,7 +73,7 @@ int cStructureUtils::findStarportToDeployUnit(cPlayer *pPlayer)
     int firstFoundStarportId = -1;
     bool foundStarportWithFreeAround = false;
     for (int i=0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
+        cAbstractStructure *theStructure = m_objects->getStructures()[i];
         if (theStructure && theStructure->getOwner() == playerId) {
             if (theStructure->getType() == STARPORT) {
                 // when no id set, always set one id
@@ -117,14 +124,14 @@ int cStructureUtils::findStructureToDeployUnit(cPlayer *pPlayer, int structureTy
 
     cLogger::getInstance()->log(LOG_DEBUG, COMP_STRUCTURES,"Primary building",
         std::format("Looking for (type {}, name {}, pPlayer {})", structureType, 
-            game.m_infoContext->getStructureInfo(structureType).name, playerId));
+            m_infos->getStructureInfo(structureType).name, playerId));
 
 
     // check primary building first if set
     int primaryBuildingOfStructureType = pPlayer->getPrimaryStructureForStructureType(structureType);
 
     if (primaryBuildingOfStructureType > -1) {
-        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[primaryBuildingOfStructureType];
+        cAbstractStructure *theStructure = m_objects->getStructures()[primaryBuildingOfStructureType];
         // this IF is needed, because the structure could be destroyed/replaced
         if (theStructure &&
                 theStructure->isValid() &&
@@ -234,12 +241,12 @@ void cStructureUtils::putStructureOnDimension(int dimensionId, cAbstractStructur
 
     for (int w = 0; w < theStructure->getWidth(); w++) {
         for (int h = 0; h < theStructure->getHeight(); h++)	{
-            int xOfStructureCell = game.m_gameObjectsContext->getMapGeometry()->getCellX(cellOfStructure);
-            int yOfStructureCell = game.m_gameObjectsContext->getMapGeometry()->getCellY(cellOfStructure);
+            int xOfStructureCell = m_objects->getMapGeometry()->getCellX(cellOfStructure);
+            int yOfStructureCell = m_objects->getMapGeometry()->getCellY(cellOfStructure);
 
-            int iCell = game.m_gameObjectsContext->getMapGeometry()->makeCell(xOfStructureCell + w, yOfStructureCell + h);
+            int iCell = m_objects->getMapGeometry()->makeCell(xOfStructureCell + w, yOfStructureCell + h);
 
-            game.m_gameObjectsContext->getMap()->cellSetIdForLayer(iCell, dimensionId, theStructure->getStructureId());
+            m_objects->getMap()->cellSetIdForLayer(iCell, dimensionId, theStructure->getStructureId());
         }
     }
 }
@@ -250,11 +257,11 @@ bool cStructureUtils::isStructureVisibleOnScreen(cAbstractStructure *structure)
 
     int drawX = structure->iDrawX();
     int drawY = structure->iDrawY();
-    int width = game.m_mapCamera->factorZoomLevel(structure->getWidthInPixels());
-    int height = game.m_mapCamera->factorZoomLevel(structure->getHeightInPixels());
+    int width = m_mapCamera->factorZoomLevel(structure->getWidthInPixels());
+    int height = m_mapCamera->factorZoomLevel(structure->getHeightInPixels());
 
-    return (drawX + width  >= 0 && drawX < game.m_gameSettings->getScreenW()) &&
-           (drawY + height >= 0 && drawY < game.m_gameSettings->getScreenH());
+    return (drawX + width  >= 0 && drawX < m_settings->getScreenW()) &&
+           (drawY + height >= 0 && drawY < m_settings->getScreenH());
 }
 
 bool cStructureUtils::isMouseOverStructure(cAbstractStructure *structure, int screenX, int screenY)
@@ -264,8 +271,8 @@ bool cStructureUtils::isMouseOverStructure(cAbstractStructure *structure, int sc
     // translate the structure coordinates to screen coordinates
     int drawX = structure->iDrawX();
     int drawY = structure->iDrawY();
-    int width = game.m_mapCamera->factorZoomLevel(structure->getWidthInPixels());
-    int height = game.m_mapCamera->factorZoomLevel(structure->getHeightInPixels());
+    int width = m_mapCamera->factorZoomLevel(structure->getWidthInPixels());
+    int height = m_mapCamera->factorZoomLevel(structure->getHeightInPixels());
 
     return cRectangle::isWithin(screenX, screenY, drawX, drawY, width, height);
 }
@@ -277,7 +284,7 @@ int cStructureUtils::getTotalPowerUsageForPlayer(cPlayer *pPlayer)
     int totalPowerUsage = 0;
 
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
+        cAbstractStructure *theStructure = m_objects->getStructures()[i];
         if (theStructure) {
             if (theStructure->getPlayer()->getId() == pPlayer->getId()) {
                 int powerUsageOfStructure = theStructure->getPowerUsage();
@@ -295,7 +302,7 @@ int cStructureUtils::getTotalSpiceCapacityForPlayer(cPlayer *pPlayer)
 
     int totalCapacity = 0;
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
+        cAbstractStructure *theStructure = m_objects->getStructures()[i];
         if (theStructure == nullptr) continue;
         if (!theStructure->isValid()) continue;
         if (theStructure->getPlayer()->getId() != pPlayer->getId()) continue; // does not belong to pPlayer
@@ -323,7 +330,7 @@ int cStructureUtils::getTotalPowerOutForPlayer(cPlayer *pPlayer)
 
     int totalPowerOut = 0;
     for (int i = 0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
+        cAbstractStructure *theStructure = m_objects->getStructures()[i];
         if (theStructure == nullptr) continue;
         if (!theStructure->isValid()) continue;
         if (theStructure->getPlayer()->getId() != pPlayer->getId()) continue; // not for pPlayer
@@ -339,7 +346,7 @@ int cStructureUtils::getTotalPowerOutForPlayer(cPlayer *pPlayer)
         }
     }
 
-    if (!game.m_gameSettings->isSkirmish()) {
+    if (!m_settings->isSkirmish()) {
         // ?? (mission 9 etc AI has no power)
     }
     return totalPowerOut;
@@ -355,7 +362,7 @@ int cStructureUtils::findHiTechToDeployAirUnit(cPlayer *pPlayer)
     int primaryBuildingOfStructureType = pPlayer->getPrimaryStructureForStructureType(HIGHTECH);
 
     if (primaryBuildingOfStructureType > -1) {
-        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[primaryBuildingOfStructureType];
+        cAbstractStructure *theStructure = m_objects->getStructures()[primaryBuildingOfStructureType];
         // this IF is needed, because the structure could be destroyed/replaced
         if (theStructure &&
                 theStructure->isValid() &&
@@ -383,7 +390,7 @@ int cStructureUtils::findStructureBy(int iPlayer, int iType, bool bFreeAround)
     if (iType < 0) return -1;
 
     for (int i=0; i < MAX_STRUCTURES; i++) {
-        cAbstractStructure *theStructure = game.m_gameObjectsContext->getStructures()[i];
+        cAbstractStructure *theStructure = m_objects->getStructures()[i];
         if (theStructure &&
                 theStructure->isValid() &&
                 theStructure->belongsTo(iPlayer) &&

--- a/src/utils/cStructureUtils.h
+++ b/src/utils/cStructureUtils.h
@@ -4,12 +4,19 @@
 #include "sidebar/cBuildingListItem.h"
 
 class cPlayer;
+struct sGameServices;
+class cGameObjectContext;
+class cInfoContext;
+class cMapCamera;
+class cGameSettings;
 
 class cStructureUtils {
 public:
     cStructureUtils();
 
     ~cStructureUtils();
+
+    void serviceInit(sGameServices* services);
 
     int findStructureToDeployUnit(cPlayer *pPlayer, int structureType);
 
@@ -38,4 +45,10 @@ public:
     int getTotalSpiceCapacityForPlayer(cPlayer *pPlayer);
 
     int getStructureTypeByUnitBuildId(int unitBuildId) const;
+
+private:
+    cGameObjectContext* m_objects = nullptr;
+    cInfoContext* m_infos = nullptr;
+    cMapCamera* m_mapCamera = nullptr;
+    cGameSettings* m_settings = nullptr;
 };

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -14,8 +14,7 @@
 
 #include "data/gfxdata.h"
 #include "data/gfxinter.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
+#include "game/cGameInterface.h"
 #include "gameobjects/projectiles/bullet.h"
 #include "gameobjects/map/cMapCamera.h"
 #include "gameobjects/map/cMap.h"
@@ -36,6 +35,8 @@
 #include <cmath>
 
 #include "data/gfxaudio.h"
+
+static cGameSettings* s_logbookSettings = nullptr;
 
 std::unique_ptr<InitialGameSettings> loadSettingsFromIni(const std::string& filename)
 {
@@ -99,13 +100,14 @@ std::unique_ptr<InitialGameSettings> loadSettingsFromIni(const std::string& file
 }
 
 
-/**
- * Default printing in logs. Only will be done if game.m_gameSettings->isDebugMode() is true.
- * @param txt
- */
+void initLogbook(cGameSettings* settings)
+{
+    s_logbookSettings = settings;
+}
+
 void logbook(const std::string &txt)
 {
-    if (game.m_gameSettings->isDebugMode()) {
+    if (s_logbookSettings && s_logbookSettings->isDebugMode()) {
         cLogger *logger = cLogger::getInstance();
         logger->log(LOG_WARN, COMP_NONE, "(logbook)", txt);
     }
@@ -157,20 +159,20 @@ float healthBar(float max_w, int i, int w)
 }
 
 // return a border cell, close to iCll
-int iFindCloseBorderCell(int iCll)
+int iFindCloseBorderCell(int iCll, cGameObjectContext* objects)
 {
-    return game.m_gameObjectsContext->getMap()->findCloseMapBorderCellRelativelyToDestinationCel(iCll);
+    return objects->getMap()->findCloseMapBorderCellRelativelyToDestinationCel(iCll);
 }
 
 
-int distanceBetweenCellAndCenterOfScreen(int iCell)
+int distanceBetweenCellAndCenterOfScreen(int iCell, cGameObjectContext* objects, cMapCamera* mapCamera)
 {
-    if (game.m_gameObjectsContext->getMapGeometry()->isValidCell(iCell)) {
-        int centerX = game.m_mapCamera->getViewportCenterX();
-        int centerY = game.m_mapCamera->getViewportCenterY();
+    if (objects->getMapGeometry()->isValidCell(iCell)) {
+        int centerX = mapCamera->getViewportCenterX();
+        int centerY = mapCamera->getViewportCenterY();
 
-        int cellX = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteXPositionFromCell(iCell);
-        int cellY = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteYPositionFromCell(iCell);
+        int cellX = objects->getMapGeometry()->getAbsoluteXPositionFromCell(iCell);
+        int cellY = objects->getMapGeometry()->getAbsoluteYPositionFromCell(iCell);
 
         return ABS_length(centerX, centerY, cellX, cellY);
     }
@@ -188,12 +190,12 @@ int distanceBetweenCellAndCenterOfScreen(int iCell)
  * @param structureWhichShoots
  * @return
  */
-int createBullet(int type, int fromCell, int targetCell, int unitWhichShoots, int structureWhichShoots)
+int createBullet(int type, int fromCell, int targetCell, int unitWhichShoots, int structureWhichShoots, cGameObjectContext* objects, cInfoContext* infos, cGameInterface* iface, cMapCamera* mapCamera)
 {
     int new_id = -1;
 
     int i = 0;
-    for (auto &bullet : game.m_gameObjectsContext->getBullets()) {
+    for (auto &bullet : objects->getBullets()) {
         if (!bullet.bAlive) {
             new_id = i;
             break;
@@ -208,25 +210,25 @@ int createBullet(int type, int fromCell, int targetCell, int unitWhichShoots, in
         return -1; // failed
 
 
-    cBullet &newBullet = game.m_gameObjectsContext->getBullets()[new_id];
+    cBullet &newBullet = objects->getBullets()[new_id];
     newBullet.init();
 
     newBullet.iType = type;
-    newBullet.posX = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteXPositionFromCellCentered(fromCell);
-    newBullet.posY = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteYPositionFromCellCentered(fromCell);
+    newBullet.posX = objects->getMapGeometry()->getAbsoluteXPositionFromCellCentered(fromCell);
+    newBullet.posY = objects->getMapGeometry()->getAbsoluteYPositionFromCellCentered(fromCell);
     newBullet.iOwnerStructure = structureWhichShoots;
     newBullet.iOwnerUnit = unitWhichShoots;
 
-    newBullet.targetX = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteXPositionFromCellCentered(targetCell);
-    newBullet.targetY = game.m_gameObjectsContext->getMapGeometry()->getAbsoluteYPositionFromCellCentered(targetCell);
+    newBullet.targetX = objects->getMapGeometry()->getAbsoluteXPositionFromCellCentered(targetCell);
+    newBullet.targetY = objects->getMapGeometry()->getAbsoluteYPositionFromCellCentered(targetCell);
 
     // if we start firing from a mountain, flag it so the bullet won't be blocked by mountains along
     // the way
-    newBullet.bStartedFromMountain = game.m_gameObjectsContext->getMap()->getCell(fromCell)->type == TERRAIN_MOUNTAIN;
+    newBullet.bStartedFromMountain = objects->getMap()->getCell(fromCell)->type == TERRAIN_MOUNTAIN;
 
-    int structureIdAtTargetCell = game.m_gameObjectsContext->getMap()->getCellIdStructuresLayer(targetCell);
+    int structureIdAtTargetCell = objects->getMap()->getCellIdStructuresLayer(targetCell);
     if (structureIdAtTargetCell > -1) {
-        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[structureIdAtTargetCell];
+        cAbstractStructure *pStructure = objects->getStructures()[structureIdAtTargetCell];
         if (pStructure && pStructure->isValid()) {
             newBullet.targetX = pStructure->getRandomPosX();
             newBullet.targetY = pStructure->getRandomPosY();
@@ -239,30 +241,30 @@ int createBullet(int type, int fromCell, int targetCell, int unitWhichShoots, in
     newBullet.iPlayer = -1;
 
     if (unitWhichShoots > -1 ) {
-        cUnit *cUnit = game.m_gameObjectsContext->getUnit(unitWhichShoots);
+        cUnit *cUnit = objects->getUnit(unitWhichShoots);
         newBullet.iPlayer = cUnit->iPlayer;
         // if an airborn unit shoots (ie Ornithopter), reveal on map for everyone
         if (cUnit->isAirbornUnit()) {
-            game.m_gameObjectsContext->getMap()->clearShroudForAllPlayers(fromCell, 2);
+            objects->getMap()->clearShroudForAllPlayers(fromCell, 2);
         }
     }
 
     if (structureWhichShoots > -1) {
-        cAbstractStructure *pStructure = game.m_gameObjectsContext->getStructures()[structureWhichShoots];
+        cAbstractStructure *pStructure = objects->getStructures()[structureWhichShoots];
         newBullet.iPlayer = pStructure->getOwner();
 
-        int unitIdAtTargetCell = game.m_gameObjectsContext->getMap()->getCellIdUnitLayer(targetCell);
+        int unitIdAtTargetCell = objects->getMap()->getCellIdUnitLayer(targetCell);
         if (unitIdAtTargetCell > -1) {
-            cUnit *unitTarget = game.m_gameObjectsContext->getUnit(unitIdAtTargetCell);
+            cUnit *unitTarget = objects->getUnit(unitIdAtTargetCell);
             // reveal for player which is being attacked
-            game.m_gameObjectsContext->getMap()->clearShroud(fromCell, 2, unitTarget->iPlayer);
+            objects->getMap()->clearShroud(fromCell, 2, unitTarget->iPlayer);
         }
 
-        unitIdAtTargetCell = game.m_gameObjectsContext->getMap()->getCellIdAirUnitLayer(targetCell);
+        unitIdAtTargetCell = objects->getMap()->getCellIdAirUnitLayer(targetCell);
         if (unitIdAtTargetCell > -1) {
-            cUnit *unitTarget = game.m_gameObjectsContext->getUnit(unitIdAtTargetCell);
+            cUnit *unitTarget = objects->getUnit(unitIdAtTargetCell);
             // reveal for player which is being attacked
-            game.m_gameObjectsContext->getMap()->clearShroud(fromCell, 2, unitTarget->iPlayer);
+            objects->getMap()->clearShroud(fromCell, 2, unitTarget->iPlayer);
         }
     }
 
@@ -271,30 +273,30 @@ int createBullet(int type, int fromCell, int targetCell, int unitWhichShoots, in
     }
 
     // play sound (when we have one)
-    s_BulletInfo &sBullet = game.m_infoContext->getBulletInfo(type);
+    s_BulletInfo &sBullet = infos->getBulletInfo(type);
     if (sBullet.sound > -1) {
-        game.playSoundWithDistance(sBullet.sound, distanceBetweenCellAndCenterOfScreen(fromCell));
+        iface->playSoundWithDistance(sBullet.sound, distanceBetweenCellAndCenterOfScreen(fromCell, objects, mapCamera));
     }
 
     return new_id;
 }
 
-const char *toStringBuildTypeSpecificType(const eBuildType &buildType, const int &specificTypeId)
+const char *toStringBuildTypeSpecificType(const eBuildType &buildType, const int &specificTypeId, cInfoContext* infos)
 {
     if (specificTypeId < 0) {
         return "Unknown";
     }
     switch (buildType) {
         case eBuildType::SPECIAL:
-            return game.m_infoContext->getSpecialInfo(specificTypeId).description;
+            return infos->getSpecialInfo(specificTypeId).description;
         case eBuildType::UNIT:
-            return game.m_infoContext->getUnitInfo(specificTypeId).name;
+            return infos->getUnitInfo(specificTypeId).name;
         case eBuildType::STRUCTURE:
-            return game.m_infoContext->getStructureInfo(specificTypeId).name;
+            return infos->getStructureInfo(specificTypeId).name;
         case eBuildType::BULLET:
-            return game.m_infoContext->getBulletInfo(specificTypeId).description;
+            return infos->getBulletInfo(specificTypeId).description;
         case eBuildType::UPGRADE:
-            return game.m_infoContext->getUpgradeInfo(specificTypeId).description;
+            return infos->getUpgradeInfo(specificTypeId).description;
         case eBuildType::UNKNOWN:
             return "Unknown";
         default:

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -19,6 +19,11 @@
 #include <SDL3/SDL.h>
 
 struct InitialGameSettings;
+class cGameObjectContext;
+class cMapCamera;
+class cInfoContext;
+class cGameInterface;
+class cGameSettings;
 
 
 /**
@@ -36,6 +41,7 @@ int slowThinkMsToTicks(int desiredMs);
 int fastThinkMsToTicks(int desiredMs);
 int fastThinkTicksToMs(int ticks);
 
+void initLogbook(cGameSettings* settings);
 void logbook(const std::string &txt);
 
 // Color makeColFromString(std::string colorStr);
@@ -44,12 +50,12 @@ void logbook(const std::string &txt);
 
 float healthBar(float max_w, int i, int w);
 
-int iFindCloseBorderCell(int iCll);
+int iFindCloseBorderCell(int iCll, cGameObjectContext* objects);
 
-int createBullet(int type, int fromCell, int targetCell, int unitWhichShoots, int structureWhichShoots);
+int createBullet(int type, int fromCell, int targetCell, int unitWhichShoots, int structureWhichShoots, cGameObjectContext* objects, cInfoContext* infos, cGameInterface* iface, cMapCamera* mapCamera);
 
-int distanceBetweenCellAndCenterOfScreen(int iCell);
+int distanceBetweenCellAndCenterOfScreen(int iCell, cGameObjectContext* objects, cMapCamera* mapCamera);
 
-const char *toStringBuildTypeSpecificType(const eBuildType &buildType, const int &specificTypeId);
+const char *toStringBuildTypeSpecificType(const eBuildType &buildType, const int &specificTypeId, cInfoContext* infos);
 
 std::unique_ptr<InitialGameSettings> loadSettingsFromIni(const std::string& filename);


### PR DESCRIPTION
## Summary

- `common.cpp`: free functions no longer reach into `game.` globals
  - Added `initLogbook(cGameSettings*)` — replaces `game.m_gameSettings->isDebugMode()` via a module-level static; called once at game startup from `cGame_logic.cpp`
  - `iFindCloseBorderCell` takes explicit `cGameObjectContext*`
  - `distanceBetweenCellAndCenterOfScreen` takes explicit `cGameObjectContext*` and `cMapCamera*`
  - `createBullet` takes explicit `cGameObjectContext*`, `cInfoContext*`, `cGameInterface*`, `cMapCamera*`
  - `toStringBuildTypeSpecificType` takes explicit `cInfoContext*`
- `cStructureUtils`: added `serviceInit(sGameServices*)`; replaces `game.m_gameObjectsContext`, `game.m_infoContext`, `game.m_mapCamera`, `game.m_gameSettings` with stored fields
- `cGame_logic`: wires `initLogbook` and `structureUtils->serviceInit` at startup
- All call sites updated: `cUnit`, `cReinforcements`, `cAbstractStructure`, `cGunTurret`, `cGamePlaying`, `cPlayerBrainSkirmish`, `cPlayerBrainMission`

## Test plan

- [x] Build passes (`./rebuildmacos.sh`) with zero errors
- [x] All 43 tests pass
- [x] `grep -rn "game\." src/utils/common.cpp src/utils/cStructureUtils.cpp` returns empty
- [ ] Test skirmish: units fire bullets correctly, sounds play at distance, structure deployment works