### PR TITLE
Step 13: migrate src/controls/ off game global

### DIFF
--- a/src/controls/cGameControlsContext.cpp
+++ b/src/controls/cGameControlsContext.cpp
@@ -5,12 +5,14 @@
 #include "gameobjects/units/cUnits.h"
 #include "gameobjects/map/cMap.h"
 #include "data/gfxdata.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "managers/cDrawManager.h"
 #include "gameobjects/map/cMapCamera.h"
 #include "context/cInfoContext.h"
 #include "context/cGameObjectContext.h"
+#include "include/sGameServices.h"
+#include "game/cGameInterface.h"
+#include "utils/cStructureUtils.h"
+#include "context/GameContext.hpp"
 
 #include "controls/mousestates/cMouseNormalState.h"
 #include "controls/mousestates/cMouseUnitsSelectedState.h"
@@ -51,6 +53,18 @@ cGameControlsContext::~cGameControlsContext()
     // smart pointers handle cleanup
 }
 
+void cGameControlsContext::serviceInit(sGameServices *services)
+{
+    m_objects = services->objects;
+    m_mapCamera = services->mapCamera;
+    m_settings = services->settings;
+    m_drawManager = services->drawManager;
+    m_interface = services->ctx->getGameInterface();
+    m_structureUtils = services->structureUtils;
+    m_infos = services->info;
+    m_mapViewport = services->mapViewport;
+}
+
 void cGameControlsContext::updateMouseCell(const cPoint &coords)
 {
     if (coords.y < cSideBar::TopBarHeight) {
@@ -59,13 +73,13 @@ void cGameControlsContext::updateMouseCell(const cPoint &coords)
         return;
     }
 
-    if (game.m_drawManager->getMiniMapDrawer()->isMouseOver()) {
+    if (m_drawManager->getMiniMapDrawer()->isMouseOver()) {
         m_mouseCell = MOUSE_CELL_HOVER_MINIMAP; // on minimap
         m_mouseOnBattleField = false;
         return;
     }
 
-    if (coords.x > (game.m_gameSettings->getScreenW() - cSideBar::SidebarWidth)) {
+    if (coords.x > (m_settings->getScreenW() - cSideBar::SidebarWidth)) {
         m_mouseCell = MOUSE_CELL_HOVER_SIDEBAR; // on sidebar
         m_mouseOnBattleField = false;
         return;
@@ -79,50 +93,50 @@ void cGameControlsContext::updateMouseCell(const cPoint &coords)
 
 int cGameControlsContext::getMouseCellFromScreen(int mouseX, int mouseY) const
 {
-    int absMapX = game.m_mapCamera->getAbsMapMouseX(mouseX);
-    int absMapY = game.m_mapCamera->getAbsMapMouseY(mouseY);
-    return game.m_mapCamera->getCellFromAbsolutePosition(absMapX, absMapY);
+    int absMapX = m_mapCamera->getAbsMapMouseX(mouseX);
+    int absMapY = m_mapCamera->getAbsMapMouseY(mouseY);
+    return m_mapCamera->getCellFromAbsolutePosition(absMapX, absMapY);
 }
 
 int cGameControlsContext::getMouseCellFromScreenClamped(int mouseX, int mouseY) const
 {
-    int absMapX = game.m_mapCamera->getAbsMapMouseX(mouseX);
-    int absMapY = game.m_mapCamera->getAbsMapMouseY(mouseY);
-    return game.m_mapCamera->getCellFromAbsolutePositionClamped(absMapX, absMapY);
+    int absMapX = m_mapCamera->getAbsMapMouseX(mouseX);
+    int absMapY = m_mapCamera->getAbsMapMouseY(mouseY);
+    return m_mapCamera->getCellFromAbsolutePositionClamped(absMapX, absMapY);
 }
 
 void cGameControlsContext::determineHoveringOverStructureId()
 {
     m_mouseHoveringOverStructureId = -1;
 
-    if (!game.m_gameObjectsContext->getMap()->isVisible(m_mouseCell, this->m_player)) {
+    if (!m_objects->getMap()->isVisible(m_mouseCell, this->m_player)) {
         return; // cell not visible
     }
 
-    m_mouseHoveringOverStructureId = game.m_gameObjectsContext->getMap()->getCellIdStructuresLayer(m_mouseCell);
+    m_mouseHoveringOverStructureId = m_objects->getMap()->getCellIdStructuresLayer(m_mouseCell);
 }
 
 void cGameControlsContext::determineHoveringOverUnitId()
 {
     if (m_mouseHoveringOverUnitId > -1) {
-        cUnit *aUnit = game.m_gameObjectsContext->getUnit(m_mouseHoveringOverUnitId);
+        cUnit *aUnit = m_objects->getUnit(m_mouseHoveringOverUnitId);
         if (aUnit->isValid()) {
             aUnit->rendering.bHovered = false;
         }
     }
     m_mouseHoveringOverUnitId = -1;
     int mc = getMouseCell();
-    tCell *cellOfMouse = game.m_gameObjectsContext->getMap()->getCell(mc);
+    tCell *cellOfMouse = m_objects->getMap()->getCell(mc);
     if (cellOfMouse == nullptr) return; // mouse is not on battlefield
 
-    if (!game.m_gameObjectsContext->getMap()->isVisible(mc, this->m_player)) {
+    if (!m_objects->getMap()->isVisible(mc, this->m_player)) {
         return; // cell not visible
     }
 
     if (cellOfMouse->id[MAPID_UNITS] > -1) {
         int iUnitId = cellOfMouse->id[MAPID_UNITS];
 
-        if (!game.m_gameObjectsContext->getUnit(iUnitId)->isHidden()) {
+        if (!m_objects->getUnit(iUnitId)->isHidden()) {
             m_mouseHoveringOverUnitId = iUnitId;
         }
 
@@ -133,7 +147,7 @@ void cGameControlsContext::determineHoveringOverUnitId()
     }
 
     if (m_mouseHoveringOverUnitId > -1) {
-        cUnit *aUnit = game.m_gameObjectsContext->getUnit(m_mouseHoveringOverUnitId);
+        cUnit *aUnit = m_objects->getUnit(m_mouseHoveringOverUnitId);
         if (aUnit->isValid()) {
             aUnit->rendering.bHovered = true;
         }
@@ -145,7 +159,7 @@ cAbstractStructure *cGameControlsContext::getStructurePointerWhereMouseHovers() 
     if (m_mouseHoveringOverStructureId < 0) {
         return nullptr;
     }
-    return game.m_gameObjectsContext->getStructures()[m_mouseHoveringOverStructureId];
+    return m_objects->getStructures()[m_mouseHoveringOverStructureId];
 }
 
 void cGameControlsContext::onMouseMovedTo(const s_MouseEvent &event)

--- a/src/controls/cGameControlsContext.h
+++ b/src/controls/cGameControlsContext.h
@@ -23,11 +23,31 @@ class cMousePlaceState;
 class cMouseDeployState;
 
 class cAbstractStructure;
+class cGameObjectContext;
+class cMapCamera;
+class cGameSettings;
+class cDrawManager;
+class cRectangle;
+class cGameInterface;
+class cStructureUtils;
+class cInfoContext;
+struct sGameServices;
 
 class cGameControlsContext : public cInputObserver, cScenarioObserver {
 public:
     explicit cGameControlsContext(cPlayer *player, cMouse *mouse);
     ~cGameControlsContext() override;
+
+    void serviceInit(sGameServices *services);
+
+    cGameObjectContext *getObjects() const { return m_objects; }
+    cMapCamera *getMapCamera() const { return m_mapCamera; }
+    cGameSettings *getSettings() const { return m_settings; }
+    cDrawManager *getDrawManager() const { return m_drawManager; }
+    cGameInterface *getInterface() const { return m_interface; }
+    cStructureUtils *getStructureUtils() const { return m_structureUtils; }
+    cInfoContext *getInfos() const { return m_infos; }
+    cRectangle *getMapViewport() const { return m_mapViewport; }
 
     int getIdOfStructureWhereMouseHovers() const {
         return m_mouseHoveringOverStructureId;
@@ -109,6 +129,15 @@ private:
     // in conjunction
 
     cMouse *m_mouse;
+
+    cGameObjectContext *m_objects = nullptr;
+    cMapCamera *m_mapCamera = nullptr;
+    cGameSettings *m_settings = nullptr;
+    cDrawManager *m_drawManager = nullptr;
+    cGameInterface *m_interface = nullptr;
+    cStructureUtils *m_structureUtils = nullptr;
+    cInfoContext *m_infos = nullptr;
+    cRectangle *m_mapViewport = nullptr;
 
     // the states, initialized once to save a lot of construct/destructs (and make it possible
     // to switch between states without needing to restore 'state' within the state object)

--- a/src/controls/cMouse.cpp
+++ b/src/controls/cMouse.cpp
@@ -2,8 +2,6 @@
 #include "game/cGameSettings.h"
 #include "controls/cGameControlsContext.h"
 #include "observers/cInputObserver.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "data/gfxdata.h"
 #include "drawers/SDLDrawer.hpp"
 #include "sidebar/cSideBar.h"
@@ -260,8 +258,8 @@ void cMouse::boxSelectLogic(int mouseCell)
         if (abs(m_coords.x - m_mouseCoX1) > 4 && abs(m_coords.y - m_mouseCoY1) > 4) {
             // assign 2nd coordinates
             m_mouseCoX2 = m_coords.x;
-            if (m_coords.x > game.m_gameSettings->getScreenW() - cSideBar::SidebarWidth) {
-                m_mouseCoX2 = game.m_gameSettings->getScreenW() - cSideBar::SidebarWidth - 1;
+            if (m_coords.x > m_settings->getScreenW() - cSideBar::SidebarWidth) {
+                m_mouseCoX2 = m_settings->getScreenW() - cSideBar::SidebarWidth - 1;
             }
 
             m_mouseCoY2 = m_coords.y;

--- a/src/controls/cMouse.h
+++ b/src/controls/cMouse.h
@@ -9,6 +9,7 @@ class cRectangle;
 class GameContext;
 class SDLDrawer;
 class cInputObserver;
+class cGameSettings;
 
 class cMouse {
 
@@ -24,6 +25,8 @@ public:
     void setMouseObserver(cInputObserver *mouseObserver);
 
     void init();
+
+    void setSettings(cGameSettings *settings) { m_settings = settings; }
 
     // these functions return true when the mouse button is being hold down
     bool isLeftButtonPressed() {
@@ -94,6 +97,7 @@ private:
     cInputObserver *m_mouseObserver = nullptr;
     GameContext* m_ctx = nullptr;
     SDLDrawer* m_renderDrawer = nullptr;
+    cGameSettings* m_settings = nullptr;
 
     bool m_leftButtonPressed;
     bool m_rightButtonPressed;

--- a/src/controls/mousestates/cMouseDeployState.cpp
+++ b/src/controls/mousestates/cMouseDeployState.cpp
@@ -1,8 +1,7 @@
 #include "cMouseDeployState.h"
 
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "data/gfxdata.h"
+#include "game/cGameInterface.h"
 #include "controls/cGameControlsContext.h"
 #include "gameobjects/players/cPlayer.h"
 #include "sidebar/cSideBar.h"
@@ -66,7 +65,7 @@ void cMouseDeployState::onMouseLeftButtonClicked()
             .playerID = m_player->getId()
         }
     };
-    game.onNotifyGameEvent(event);
+    m_context->getInterface()->onNotifyGameEvent(event);
 }
 
 void cMouseDeployState::onMouseRightButtonPressed()

--- a/src/controls/mousestates/cMouseNormalState.cpp
+++ b/src/controls/mousestates/cMouseNormalState.cpp
@@ -6,12 +6,12 @@
 #include "utils/cRectangle.h"
 #include "utils/cSoundPlayer.h"
 #include "managers/cDrawManager.h"
+#include "game/cGameInterface.h"
 #include "gameobjects/units/cUnit.h"
 #include "gameobjects/structures/cAbstractStructure.h"
 #include "gameobjects/players/cPlayer.h"
 
-#include "game/cGame.h"
-#include "include/d2tmc.h"
+
 
 #include "utils/cLog.h"
 #include "data/gfxdata.h"
@@ -78,11 +78,11 @@ void cMouseNormalState::onMouseLeftButtonClicked()
 
         if (!ids.empty()) {
             if (ids.size() > 1) {
-                game.m_drawManager->setMessage(std::format("{} units selected", ids.size()));
+                m_context->getDrawManager()->setMessage(std::format("{} units selected", ids.size()));
             }
             else {
-                cUnit *pUnit = game.m_gameObjectsContext->getUnit(ids[0]);
-                game.m_drawManager->setMessage(pUnit->getUnitStatusForMessageBar());
+                cUnit *pUnit = m_context->getObjects()->getUnit(ids[0]);
+                m_context->getDrawManager()->setMessage(pUnit->getUnitStatusForMessageBar());
             }
         }
     }
@@ -96,7 +96,7 @@ void cMouseNormalState::onMouseLeftButtonClicked()
             if (hoverUnitId > -1) {
                 m_player->deselectAllUnits();
 
-                cUnit *pUnit = game.m_gameObjectsContext->getUnit(hoverUnitId);
+                cUnit *pUnit = m_context->getObjects()->getUnit(hoverUnitId);
                 if (pUnit->isValid() && pUnit->belongsTo(m_player) && !pUnit->isSelected()) {
                     pUnit->select();
                     if (pUnit->isInfantryUnit()) {
@@ -105,7 +105,7 @@ void cMouseNormalState::onMouseLeftButtonClicked()
                     else {
                         unitSelected = true;
                     }
-                    game.m_drawManager->setMessage(pUnit->getUnitStatusForMessageBar());
+                    m_context->getDrawManager()->setMessage(pUnit->getUnitStatusForMessageBar());
                 }
             }
 
@@ -124,7 +124,7 @@ void cMouseNormalState::onMouseLeftButtonClicked()
                 }
 
                 if (pStructure && pStructure->isValid()) {
-                    game.m_drawManager->setMessage(pStructure->getStatusForMessageBar());
+                    m_context->getDrawManager()->setMessage(pStructure->getStatusForMessageBar());
                 }
             }
         }
@@ -137,11 +137,11 @@ void cMouseNormalState::onMouseLeftButtonClicked()
         }
 
         if (unitSelected) {
-            game.playSound(SOUND_REPORTING);
+            m_context->getInterface()->playSound(SOUND_REPORTING);
         }
 
         if (infantrySelected) {
-            game.playSound(SOUND_YESSIR);
+            m_context->getInterface()->playSound(SOUND_YESSIR);
         }
 
         selectedUnits = unitSelected || infantrySelected;
@@ -178,7 +178,7 @@ int cMouseNormalState::getMouseTileForNormalState() const
 {
     int hoverUnitId = m_context->getIdOfUnitWhereMouseHovers();
     if (hoverUnitId > -1) {
-        cUnit *pUnit = game.m_gameObjectsContext->getUnit(hoverUnitId);
+        cUnit *pUnit = m_context->getObjects()->getUnit(hoverUnitId);
         if (pUnit->isValid() && pUnit->belongsTo(m_player)) {
             // only show this for units
             return MOUSE_PICK;
@@ -234,7 +234,7 @@ void cMouseNormalState::onKeyDown(const cKeyboardEvent &event)
     }
 
     if (event.isAction(eKeyAction::SELECT_INFANTRY_ON_SCREEN)) {
-        const auto infantryUnits = m_player->getInfantryUnitsOnViewport(*game.m_mapViewport);
+        const auto infantryUnits = m_player->getInfantryUnitsOnViewport(*m_context->getMapViewport());
         bool hasUnit = m_player->selectUnits(infantryUnits);
         if (hasUnit) {
             m_context->setMouseState(MOUSESTATE_UNITS_SELECTED);
@@ -251,7 +251,7 @@ void cMouseNormalState::onKeyDown(const cKeyboardEvent &event)
     }
 
     if (event.isAction(eKeyAction::SELECT_WHEELS_ON_SCREEN)) {
-        const auto wheelUnits = m_player->getWheelUnitsOnViewport(*game.m_mapViewport);
+        const auto wheelUnits = m_player->getWheelUnitsOnViewport(*m_context->getMapViewport());
         bool hasUnit = m_player->selectUnits(wheelUnits);
         if (hasUnit) {
             m_context->setMouseState(MOUSESTATE_UNITS_SELECTED);
@@ -267,7 +267,7 @@ void cMouseNormalState::onKeyDown(const cKeyboardEvent &event)
     }
 
     if (event.isAction(eKeyAction::SELECT_TANKS_ON_SCREEN)) {
-        const auto tankUnits = m_player->getTankUnitsOnViewport(*game.m_mapViewport);
+        const auto tankUnits = m_player->getTankUnitsOnViewport(*m_context->getMapViewport());
         bool hasUnit = m_player->selectUnits(tankUnits);
         if (hasUnit) {
             m_context->setMouseState(MOUSESTATE_UNITS_SELECTED);
@@ -284,7 +284,7 @@ void cMouseNormalState::onKeyDown(const cKeyboardEvent &event)
 
 
     if (event.isAction(eKeyAction::SELECT_LAUNCHERS_ON_SCREEN)) {
-        const auto launcherUnits = m_player->getLauncherUnitsOnViewport(*game.m_mapViewport);
+        const auto launcherUnits = m_player->getLauncherUnitsOnViewport(*m_context->getMapViewport());
         bool hasUnit = m_player->selectUnits(launcherUnits);
         if (hasUnit) {
             m_context->setMouseState(MOUSESTATE_UNITS_SELECTED);
@@ -302,7 +302,7 @@ void cMouseNormalState::onKeyDown(const cKeyboardEvent &event)
 
 
     if (event.isAction(eKeyAction::SELECT_HARVESTERS_ON_SCREEN)) {
-        const auto harvesterUnits = m_player->getHarvesterUnitsOnViewport(*game.m_mapViewport);
+        const auto harvesterUnits = m_player->getHarvesterUnitsOnViewport(*m_context->getMapViewport());
         bool hasUnit = m_player->selectUnits(harvesterUnits);
         if (hasUnit) {
             m_context->setMouseState(MOUSESTATE_UNITS_SELECTED);

--- a/src/controls/mousestates/cMousePlaceState.cpp
+++ b/src/controls/mousestates/cMousePlaceState.cpp
@@ -1,8 +1,7 @@
 #include "cMousePlaceState.h"
 
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "gameobjects/map/cMap.h"
+#include "game/cGameInterface.h"
 #include "data/gfxdata.h"
 #include "controls/cGameControlsContext.h"
 #include "gameobjects/structures/cStructures.h"
@@ -68,7 +67,7 @@ void cMousePlaceState::onMouseLeftButtonClicked()
     }
 
     if (mayPlaceIt(itemToPlace, m_context->getMouseCell())) {
-        game.playSound(SOUND_PLACE);
+        m_context->getInterface()->playSound(SOUND_PLACE);
         m_player->placeItem(mouseCell, itemToPlace);
         m_context->toPreviousState();
     }
@@ -86,13 +85,13 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
 
     bool bWithinBuildDistance = false;
 
-    int cellWidth = game.m_structureUtils->getWidthOfStructureTypeInCells(structureIdToPlace);
-    int cellHeight = game.m_structureUtils->getHeightOfStructureTypeInCells(structureIdToPlace);
+    int cellWidth = m_context->getStructureUtils()->getWidthOfStructureTypeInCells(structureIdToPlace);
+    int cellHeight = m_context->getStructureUtils()->getHeightOfStructureTypeInCells(structureIdToPlace);
 
 #define SCANWIDTH    1
 
-    int iCellX = game.m_gameObjectsContext->getMapGeometry()->getCellX(mouseCell);
-    int iCellY = game.m_gameObjectsContext->getMapGeometry()->getCellY(mouseCell);
+    int iCellX = m_context->getObjects()->getMapGeometry()->getCellX(mouseCell);
+    int iCellY = m_context->getObjects()->getMapGeometry()->getCellY(mouseCell);
 
     // check
     int iStartX = iCellX - SCANWIDTH;
@@ -102,20 +101,20 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
     int iEndY = iCellY + SCANWIDTH + cellHeight;
 
     // Fix up the boundaries
-    cPoint::split(iStartX, iStartY) = game.m_gameObjectsContext->getMapGeometry()->fixCoordinatesToBeWithinMap(iStartX, iStartY);
-    cPoint::split(iEndX, iEndY) = game.m_gameObjectsContext->getMapGeometry()->fixCoordinatesToBeWithinMap(iEndX, iEndY);
+    cPoint::split(iStartX, iStartY) = m_context->getObjects()->getMapGeometry()->fixCoordinatesToBeWithinMap(iStartX, iStartY);
+    cPoint::split(iEndX, iEndY) = m_context->getObjects()->getMapGeometry()->fixCoordinatesToBeWithinMap(iEndX, iEndY);
 
     // Determine if structure to be placed is within build distance
     for (int iX = iStartX; iX < iEndX; iX++) {
         for (int iY = iStartY; iY < iEndY; iY++) {
-            int iCll = game.m_gameObjectsContext->getMapGeometry()->getCellWithMapDimensions(iX, iY);
+            int iCll = m_context->getObjects()->getMapGeometry()->getCellWithMapDimensions(iX, iY);
 
             if (iCll > -1) {
-                int idOfStructureAtCell = game.m_gameObjectsContext->getMap()->getCellIdStructuresLayer(iCll);
+                int idOfStructureAtCell = m_context->getObjects()->getMap()->getCellIdStructuresLayer(iCll);
                 if (idOfStructureAtCell > -1) {
                     int iID = idOfStructureAtCell;
 
-                    if (game.m_gameObjectsContext->getStructures()[iID]->getOwner() == HUMAN) {
+                    if (m_context->getObjects()->getStructures()[iID]->getOwner() == HUMAN) {
                         bWithinBuildDistance = true; // connection!
                         break;
                     }
@@ -123,8 +122,8 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
                     // TODO: Allow placement nearby allies?
                 }
 
-                if (game.m_gameObjectsContext->getMap()->getCellType(iCll) == TERRAIN_WALL ||
-                        game.m_gameObjectsContext->getMap()->getCellType(iCll) == TERRAIN_SLAB) {
+                if (m_context->getObjects()->getMap()->getCellType(iCll) == TERRAIN_WALL ||
+                        m_context->getObjects()->getMap()->getCellType(iCll) == TERRAIN_SLAB) {
                     bWithinBuildDistance = true;
                     // TODO: here we should actually find out if the slab is ours or not??
                     break;
@@ -145,14 +144,14 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
             int cellX = iCellX + iX;
             int cellY = iCellY + iY;
 
-            if (!game.m_gameObjectsContext->getMapGeometry()->isWithinBoundaries(cellX, cellY)) {
+            if (!m_context->getObjects()->getMapGeometry()->isWithinBoundaries(cellX, cellY)) {
                 return false;
             }
 
-            int iCll = game.m_gameObjectsContext->getMapGeometry()->makeCell(cellX, cellY);
+            int iCll = m_context->getObjects()->getMapGeometry()->makeCell(cellX, cellY);
 
             // occupied by units or structures
-            int idOfStructureAtCell = game.m_gameObjectsContext->getMap()->getCellIdStructuresLayer(iCll);
+            int idOfStructureAtCell = m_context->getObjects()->getMap()->getCellIdStructuresLayer(iCll);
             if (idOfStructureAtCell > -1) {
                 // may not place when we're not placing a slab.. hack hack
                 if (structureIdToPlace != SLAB4) {
@@ -162,10 +161,10 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
 
             // non slab 'structures' can be blocked by units
             if (structureIdToPlace != SLAB4 && structureIdToPlace != SLAB1) {
-                int unitIdOnMap = game.m_gameObjectsContext->getMap()->getCellIdUnitLayer(iCll);
+                int unitIdOnMap = m_context->getObjects()->getMap()->getCellIdUnitLayer(iCll);
                 if (unitIdOnMap > -1) {
                     // temporarily dead units do not block, but alive units (non-dead) do block placement
-                    if (!game.m_gameObjectsContext->getUnit(unitIdOnMap)->isDead()) {
+                    if (!m_context->getObjects()->getUnit(unitIdOnMap)->isDead()) {
                         return false;
                     }
                     // TODO: Allow placement, let units move aside when clicking before placement?

--- a/src/controls/mousestates/cMouseRepairState.cpp
+++ b/src/controls/mousestates/cMouseRepairState.cpp
@@ -1,8 +1,6 @@
 #include "cMouseRepairState.h"
 
 #include "controls/eKeyAction.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "data/gfxdata.h"
 #include "gameobjects/map/cMap.h"
 #include "controls/cGameControlsContext.h"
@@ -53,7 +51,7 @@ void cMouseRepairState::onMouseLeftButtonClicked()
 {
     int hoverUnitId = m_context->getIdOfUnitWhereMouseHovers();
     if (hoverUnitId > -1) {
-        cUnit *pUnit = game.m_gameObjectsContext->getUnit(hoverUnitId);
+        cUnit *pUnit = m_context->getObjects()->getUnit(hoverUnitId);
         if (pUnit->isValid() && pUnit->belongsTo(m_player) && pUnit->isEligibleForRepair()) {
             pUnit->findBestStructureCandidateAndHeadTowardsItOrWait(REPAIR, true, INTENT_REPAIR);
         }
@@ -104,7 +102,7 @@ int cMouseRepairState::getMouseTileForRepairState()
 {
     int hoverUnitId = m_context->getIdOfUnitWhereMouseHovers();
     if (hoverUnitId > -1) {
-        cUnit *pUnit = game.m_gameObjectsContext->getUnit(hoverUnitId);
+        cUnit *pUnit = m_context->getObjects()->getUnit(hoverUnitId);
         if (pUnit->isValid() && pUnit->belongsTo(m_player) && pUnit->isEligibleForRepair()) {
             return MOUSE_REPAIR;
         }

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -1,11 +1,10 @@
 #include "cMouseUnitsSelectedState.h"
 
 #include "controls/eKeyAction.h"
-#include "game/cGame.h"
-#include "include/d2tmc.h"
 #include "data/gfxdata.h"
 #include "controls/cGameControlsContext.h"
 #include "context/cInfoContext.h"
+#include "game/cGameInterface.h"
 #include "context/cGameObjectContext.h"
 #include "gameobjects/particles/cParticle.h"
 #include "gameobjects/units/cUnits.h"
@@ -151,7 +150,7 @@ void cMouseUnitsSelectedState::onMouseLeftButtonClicked()
                  m_state == SELECTED_STATE_MOVE) {
 
             for (auto id: m_selectedUnits) {
-                cUnit *pUnit = game.m_gameObjectsContext->getUnit(id);
+                cUnit *pUnit = m_context->getObjects()->getUnit(id);
                 if (m_state == SELECTED_STATE_REPAIR) {
                     // only send units that are eligible for repair to facility
                     if (pUnit->isEligibleForRepair()) {
@@ -178,7 +177,7 @@ void cMouseUnitsSelectedState::onMouseLeftButtonClicked()
         }
         else if (m_state == SELECTED_STATE_ATTACK || m_state == SELECTED_STATE_FORCE_ATTACK) {
             for (auto id: m_selectedUnits) {
-                cUnit *pUnit = game.m_gameObjectsContext->getUnit(id);
+                cUnit *pUnit = m_context->getObjects()->getUnit(id);
                 if (pUnit->isHarvester()) {
                     continue;
                 }
@@ -196,7 +195,7 @@ void cMouseUnitsSelectedState::onMouseLeftButtonClicked()
         else if (m_state == SELECTED_STATE_ADD_TO_SELECTION) {
             const int hoverUnitId = m_context->getIdOfUnitWhereMouseHovers();
             if (hoverUnitId > -1) {
-                cUnit *pUnit = game.m_gameObjectsContext->getUnit(hoverUnitId);
+                cUnit *pUnit = m_context->getObjects()->getUnit(hoverUnitId);
                 if (pUnit->getPlayer() == m_player) {
                     auto ids = m_player->getSelectedUnits();
                     auto position = std::find(ids.begin(), ids.end(), hoverUnitId);
@@ -213,11 +212,11 @@ void cMouseUnitsSelectedState::onMouseLeftButtonClicked()
         }
 
         if (infantryAcknowledged) {
-            game.playSound(SOUND_MOVINGOUT + RNG::rnd(2));
+            m_context->getInterface()->playSound(SOUND_MOVINGOUT + RNG::rnd(2));
         }
 
         if (unitAcknowledged) {
-            game.playSound(SOUND_ACKNOWLEDGED + RNG::rnd(3));
+            m_context->getInterface()->playSound(SOUND_ACKNOWLEDGED + RNG::rnd(3));
         }
     }
 
@@ -312,7 +311,7 @@ void cMouseUnitsSelectedState::evaluateMouseMoveState()
     if (unitsWhichCanAttackSelected) {
         int hoverUnitId = m_context->getIdOfUnitWhereMouseHovers();
         if (hoverUnitId > -1) {
-            cUnit *pUnit = game.m_gameObjectsContext->getUnit(hoverUnitId);
+            cUnit *pUnit = m_context->getObjects()->getUnit(hoverUnitId);
             if (pUnit->isValid()) {
                 if (!pUnit->getPlayer()->isSameTeamAs(m_player)) {
                     m_mouseTile = MOUSE_ATTACK;
@@ -345,7 +344,7 @@ void cMouseUnitsSelectedState::updateSelectedUnitsState()
     m_infantrySelected = false;
     m_repairableUnitsSelected = false;
     for (auto id: m_selectedUnits) {
-        cUnit *pUnit = game.m_gameObjectsContext->getUnit(id);
+        cUnit *pUnit = m_context->getObjects()->getUnit(id);
         if (pUnit->isHarvester()) {
             m_harvestersSelected = true;
             m_repairableUnitsSelected = true;
@@ -373,9 +372,9 @@ void cMouseUnitsSelectedState::evaluateSelectedUnits()
             m_selectedUnits.begin(),
             m_selectedUnits.end(),
     [this](int id) {
-        return !game.m_gameObjectsContext->getUnit(id)->isValid() || // no (longer) valid
-               !game.m_gameObjectsContext->getUnit(id)->belongsTo(m_player) || // no longer belongs to player
-               game.m_gameObjectsContext->getUnit(id)->isHidden(); // hidden (entered structure, etc). Forget it then.
+        return !m_context->getObjects()->getUnit(id)->isValid() || // no (longer) valid
+               !m_context->getObjects()->getUnit(id)->belongsTo(m_player) || // no longer belongs to player
+               m_context->getObjects()->getUnit(id)->isHidden(); // hidden (entered structure, etc). Forget it then.
     }),
     m_selectedUnits.end()
     );
@@ -428,7 +427,7 @@ void cMouseUnitsSelectedState::onKeyDown(const cKeyboardEvent &event)
         if (!m_mouse->isBoxSelecting()) {
             int hoverUnitId = m_context->getIdOfUnitWhereMouseHovers();
             if (hoverUnitId > -1) {
-                cUnit *pUnit = game.m_gameObjectsContext->getUnit(hoverUnitId);
+                cUnit *pUnit = m_context->getObjects()->getUnit(hoverUnitId);
                 if (pUnit->getPlayer() == m_player) {
                     m_mouseTile = MOUSE_PICK;
                 }
@@ -468,14 +467,14 @@ void cMouseUnitsSelectedState::onKeyDown(const cKeyboardEvent &event)
 
     if (event.isAction(eKeyAction::SELECT_SAME_TYPE_ON_SCREEN)) {
         if (m_selectedUnits.size() == 1) {
-            cUnit *pUnit = game.m_gameObjectsContext->getUnit(m_selectedUnits[0]);
+            cUnit *pUnit = m_context->getObjects()->getUnit(m_selectedUnits[0]);
             selectSameUnitsOnScreen(pUnit->iType);
         }
     }
 
     if (event.isAction(eKeyAction::SELECT_SAME_TYPE_ON_MAP)) {
         if (m_selectedUnits.size() == 1) {
-            cUnit *pUnit = game.m_gameObjectsContext->getUnit(m_selectedUnits[0]);
+            cUnit *pUnit = m_context->getObjects()->getUnit(m_selectedUnits[0]);
             selectSameUnitsOnMap(pUnit->iType);
         }
     }
@@ -487,7 +486,7 @@ void cMouseUnitsSelectedState::onKeyDown(const cKeyboardEvent &event)
     }
 
     if (event.isAction(eKeyAction::SELECT_INFANTRY_ON_SCREEN)) {
-        const auto infantryUnits = m_player->getInfantryUnitsOnViewport(*game.m_mapViewport);
+        const auto infantryUnits = m_player->getInfantryUnitsOnViewport(*m_context->getMapViewport());
         m_player->selectUnits(infantryUnits);
         m_selectedUnits = m_player->getSelectedUnits();
     }
@@ -499,7 +498,7 @@ void cMouseUnitsSelectedState::onKeyDown(const cKeyboardEvent &event)
     }
 
     if (event.isAction(eKeyAction::SELECT_WHEELS_ON_SCREEN)) {
-        const auto wheelUnits = m_player->getWheelUnitsOnViewport(*game.m_mapViewport);
+        const auto wheelUnits = m_player->getWheelUnitsOnViewport(*m_context->getMapViewport());
         m_player->selectUnits(wheelUnits);
         m_selectedUnits = m_player->getSelectedUnits();
     }
@@ -511,7 +510,7 @@ void cMouseUnitsSelectedState::onKeyDown(const cKeyboardEvent &event)
     }
 
     if (event.isAction(eKeyAction::SELECT_TANKS_ON_SCREEN)) {
-        const auto tankUnits = m_player->getTankUnitsOnViewport(*game.m_mapViewport);
+        const auto tankUnits = m_player->getTankUnitsOnViewport(*m_context->getMapViewport());
         m_player->selectUnits(tankUnits);
         m_selectedUnits = m_player->getSelectedUnits();
     }
@@ -523,7 +522,7 @@ void cMouseUnitsSelectedState::onKeyDown(const cKeyboardEvent &event)
     }
 
     if (event.isAction(eKeyAction::SELECT_LAUNCHERS_ON_SCREEN)) {
-        const auto launcherUnits = m_player->getLauncherUnitsOnViewport(*game.m_mapViewport);
+        const auto launcherUnits = m_player->getLauncherUnitsOnViewport(*m_context->getMapViewport());
         m_player->selectUnits(launcherUnits);
         m_selectedUnits = m_player->getSelectedUnits();
     }
@@ -535,7 +534,7 @@ void cMouseUnitsSelectedState::onKeyDown(const cKeyboardEvent &event)
     }
 
     if (event.isAction(eKeyAction::SELECT_HARVESTERS_ON_SCREEN)) {
-        const auto harvesterUnits = m_player->getHarvesterUnitsOnViewport(*game.m_mapViewport);
+        const auto harvesterUnits = m_player->getHarvesterUnitsOnViewport(*m_context->getMapViewport());
         m_player->selectUnits(harvesterUnits);
         m_selectedUnits = m_player->getSelectedUnits();
     }
@@ -565,14 +564,14 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
             m_context->setMouseState(MOUSESTATE_REPAIR);
         } else {
             for (auto id: m_selectedUnits) {
-                cUnit *pUnit = game.m_gameObjectsContext->getUnit(id);
+                cUnit *pUnit = m_context->getObjects()->getUnit(id);
                 if (pUnit->isEligibleForRepair()) {
                     pUnit->findBestStructureCandidateAndHeadTowardsItOrWait(REPAIR, true, INTENT_REPAIR);
                     pUnit->deselect();
                 }
             }
             std::erase_if(m_selectedUnits, [&](auto id) {
-                cUnit *pUnit = game.m_gameObjectsContext->getUnit(id);
+                cUnit *pUnit = m_context->getObjects()->getUnit(id);
                 return pUnit->isEligibleForRepair(); // remove from selection
             });
         }
@@ -582,7 +581,7 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
     if (event.isAction(eKeyAction::SEND_TO_REFINERY)) {
         const std::vector<int> &selectedUnits = m_player->getSelectedUnits();
         for (auto &id : selectedUnits) {
-            cUnit *pUnit = game.m_gameObjectsContext->getUnit(id);
+            cUnit *pUnit = m_context->getObjects()->getUnit(id);
             if (pUnit->isHarvester() && pUnit->canUnload()) {
                 pUnit->findBestStructureCandidateAndHeadTowardsItOrWait(REFINERY, true, INTENT_UNLOAD_SPICE);
             }
@@ -594,7 +593,7 @@ void cMouseUnitsSelectedState::onKeyPressed(const cKeyboardEvent &event)
 
     if (event.isAction(eKeyAction::RETURN_TO_BASE)) {
         for (auto id: m_selectedUnits) {
-            cUnit *pUnit = game.m_gameObjectsContext->getUnit(id);
+            cUnit *pUnit = m_context->getObjects()->getUnit(id);
             pUnit->retreatToNearbyBase();
             pUnit->deselect();
         }
@@ -609,9 +608,9 @@ void cMouseUnitsSelectedState::toPreviousState()
 
 void cMouseUnitsSelectedState::spawnParticle(const int type)
 {
-    int absoluteXCoordinate = game.m_mapCamera->getAbsMapMouseX(m_mouse->getX());
-    int absoluteYCoordinate = game.m_mapCamera->getAbsMapMouseY(m_mouse->getY());
-    cParticle::create(absoluteXCoordinate, absoluteYCoordinate, type, -1, -1, game.m_gameObjectsContext.get(), game.m_infoContext.get());
+    int absoluteXCoordinate = m_context->getMapCamera()->getAbsMapMouseX(m_mouse->getX());
+    int absoluteYCoordinate = m_context->getMapCamera()->getAbsMapMouseY(m_mouse->getY());
+    cParticle::create(absoluteXCoordinate, absoluteYCoordinate, type, -1, -1, m_context->getObjects(), m_context->getInfos());
 }
 
 void cMouseUnitsSelectedState::onFocus()
@@ -627,10 +626,10 @@ void cMouseUnitsSelectedState::onBlur()
 
 void cMouseUnitsSelectedState::selectSameUnitsOnScreen(int unitType)
 {
-    const std::vector<int> &ids = m_player->getAllMyUnitsWithinViewportRect(*game.m_mapViewport);
+    const std::vector<int> &ids = m_player->getAllMyUnitsWithinViewportRect(*m_context->getMapViewport());
     std::vector<int> sameUnits =std::vector<int>();
     for (int i : ids) {
-        cUnit *pUnit = game.m_gameObjectsContext->getUnit(i);
+        cUnit *pUnit = m_context->getObjects()->getUnit(i);
         if (pUnit->iType == unitType) {
             sameUnits.push_back(i);
         }
@@ -644,7 +643,7 @@ void cMouseUnitsSelectedState::selectSameUnitsOnMap(int unitType)
     const std::vector<int> &ids = m_player->getAllMyUnits();
     std::vector<int> sameUnits =std::vector<int>();
     for (int i : ids) {
-        cUnit *pUnit = game.m_gameObjectsContext->getUnit(i);
+        cUnit *pUnit = m_context->getObjects()->getUnit(i);
         if (pUnit->iType == unitType) {
             sameUnits.push_back(i);
         }

--- a/src/drawers/SDLDrawer.cpp
+++ b/src/drawers/SDLDrawer.cpp
@@ -18,7 +18,7 @@ SDLDrawer::~SDLDrawer()
 
 void SDLDrawer::renderSprite(Texture *src,int x, int y,Uint8 opacity)
 {
-    if (src == nullptr) return;
+    if (src == nullptr || src->tex.get() == nullptr) return;
     SDL_FRect tmp = {(float)x, (float)y, (float)src->w, (float)src->h};
     SDL_SetTextureBlendMode(src->tex.get(), SDL_BLENDMODE_BLEND);
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
@@ -59,9 +59,8 @@ void SDLDrawer::renderFromSurface(SDL_Surface *src, int x, int y,Uint8 opacity)
 
 void SDLDrawer::renderStrechSprite(Texture *src, cRectangle src_pos, cRectangle dest_pos, Uint8 opacity)
 {
-    if (!SDL_SetTextureBlendMode(src->tex.get(), SDL_BLENDMODE_BLEND)) {
-        std::cerr << "Error SDL_SetTextureBlendMode : " << SDL_GetError() << std::endl;
-    }
+    if (src == nullptr || src->tex.get() == nullptr) return;
+    SDL_SetTextureBlendMode(src->tex.get(), SDL_BLENDMODE_BLEND);
     SDL_SetTextureAlphaMod(src->tex.get(), opacity);
     SDL_FRect srcRect = src_pos.toSDLF();
     SDL_FRect destRect = dest_pos.toSDLF();
@@ -70,9 +69,8 @@ void SDLDrawer::renderStrechSprite(Texture *src, cRectangle src_pos, cRectangle 
 
 void SDLDrawer::renderStrechFullSprite(Texture *src, cRectangle dest_pos, Uint8 opacity)
 {
-    if (!SDL_SetTextureBlendMode(src->tex.get(), SDL_BLENDMODE_BLEND)) {
-        std::cerr << "Error SDL_SetTextureBlendMode : " << SDL_GetError() << std::endl;
-    }
+    if (src == nullptr || src->tex.get() == nullptr) return;
+    SDL_SetTextureBlendMode(src->tex.get(), SDL_BLENDMODE_BLEND);
     SDL_SetTextureAlphaMod(src->tex.get(), opacity);
     SDL_FRect destRect = dest_pos.toSDLF();
     SDL_RenderTexture(renderer, src->tex.get(), nullptr, &destRect);

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -706,6 +706,7 @@ bool cGame::setupGame()
 
     // do it here, because it depends on fonts to be loaded
     m_mouse = new cMouse(ctx.get());
+    m_mouse->setSettings(m_gameSettings.get());
 
     /***
      * Viewport(s)
@@ -766,6 +767,8 @@ bool cGame::setupGame()
     cPlayer *humanPlayer = m_gameObjectsContext->getPlayer(HUMAN);
 
     m_drawManager = new cDrawManager(ctx.get(), humanPlayer, m_services.get());
+    m_services->drawManager = m_drawManager;
+    m_services->mapViewport = m_mapViewport;
 
     setupPlayers();
 

--- a/src/gameobjects/players/cPlayers.cpp
+++ b/src/gameobjects/players/cPlayers.cpp
@@ -127,6 +127,7 @@ void cPlayers::setupRuntimePlayerComponents(cSideBarFactory* sideBarFactory, cMo
         player->setOrderProcesser(std::move(orderProcesser));
 
         auto gameControlsContext = std::make_unique<cGameControlsContext>(player, mouse);
+        gameControlsContext->serviceInit(services);
         player->setGameControlsContext(std::move(gameControlsContext));
 
         player->setTechLevel(techLevel);

--- a/src/include/sGameServices.h
+++ b/src/include/sGameServices.h
@@ -8,6 +8,8 @@ class cLog;
 class cMapCamera;
 class cStructureUtils;
 class cEventEmitter;
+class cDrawManager;
+class cRectangle;
 
 struct sGameServices
 {
@@ -19,4 +21,6 @@ struct sGameServices
     cStructureUtils *structureUtils = nullptr;
     cLog *m_log = nullptr;
     cEventEmitter *eventEmitter = nullptr;
+    cDrawManager *drawManager = nullptr;
+    cRectangle *mapViewport = nullptr;
 };


### PR DESCRIPTION
## Summary

- Adds `drawManager` and `mapViewport` to `sGameServices`
- Adds `serviceInit(sGameServices*)` to `cGameControlsContext` with getters for all 8 services
- Adds `setSettings(cGameSettings*)` to `cMouse` to remove last two `game.` references from `cMouse.cpp`
- Replaces all `game.` references across `src/controls/` and `src/controls/mousestates/` with injected service access
- Calls `gameControlsContext->serviceInit(services)` in `cPlayers::setupRuntimePlayerComponents()`
- Guards `renderSprite`/`renderStrechSprite`/`renderStrechFullSprite` against null inner SDL_Texture (pre-existing issue exposed after crash fix in Step 12)

Part of #1254.

## Test plan

- [ ] Build passes with `./rebuildmacos.sh`
- [ ] All 43 tests pass
- [ ] Game runs without crash on mission start (skirmish)
- [ ] Mouse selection, unit commands, structure placement, deploy mode all work
- [ ] No SDL_SetTextureBlendMode errors in the log