### PR TITLE
Double click on unit selects all same type on screen

### DIFF
--- a/src/controls/cMouse.cpp
+++ b/src/controls/cMouse.cpp
@@ -28,6 +28,7 @@ cMouse::cMouse(GameContext *ctx) :
     m_rightButtonReleased=false;
     m_mouseScrolledUp=false;
     m_mouseScrolledDown=false;
+    m_leftButtonDoubleClicked = false;
     m_leftButtonClickedInPreviousFrame = false;
     m_rightButtonClickedInPreviousFrame = false;
     m_mouseObserver = nullptr; // set later
@@ -63,7 +64,7 @@ void cMouse::handleEvent(const SDL_Event &event)
             float px, py;
             SDL_RenderCoordinatesFromWindow(renderer, event.button.x, event.button.y, &px, &py);
             if (event.button.button == SDL_BUTTON_LEFT) {
-                m_leftButtonPressed = true;
+                m_leftButtonPressed = (event.button.clicks == 1);
                 m_coordsOnClick.x = (int)px;
                 m_coordsOnClick.y = (int)py;
             }
@@ -83,7 +84,11 @@ void cMouse::handleEvent(const SDL_Event &event)
                 int dx = m_coordsOnClick.x - (int)px;
                 int dy = m_coordsOnClick.y - (int)py;
                 if (dx*dx + dy*dy < 16) {
-                    m_leftButtonClicked = true;
+                    if (event.button.clicks == 2) {
+                        m_leftButtonDoubleClicked = true;
+                    } else {
+                        m_leftButtonClicked = true;
+                    }
                 }
             }
             if (event.button.button == SDL_BUTTON_RIGHT) {
@@ -144,7 +149,10 @@ void cMouse::updateState()
             // std::cout << "emit left pressed" << std::endl;
         }
 
-        if (m_leftButtonReleased) {
+        if (m_leftButtonDoubleClicked) {
+            event.eventType = eMouseEventType::MOUSE_LEFT_BUTTON_DOUBLE_CLICKED;
+            m_mouseObserver->onNotifyMouseEvent(event);
+        } else if (m_leftButtonReleased) {
             event.eventType = eMouseEventType::MOUSE_LEFT_BUTTON_CLICKED;
             m_mouseObserver->onNotifyMouseEvent(event);
             // std::cout << "emit left released" << std::endl;
@@ -173,6 +181,7 @@ void cMouse::updateState()
     }
     m_didMouseMove = false;
     m_leftButtonReleased = false;
+    m_leftButtonDoubleClicked = false;
     m_rightButtonReleased = false;
     m_mouseScrolledDown = false;
     m_mouseScrolledUp = false;

--- a/src/controls/cMouse.h
+++ b/src/controls/cMouse.h
@@ -107,6 +107,7 @@ private:
 
     bool m_leftButtonClicked;
     bool m_rightButtonClicked;
+    bool m_leftButtonDoubleClicked;
 
     bool m_leftButtonClickedInPreviousFrame;
     bool m_rightButtonClickedInPreviousFrame;

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -76,6 +76,9 @@ void cMouseUnitsSelectedState::onNotifyMouseEvent(const s_MouseEvent &event)
         case MOUSE_LEFT_BUTTON_CLICKED:
             onMouseLeftButtonClicked();
             break;
+        case MOUSE_LEFT_BUTTON_DOUBLE_CLICKED:
+            onMouseLeftButtonDoubleClicked();
+            break;
         case MOUSE_RIGHT_BUTTON_PRESSED:
             onMouseRightButtonPressed();
             break;
@@ -622,6 +625,20 @@ void cMouseUnitsSelectedState::onBlur()
 {
     m_mouse->resetBoxSelect();
     m_mouse->resetDragViewportInteraction();
+}
+
+void cMouseUnitsSelectedState::onMouseLeftButtonDoubleClicked()
+{
+    int hoverUnitId = m_context->getIdOfUnitWhereMouseHovers();
+    if (hoverUnitId > -1) {
+        cUnit *pUnit = m_context->getObjects()->getUnit(hoverUnitId);
+        if (pUnit->getPlayer() == m_player) {
+            selectSameUnitsOnScreen(pUnit->iType);
+        }
+    } else if (m_selectedUnits.size() == 1) {
+        cUnit *pUnit = m_context->getObjects()->getUnit(m_selectedUnits[0]);
+        selectSameUnitsOnScreen(pUnit->iType);
+    }
 }
 
 void cMouseUnitsSelectedState::selectSameUnitsOnScreen(int unitType)

--- a/src/controls/mousestates/cMouseUnitsSelectedState.h
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.h
@@ -66,6 +66,8 @@ private:
 
     void onMouseLeftButtonClicked();
 
+    void onMouseLeftButtonDoubleClicked();
+
     void onMouseRightButtonPressed();
 
     void onMouseRightButtonClicked();

--- a/src/controls/sMouseEvent.h
+++ b/src/controls/sMouseEvent.h
@@ -9,14 +9,15 @@
 
 
 enum eMouseEventType {
-    MOUSE_NONE,                 
-    MOUSE_MOVED_TO,             // Mouse moved to a position on screen
-    MOUSE_RIGHT_BUTTON_CLICKED, // When mouse button has been pressed down, and released; it becomes a "click"
-    MOUSE_LEFT_BUTTON_CLICKED,  // When mouse button has been pressed down, and released; it becomes a "click"
-    MOUSE_RIGHT_BUTTON_PRESSED, // If a mouse button has been pressed (held down)
-    MOUSE_LEFT_BUTTON_PRESSED,  // If a mouse button has been pressed (held down)
-    MOUSE_SCROLLED_UP,          // Mouse scroll wheel moved up
-    MOUSE_SCROLLED_DOWN         // Mouse scroll wheel moved down
+    MOUSE_NONE,
+    MOUSE_MOVED_TO,                     // Mouse moved to a position on screen
+    MOUSE_RIGHT_BUTTON_CLICKED,         // When mouse button has been pressed down, and released; it becomes a "click"
+    MOUSE_LEFT_BUTTON_CLICKED,          // When mouse button has been pressed down, and released; it becomes a "click"
+    MOUSE_LEFT_BUTTON_DOUBLE_CLICKED,   // When mouse left button is clicked twice in quick succession
+    MOUSE_RIGHT_BUTTON_PRESSED,         // If a mouse button has been pressed (held down)
+    MOUSE_LEFT_BUTTON_PRESSED,          // If a mouse button has been pressed (held down)
+    MOUSE_SCROLLED_UP,                  // Mouse scroll wheel moved up
+    MOUSE_SCROLLED_DOWN                 // Mouse scroll wheel moved down
 };
 
 // Rename to GUI_EVENT? Might be more appropriate
@@ -46,6 +47,8 @@ struct s_MouseEvent {
                 return "MOUSE_SCROLLED_UP";
             case eMouseEventType::MOUSE_LEFT_BUTTON_CLICKED:
                 return "MOUSE_LEFT_BUTTON_CLICKED";
+            case eMouseEventType::MOUSE_LEFT_BUTTON_DOUBLE_CLICKED:
+                return "MOUSE_LEFT_BUTTON_DOUBLE_CLICKED";
             case eMouseEventType::MOUSE_LEFT_BUTTON_PRESSED:
                 return "MOUSE_LEFT_BUTTON_PRESSED";
             case eMouseEventType::MOUSE_NONE:


### PR DESCRIPTION
## Summary

- Adds `MOUSE_LEFT_BUTTON_DOUBLE_CLICKED` event type to the mouse event system
- `cMouse` detects SDL's double-click (`event.button.clicks == 2`) and emits the new event instead of a regular single-click for that second press, keeping game logic free of SDL checks
- `cMouseUnitsSelectedState` handles the event by selecting all units of the same type on screen (matching the existing CTRL-Z behavior), using the hovered unit's type or falling back to the single selected unit

## Test plan

- [ ] Double click a unit on the battlefield — all units of the same type visible on screen should be selected
- [ ] Single click a unit — normal selection still works (no regression)
- [ ] Box select multiple units — no unintended double-click triggers
- [ ] Double click on empty ground — no crash, no selection change

Closes #1242