### PR TITLE
Shift build multiplier resets when Shift key is released

### DIFF
--- a/src/building/cItemBuilder.cpp
+++ b/src/building/cItemBuilder.cpp
@@ -835,7 +835,7 @@ void cItemBuilder::onKeyHold(const cKeyboardEvent &event)
 
 void cItemBuilder::onKeyPressed(const cKeyboardEvent &event)
 {
-    if (event.isShiftPressed()) {
+    if (event.hasEitherKey(SDL_SCANCODE_LSHIFT, SDL_SCANCODE_RSHIFT)) {
         m_buildItemMultiplierEnabled = false;
     }
 }


### PR DESCRIPTION
## Summary
- `isShiftPressed()` reads from the combo struct, which is already cleared by the time a key-release event fires
- Replaced with `hasEitherKey(SDL_SCANCODE_LSHIFT, SDL_SCANCODE_RSHIFT)` which reads the raw released-key bitset, correctly detecting Shift on release

## Test plan
- Hold Shift and click a build item — quantity should multiply by 4
- Release Shift — multiplier should stop; subsequent clicks should add 1 at a time

Fixes #1282