### PR TITLE
Double-click on sidebar adds item to build queue

### DIFF
--- a/src/sidebar/cSideBar.cpp
+++ b/src/sidebar/cSideBar.cpp
@@ -322,6 +322,7 @@ void cSideBar::onNotifyMouseEvent(const s_MouseEvent &event)
             onMouseAt(event);
             return;
         case eMouseEventType::MOUSE_LEFT_BUTTON_CLICKED:
+        case eMouseEventType::MOUSE_LEFT_BUTTON_DOUBLE_CLICKED:
             onMouseClickedLeft(event);
             return;
         case eMouseEventType::MOUSE_RIGHT_BUTTON_CLICKED:


### PR DESCRIPTION
## Summary
- `MOUSE_LEFT_BUTTON_DOUBLE_CLICKED` was not handled in `cSideBar::onNotifyMouseEvent`
- Added it as a fall-through case to `MOUSE_LEFT_BUTTON_CLICKED`, routing both to `onMouseClickedLeft`

## Test plan
- Open a skirmish or campaign game
- Double-click a buildable item in the sidebar — it should add to the build queue (same as single click)
- Single click still works as before

Fixes #1306