### PR TITLE
Fremen unit stats load correctly from game.ini

### DIFF
--- a/src/utils/cIniUTils.cpp
+++ b/src/utils/cIniUTils.cpp
@@ -126,7 +126,7 @@ const std::unordered_map<std::string, int> cIniUtils::unitNameMap = {
     {"Ornithopter", ORNITHOPTER},
     {"Sandworm", SANDWORM},
     {"Saboteur", SABOTEUR},
-    {"ONEFREMEN", UNIT_FREMEN_ONE},
+    {"FREMEN", UNIT_FREMEN_ONE},
     {"THREEFREMEN", UNIT_FREMEN_THREE}
 };
 


### PR DESCRIPTION
## Summary
- `unitNameMap` had `"ONEFREMEN"` as the key for `UNIT_FREMEN_ONE`, but `game.ini` uses `[UNIT: FREMEN]`
- The INI parser extracts `"FREMEN"` from that section header, which never matched `"ONEFREMEN"`, so the unit's stats (HP, damage, build time, etc.) were never loaded
- Fixed by renaming the map key to `"FREMEN"` to match the INI section name

## Test plan
- Start an Atreides campaign mission that spawns Fremen from the Palace
- Verify Fremen units have correct stats (HP, attack damage) instead of defaults

Fixes #1310