### PR TITLE
Saboteur can enter and destroy enemy buildings

### DIFF
--- a/src/context/cInfoContextCreator.cpp
+++ b/src/context/cInfoContextCreator.cpp
@@ -589,6 +589,7 @@ void cInfoContextCreator::initUnits(cUnitInfos& unitInfos)
     unitInfos[SABOTEUR].infantry = true; // infantry unit, so it can be squished
     unitInfos[SABOTEUR].listType = eListType::LIST_PALACE;
     unitInfos[SABOTEUR].subListId = 0;
+    unitInfos[SABOTEUR].canAttackUnits = true;
     unitInfos[SABOTEUR].canEnterAndDamageStructure = true;
     unitInfos[SABOTEUR].attackIsEnterStructure = true;
     unitInfos[SABOTEUR].damageOnEnterStructure = 9999.99f; // a lot of damage (instant destroy)

--- a/src/context/cInfoContextCreator.cpp
+++ b/src/context/cInfoContextCreator.cpp
@@ -589,7 +589,6 @@ void cInfoContextCreator::initUnits(cUnitInfos& unitInfos)
     unitInfos[SABOTEUR].infantry = true; // infantry unit, so it can be squished
     unitInfos[SABOTEUR].listType = eListType::LIST_PALACE;
     unitInfos[SABOTEUR].subListId = 0;
-    unitInfos[SABOTEUR].canAttackUnits = true;
     unitInfos[SABOTEUR].canEnterAndDamageStructure = true;
     unitInfos[SABOTEUR].attackIsEnterStructure = true;
     unitInfos[SABOTEUR].damageOnEnterStructure = 9999.99f; // a lot of damage (instant destroy)

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -979,7 +979,7 @@ void cUnit::attack(int goalCell, int unitId, int structureId, int attackCell, bo
 
 void cUnit::attackAt(int cell)
 {
-    if (!isAttackingUnit()) {
+    if (!isAttackingUnit() && !isSaboteur()) {
         return;
     }
 

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -3059,7 +3059,7 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
                 if (potentialDeadUnit->position.iCell != position.iCell) continue; // not on my cell
                 if (!potentialDeadUnit->canBeSquished()) continue;
 
-                if (potentialDeadUnit->canAttackOnEnterStructure()) {
+                if (potentialDeadUnit->isSaboteur()) {
                     takeDamage(potentialDeadUnit->getUnitInfo().damageOnEnterStructure);
                 }
 

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -2612,17 +2612,22 @@ void cUnit::thinkFast_move()
                             movement.iPathFails = 0;
                         }
                         else {
-                            log("Something else blocks path, but goal itself is not occupied.");
-                            setGoalCell(position.iCell);
-                            movement.iPathIndex = -1;
-                            movement.iPathFails = 0;
-                            iStructureID = -1;
+                            if (sID > -1 && iStructureID > -1 && sID == iStructureID) {
+                                log("Path failed toward target structure; will retry.");
+                            }
+                            else {
+                                log("Something else blocks path, but goal itself is not occupied.");
+                                setGoalCell(position.iCell);
+                                movement.iPathIndex = -1;
+                                movement.iPathFails = 0;
+                                iStructureID = -1;
 
-                            // random move around
-                            int iF = cUnit::freeAroundMove(iID, m_objects);
+                                // random move around
+                                int iF = cUnit::freeAroundMove(iID, m_objects);
 
-                            if (iF > -1) {
-                                move_to(iF);
+                                if (iF > -1) {
+                                    move_to(iF);
+                                }
                             }
                         }
                     }

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -3063,8 +3063,7 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
                     takeDamage(potentialDeadUnit->getUnitInfo().damageOnEnterStructure);
                 }
 
-                // die
-                potentialDeadUnit->die(false, true);
+                potentialDeadUnit->takeDamage(potentialDeadUnit->getHitPoints() + 1);
             }
         }
 

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -963,8 +963,7 @@ void cUnit::attack(int goalCell, int unitId, int structureId, int attackCell, bo
     }
 
     // TODO: We have somewhere else something with "intents", so this whole if statement should be removed / replaced?
-    if (isSaboteur()) {
-        // saboteur does not attack, but only captures
+    if (getUnitInfo().attackIsEnterStructure) {
         move_to(goalCell, structureId, -1, eUnitActionIntent::INTENT_CAPTURE);
         return;
     }
@@ -979,7 +978,7 @@ void cUnit::attack(int goalCell, int unitId, int structureId, int attackCell, bo
 
 void cUnit::attackAt(int cell)
 {
-    if (!isAttackingUnit() && !isSaboteur()) {
+    if (!isAttackingUnit() && !getUnitInfo().attackIsEnterStructure) {
         return;
     }
 
@@ -2064,8 +2063,7 @@ void cUnit::think_hit(int iShotUnit, int iShotStructure)
         return;
     }
 
-    if (isSaboteur()) {
-        // ignore being shot?
+    if (getUnitInfo().attackIsEnterStructure) {
         return;
     }
 
@@ -2870,8 +2868,7 @@ void cUnit::thinkFast_move()
                         }
                     }
                     else if (intent == eUnitActionIntent::INTENT_CAPTURE || intent == eUnitActionIntent::INTENT_MOVE) {
-                        if (isSaboteur()) {
-                            // the unit will die and inflict damage
+                        if (getUnitInfo().attackIsEnterStructure) {
                             pStructure->damage(getUnitInfo().damageOnEnterStructure, -1); // no need to pass ID of unit, as it is dead
                             die(true, false);
                         }
@@ -3062,8 +3059,7 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
                 if (potentialDeadUnit->position.iCell != position.iCell) continue; // not on my cell
                 if (!potentialDeadUnit->canBeSquished()) continue;
 
-                if (potentialDeadUnit->isSaboteur()) {
-                    // this unit takes damage, catches the explosion so to speak
+                if (potentialDeadUnit->getUnitInfo().attackIsEnterStructure) {
                     takeDamage(potentialDeadUnit->getUnitInfo().damageOnEnterStructure);
                 }
 
@@ -3210,11 +3206,6 @@ cPlayer *cUnit::getPlayer()
     return m_objects->getPlayer(iPlayer);
 }
 
-bool cUnit::isSaboteur()
-{
-    return iType == SABOTEUR;
-}
-
 void cUnit::move_to(int iGoalCell)
 {
     eUnitActionIntent intent = eUnitActionIntent::INTENT_MOVE;
@@ -3250,7 +3241,7 @@ void cUnit::move_to(int iGoalCell)
             }
             else {
                 // if capturable... (TODO)
-                if (isInfantryUnit() || isSaboteur()) {
+                if (isInfantryUnit() || getUnitInfo().attackIsEnterStructure) {
                     intent = eUnitActionIntent::INTENT_CAPTURE;
                 }
                 else {

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -963,7 +963,7 @@ void cUnit::attack(int goalCell, int unitId, int structureId, int attackCell, bo
     }
 
     // TODO: We have somewhere else something with "intents", so this whole if statement should be removed / replaced?
-    if (getUnitInfo().attackIsEnterStructure) {
+    if (canAttackOnEnterStructure()) {
         move_to(goalCell, structureId, -1, eUnitActionIntent::INTENT_CAPTURE);
         return;
     }
@@ -978,7 +978,7 @@ void cUnit::attack(int goalCell, int unitId, int structureId, int attackCell, bo
 
 void cUnit::attackAt(int cell)
 {
-    if (!isAttackingUnit() && !getUnitInfo().attackIsEnterStructure) {
+    if (!isAttackingUnit() && !canAttackOnEnterStructure()) {
         return;
     }
 
@@ -2063,7 +2063,7 @@ void cUnit::think_hit(int iShotUnit, int iShotStructure)
         return;
     }
 
-    if (getUnitInfo().attackIsEnterStructure) {
+    if (isSaboteur()) {
         return;
     }
 
@@ -2868,7 +2868,7 @@ void cUnit::thinkFast_move()
                         }
                     }
                     else if (intent == eUnitActionIntent::INTENT_CAPTURE || intent == eUnitActionIntent::INTENT_MOVE) {
-                        if (getUnitInfo().attackIsEnterStructure) {
+                        if (canAttackOnEnterStructure()) {
                             pStructure->damage(getUnitInfo().damageOnEnterStructure, -1); // no need to pass ID of unit, as it is dead
                             die(true, false);
                         }
@@ -3059,7 +3059,7 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
                 if (potentialDeadUnit->position.iCell != position.iCell) continue; // not on my cell
                 if (!potentialDeadUnit->canBeSquished()) continue;
 
-                if (potentialDeadUnit->getUnitInfo().attackIsEnterStructure) {
+                if (potentialDeadUnit->canAttackOnEnterStructure()) {
                     takeDamage(potentialDeadUnit->getUnitInfo().damageOnEnterStructure);
                 }
 
@@ -3206,6 +3206,16 @@ cPlayer *cUnit::getPlayer()
     return m_objects->getPlayer(iPlayer);
 }
 
+bool cUnit::isSaboteur()
+{
+    return iType == SABOTEUR;
+}
+
+bool cUnit::canAttackOnEnterStructure()
+{
+    return getUnitInfo().attackIsEnterStructure;
+}
+
 void cUnit::move_to(int iGoalCell)
 {
     eUnitActionIntent intent = eUnitActionIntent::INTENT_MOVE;
@@ -3241,7 +3251,7 @@ void cUnit::move_to(int iGoalCell)
             }
             else {
                 // if capturable... (TODO)
-                if (isInfantryUnit() || getUnitInfo().attackIsEnterStructure) {
+                if (isInfantryUnit() || canAttackOnEnterStructure()) {
                     intent = eUnitActionIntent::INTENT_CAPTURE;
                 }
                 else {

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -3063,7 +3063,7 @@ eUnitMoveToCellResult cUnit::moveToNextCellLogic()
                     takeDamage(potentialDeadUnit->getUnitInfo().damageOnEnterStructure);
                 }
 
-                potentialDeadUnit->takeDamage(potentialDeadUnit->getHitPoints() + 1);
+                potentialDeadUnit->die(false, true);
             }
         }
 

--- a/src/gameobjects/units/cUnit.h
+++ b/src/gameobjects/units/cUnit.h
@@ -512,6 +512,9 @@ private:
 
     int unitsEaten; // worm related
 
+    bool isSaboteur();
+    bool canAttackOnEnterStructure();
+
     void forgetAboutCurrentPathAndPrepareToCreateNewOne(int timeToWait = 35);
 
     void takeDamage(int damage);

--- a/src/gameobjects/units/cUnit.h
+++ b/src/gameobjects/units/cUnit.h
@@ -512,8 +512,6 @@ private:
 
     int unitsEaten; // worm related
 
-    bool isSaboteur();
-
     void forgetAboutCurrentPathAndPrepareToCreateNewOne(int timeToWait = 35);
 
     void takeDamage(int damage);

--- a/src/gameobjects/units/cUnitInfos.h
+++ b/src/gameobjects/units/cUnitInfos.h
@@ -74,7 +74,7 @@ struct s_UnitInfo {
     bool canAttackAirUnits;   // ie for rocket typed units
     bool canAttackUnits;   // a unit used for attacking other units? (ie, mvc or harvester is no)
     bool canEnterAndDamageStructure;  // can this unit enter a structure and damage it? (and eventually capture?)
-    bool attackIsEnterStructure;      // for saboteur only really
+    bool attackIsEnterStructure;      // unit attacks by entering a structure (eg saboteur)
     float damageOnEnterStructure;     // the damage inflicted to a structure when entered
 
     bool renderSmokeOnUnitWhenThresholdMet; // if yes, spawn smoke particle (and attach to unit) when hp factor met


### PR DESCRIPTION
## Summary

- Saboteur can now be ordered onto enemy structures and destroy them on entry
- `attackAt()` guard that blocked Saboteur (`if (!isAttackingUnit())`) is widened to also allow units where `getUnitInfo().attackIsEnterStructure` is true
- The path-fail else-branch no longer clears `iStructureID` when the goal cell holds the target structure — preserving the enter intent through path retries
- All checks that previously used `isSaboteur()` (a unit-type test) now read `getUnitInfo().attackIsEnterStructure` so any future unit type with that flag follows the same path
- `canAttackUnits` remains `false` so the AI does not treat the Saboteur as a combat unit or include it in attack groups

The flag is not yet configurable via `game.ini` — see follow-up issue for that work.

## Test plan

- [ ] Select a Saboteur unit, hover over an enemy structure — cursor should change to the attack cursor
- [ ] Left-click the enemy structure — Saboteur should move to it and destroy it on entry
- [ ] Confirm the AI does not send Saboteurs as part of normal attack waves
- [ ] Confirm Saboteur cannot be ordered to attack enemy units directly