### PR TITLE
AI no longer over-builds carry-alls in skirmish

### DIFF
--- a/src/gameobjects/players/brains/cPlayerBrainSkirmish.cpp
+++ b/src/gameobjects/players/brains/cPlayerBrainSkirmish.cpp
@@ -587,10 +587,8 @@ void cPlayerBrainSkirmish::produceEconomyImprovingMissions()
         }
     }
 
-    // TODO: make this even smarter (ie don't build when also building harvester, etc)
     if (player->hasAtleastOneStructure(HIGHTECH)) {
-        int idealAmountOfCarryAlls = (amountOfHarvesters/2)+1;
-        if (player->getAmountOfUnitsForType(CARRYALL) < idealAmountOfCarryAlls) {
+        if (player->getAmountOfUnitsForType(CARRYALL) < m_idealCarryallCount) {
             if (!hasMission(MISSION_IMPROVE_ECONOMY_BUILD_ADDITIONAL_CARRYALL)) {
                 std::vector<s_groupKind> group = std::vector<s_groupKind>();
                 group.push_back(s_groupKind{


### PR DESCRIPTION
## Summary

- Two independent carry-all build paths existed in `cPlayerBrainSkirmish`: a direct-queue path (capped at `m_idealCarryallCount`) and a mission-creation path (capped at `(harvesters/2)+1`)
- These paths ran independently and could both be active simultaneously, queuing carry-alls beyond the intended cap
- Unified both paths to use `m_idealCarryallCount` as the target

Closes #1307