### PR TITLE
Music error logged once and stops retrying on missing audio sample

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -391,6 +391,7 @@ void cGame::thinkFast_audio()
     }
 
     if (m_newMusicCountdown < 0) {
+        if (!m_soundPlayer->getMusicEnabled()) return;
         if (!m_soundPlayer->isMusicPlaying()) {
             int desiredMusicType = m_gameSettings->m_musicType;
             if (m_gameSettings->m_musicType == MUSIC_ATTACK) {

--- a/src/utils/cSoundPlayer.cpp
+++ b/src/utils/cSoundPlayer.cpp
@@ -128,6 +128,9 @@ void cSoundPlayer::playMusic(int sampleId)
     }
     MIX_Audio *audio = soundData->getAudio(sampleId);
     if (!audio) {
+        cLogger::getInstance()->log(LOG_ERROR, COMP_SOUND, "playMusic",
+            std::format("Audio sample [{}] not found, disabling music.", sampleId));
+        m_isMusicEnabled = false;
         return;
     }
     MIX_StopTrack(m_musicTrack, 0);


### PR DESCRIPTION
## Summary

- When an audio sample ID could not be loaded, `playMusic()` silently returned without playing anything
- `isMusicPlaying()` then returned false, causing `thinkFast_audio()` to call `playMusicByType()` (and its log statement) again every ~5ms indefinitely
- `playMusic()` now logs once and sets `m_isMusicEnabled = false` when the audio sample is missing
- `thinkFast_audio()` now exits early when `getMusicEnabled()` is false, preventing the retry loop

Closes #1299