### PR TITLE
Briefing music no longer crashes when house is not yet selected

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1499,9 +1499,16 @@ bool cGame::playMusicByType(int iType, int playerId, bool triggerWithVoice)
         else if (houseIndex == ORDOS) {
             sampleId = MIDI_MENTAT_ORD;
         }
-        else {
-            logbook(std::format("playMusicByType: MUSIC_BRIEFING requested for unrecognized house {}, falling back to menu music", houseIndex));
+        else if (houseIndex == SARDAUKAR) {
+            // No dedicated Sardaukar mentat track yet; use menu music as placeholder
             sampleId = MIDI_MENU;
+        }
+        else if (houseIndex == GENERALHOUSE) {
+            // BeneMentat has no dedicated track; house selection is still in progress
+            sampleId = MIDI_MENU;
+        }
+        else {
+            d2tm_assert(false && "Undefined house for MUSIC_BRIEFING.");
         }
     }
     else {

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1500,7 +1500,8 @@ bool cGame::playMusicByType(int iType, int playerId, bool triggerWithVoice)
             sampleId = MIDI_MENTAT_ORD;
         }
         else {
-            d2tm_assert(false && "Undefined house.");
+            logbook(std::format("playMusicByType: MUSIC_BRIEFING requested for unrecognized house {}, falling back to menu music", houseIndex));
+            sampleId = MIDI_MENU;
         }
     }
     else {


### PR DESCRIPTION
## Root cause

`BeneMentat::onYesButtonPressed()` sets the human player's house to `GENERALHOUSE` and immediately queues a `GAME_BRIEFING` state transition. When that state starts, `playMusicByType(MUSIC_BRIEFING)` reads `humanPlayer->getHouse()` — which is still `GENERALHOUSE` — and hit a `d2tm_assert` because no mentat track was defined for it.

The same crash can occur with `SARDAUKAR` once that house is fully integrated, since it also has no dedicated mentat track yet.

## Changes

- `GENERALHOUSE` now falls back to `MIDI_MENU` (house selection is still in progress at that point)
- `SARDAUKAR` now falls back to `MIDI_MENU` with a note that a dedicated track can be added later
- Any other undefined house retains the `d2tm_assert` so new houses don't silently play wrong music

## Test plan

- [ ] Click Yes on the BeneMentat screen — game should transition to briefing without crash
- [ ] Click No on the BeneMentat screen — game should return to house selection without crash
- [ ] Start a campaign as Atreides, Harkonnen, and Ordos — confirm correct mentat tracks play