### PR TITLE
Terrain tile rendering no longer produces lines on transition tiles

### DIFF
--- a/src/drawers/cMapDrawer.cpp
+++ b/src/drawers/cMapDrawer.cpp
@@ -46,8 +46,8 @@ void cMapDrawer::drawShroud()
     float tileWidth = m_camera->getZoomedTileWidth();
     float tileHeight = m_camera->getZoomedTileHeight();
 
-    int iTileHeight = (tileHeight + 1);
-    int iTileWidth = (tileWidth + 1);
+    int iTileHeight = (int)round(tileHeight);
+    int iTileWidth = (int)round(tileWidth);
     int iPl = m_player->getId();
 
     for (int viewportX = m_camera->getViewportStartX(); viewportX < m_camera->getViewportEndX() + 32; viewportX += 32) {
@@ -101,8 +101,8 @@ void cMapDrawer::drawTerrain()
     float tileWidth = m_camera->getZoomedTileWidth();
     float tileHeight = m_camera->getZoomedTileHeight();
 
-    int iTileHeight = (tileHeight + 1);
-    int iTileWidth = (tileWidth + 1);
+    int iTileHeight = (int)round(tileHeight);
+    int iTileWidth = (int)round(tileWidth);
 
     int iPl = m_player->getId();
     int mouseCell = m_player->getGameControlsContext()->getMouseCell();


### PR DESCRIPTION
## Summary

- Tile dest rect was `(int)(tileWidth + 1)` causing each tile to render 1px wider and taller than its 32px spacing
- On transition tiles (rock-to-sand, mountain-to-rock edges), this 1px overdraw shows the tile's edge colour overlapping the neighbouring tile, appearing as a visible line
- Changed to `(int)round(tileWidth)` so tiles at default zoom (1.0x, 32px) render exactly 32×32 with no overlap

Closes #1311