### PR TITLE
fix: respect tech level when generating skirmish starting units

### DIFF
--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -613,6 +613,43 @@ void cSetupSkirmishState::drawTechLevel(const cRectangle &techLevelRect) const
                         std::format("TechLevel : {}", techLevel));
 }
 
+std::vector<int> cSetupSkirmishState::getEligibleStartingUnitTypes(int forTechLevel) const
+{
+    // Minimum tech level required for each starting-unit type, matching the
+    // structure prerequisites (cBuildingListUpdater) and unit upgrade tech
+    // levels (cInfoContextCreator) that gate building these units in skirmish
+    // mode. The random starting-unit draw uses unit types 0..11; keep in sync.
+    static const struct { int unitType; int minTechLevel; } eligibility[] = {
+        { SOLDIER,    2 },  // base infantry: BARRACKS (techLevel >= 2)
+        { TROOPER,    2 },  // base infantry: WOR (techLevel >= 2)
+        { INFANTRY,   3 },  // UPGRADE_TYPE_BARRACKS_INFANTRY (techLevel 3)
+        { TROOPERS,   3 },  // UPGRADE_TYPE_WOR_TROOPERS (techLevel 3)
+        { TRIKE,      3 },  // LIGHTFACTORY (techLevel >= 3)
+        { RAIDER,     3 },  // LIGHTFACTORY (techLevel >= 3)
+        { QUAD,       3 },  // UPGRADE_TYPE_LIGHTFCTRY_QUAD (techLevel 3)
+        { TANK,       4 },  // HEAVYFACTORY (techLevel >= 4)
+        { LAUNCHER,   5 },  // UPGRADE_TYPE_HEAVYFCTRY_LAUNCHER (techLevel 5)
+        { SIEGETANK,  6 },  // UPGRADE_TYPE_HEAVYFCTRY_SIEGETANK (techLevel 6)
+        { DEVASTATOR, 7 },  // special heavy units (techLevel >= 7)
+        { DEVIATOR,   7 },  // special heavy units (techLevel >= 7)
+    };
+
+    std::vector<int> eligible;
+    for (const auto &entry : eligibility) {
+        if (forTechLevel >= entry.minTechLevel) {
+            eligible.push_back(entry.unitType);
+        }
+    }
+
+    // Always guarantee at least one selectable type so the spawn loop can
+    // terminate even at the lowest tech level.
+    if (eligible.empty()) {
+        eligible.push_back(SOLDIER);
+    }
+
+    return eligible;
+}
+
 void cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState(int iSkirmishMap)
 {
     s_PreviewMap *selectedMap = m_previewMaps->getMap(iSkirmishMap);
@@ -805,9 +842,14 @@ void cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState(in
     }
 
     // create units
+    // restrict the random starting-unit pool to the selected tech level, so we
+    // never spawn units the player could not have built at that tech level
+    // (e.g. Devastators at tech level 3). See issue #1281.
+    std::vector<int> eligibleUnitTypes = getEligibleStartingUnitTypes(techLevel);
+
     while (u < maxAmountOfStartingUnits) {
-        // pick a random unit type
-        int iType = RNG::rnd(12);
+        // pick a random unit type from the tech-level-eligible pool
+        int iType = eligibleUnitTypes[RNG::rnd(eligibleUnitTypes.size())];
 
         for (int p = 0; p < MAX_PLAYERS; p++) {
             cPlayer* pPlayer = m_objects->getPlayer(p);

--- a/src/gamestates/cSetupSkirmishState.h
+++ b/src/gamestates/cSetupSkirmishState.h
@@ -9,6 +9,7 @@ struct sGameServices;
 #include "utils/Color.hpp"
 #include <memory>
 #include <functional>
+#include <vector>
 
 struct SDL_Surface;
 
@@ -128,6 +129,10 @@ private:
 
     // Functions
     void prepareSkirmishGameToPlayAndTransitionToCombatState(int iSkirmishMap);
+
+    // Returns the starting-unit types that are allowed at the given tech level.
+    std::vector<int> getEligibleStartingUnitTypes(int forTechLevel) const;
+
     void surpriseMe();
 
     void onMouseLeftButtonClicked(const s_MouseEvent &event);


### PR DESCRIPTION
Fixes #1281

## **Goal**

Make skirmish starting units respect the selected tech level. Previously, starting a skirmish at a low tech level (e.g. level 3) could still spawn high-tech units the player could never build at that level - the reporter saw 6 Devastators at tech level 3.

The cause (per #1281): `cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState` generated each starting unit with `RNG::rnd(12)`, which picks any of unit types 0..11 (SOLDIER through DEVIATOR) regardless of the chosen tech level. The selection never consulted the tech level shown on the skirmish settings screen, so units far above the configured tier could be spawned at game start.

### Changes

The starting-unit generator now filters its random draw to the units the player could actually build at the chosen tech level, so an out-of-tier unit can no longer appear at game start.

- Added `cSetupSkirmishState::getEligibleStartingUnitTypes(int forTechLevel)`, which builds the pool of starting-unit types allowed at a given tech level. The per-unit minimum tech levels mirror the existing structure prerequisites (`cBuildingListUpdater`) and unit upgrade tech levels (`cInfoContextCreator`): base infantry at 2; INFANTRY/TROOPERS/TRIKE/RAIDER/QUAD at 3; TANK at 4; LAUNCHER at 5; SIEGETANK at 6; DEVASTATOR/DEVIATOR at 7.
- The starting-unit loop now draws from this eligible pool (`eligibleUnitTypes[RNG::rnd(eligibleUnitTypes.size())]`) instead of `RNG::rnd(12)`.
- The pool is guaranteed non-empty (falls back to SOLDIER) so the spawn loop always terminates, even at the lowest tech level.
- `maxAmountOfStartingUnits` behavior is unchanged.

## Testing Steps

- Verified the eligibility logic in isolation (compiled with `clang++ -std=c++23 -Wall -Wextra`) against the issue's scenarios:
  - Tech level 3: no Tanks/Launchers/Siege/Devastators/Deviators are eligible (the reported Devastators-at-tech-3 case can no longer occur); infantry, trikes, raiders, and quads remain available.
  - Tech level 4 adds Tanks; 5 adds Launchers; 6 adds Siege Tanks; 7 (and the max of 9) yields the full unit range, so there is no variety regression at high tech.
  - Tech level 1 yields a single eligible type (SOLDIER), so the spawn loop still terminates and cannot loop or crash.
- A full SDL3 build was not run locally (SDL3 dependencies are not installed in this environment); the change is syntactically validated and confined to the two skirmish-setup files.

To reproduce manually: start a skirmish at tech level 3 and confirm only low-tech units spawn (never Devastators/Tanks); then start at the maximum tech level and confirm the full unit range can still appear.

## Screenshots (optional)

N/A - gameplay behavior change; see the Testing Steps above for the reproduction.

AI was used for assistance.
