### PR TITLE
Skirmish win/lose mentat shows wrong house when GENERALHOUSE is selected

### DIFF
--- a/src/gamestates/cMentatState.cpp
+++ b/src/gamestates/cMentatState.cpp
@@ -48,7 +48,7 @@ eGameStateType cMentatState::getType()
 void cMentatState::prepareMentat(int house)
 {
     auto* humanPlayer = m_objets->getPlayer(HUMAN);
-    house = (m_house != -1) ? m_house : humanPlayer->getHouse();
+    house = (m_house > GENERALHOUSE) ? m_house : humanPlayer->getHouse();
     bool allowMissionSelect = !m_settings->isSkirmish();
     switch (m_mode) {
         case MentatMode::Briefing:


### PR DESCRIPTION
## Summary

- `prepareMentat()` used `m_house != -1` to decide whether to use the stored house
- `GENERALHOUSE == 0`, so this check was truthy for GENERALHOUSE and returned 0 instead of falling back to the human player's actual house
- Changed to `m_house > GENERALHOUSE` so it correctly falls back to `humanPlayer->getHouse()`

Closes #1285