### PR TITLE
loadScenario null dereference crash on first campaign visit

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1062,6 +1062,7 @@ void cGame::prepareMentatToTellAboutHouse(int house)
 void cGame::loadScenario()
 {
     auto *pState = dynamic_cast<cMentatState *>(m_states[GAME_BRIEFING]);
+    if (!pState) return; // state not yet created; prepareMentat() in the constructor will load the scenario
     pState->loadScenario(m_reinforcements.get());
 }
 


### PR DESCRIPTION
## Summary

- `cGame::loadScenario()` dereferenced `m_states[GAME_BRIEFING]` without a null check
- On the first campaign visit the mentat state is not yet instantiated, causing a null pointer dereference crash
- Added an early return: `prepareMentat()` in the constructor already handles scenario loading for this case

Closes #1246