### PR TITLE
Linux build works when stdc++exp is not available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,12 @@ elseif(UNIX)
             -Wredundant-tags
     )
 
-    target_link_libraries(cpp_stacktrace INTERFACE stdc++exp backtrace)
+    find_library(LIBSTDCXXEXP stdc++exp)
+    if(LIBSTDCXXEXP)
+        target_link_libraries(cpp_stacktrace INTERFACE ${LIBSTDCXXEXP})
+    else()
+        target_compile_definitions(cpp_stacktrace INTERFACE DISABLE_D2TM_STACKTRACE)
+    endif()
 
 else()
     target_compile_options(${PROJECT_NAME}

--- a/src/include/cAssert.h
+++ b/src/include/cAssert.h
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#ifdef __cpp_lib_stacktrace
+#if defined(__cpp_lib_stacktrace) && !defined(DISABLE_D2TM_STACKTRACE)
 #include <stacktrace>
 #endif
 #include <source_location>
@@ -25,7 +25,7 @@ inline void d2tm_assert(
     report << "Function: " << location.function_name() << "\n";
     report << "----------------------------------------\n";
     report << "Call Stack:\n";
-#ifdef __cpp_lib_stacktrace
+#if defined(__cpp_lib_stacktrace) && !defined(DISABLE_D2TM_STACKTRACE)
     auto trace = std::stacktrace::current();
     for (size_t i = 1; i < trace.size(); ++i) {
         const auto& entry = trace[i];


### PR DESCRIPTION
## Summary

- `target_link_libraries(cpp_stacktrace INTERFACE stdc++exp backtrace)` was unconditional on Linux, causing link failure when `stdc++exp` is not installed
- CMake now probes for `stdc++exp`; if found it links it, otherwise sets `DISABLE_D2TM_STACKTRACE`
- Both `#ifdef __cpp_lib_stacktrace` guards in `cAssert.h` updated to also check `!defined(DISABLE_D2TM_STACKTRACE)` so the stacktrace code path is cleanly excluded when unavailable

Closes #1293