### PR TITLE
Placing SLAB1 on a vehicle is blocked instead of silently failing

### DIFF
--- a/src/controls/mousestates/cMousePlaceState.cpp
+++ b/src/controls/mousestates/cMousePlaceState.cpp
@@ -160,7 +160,7 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
             }
 
             // non slab 'structures' can be blocked by units
-            if (structureIdToPlace != SLAB4 && structureIdToPlace != SLAB1) {
+            if (structureIdToPlace != SLAB4) {
                 int unitIdOnMap = m_context->getObjects()->getMap()->getCellIdUnitLayer(iCll);
                 if (unitIdOnMap > -1) {
                     // temporarily dead units do not block, but alive units (non-dead) do block placement


### PR DESCRIPTION
## Summary

- `mayPlaceIt()` excluded `SLAB1` from the unit-blocking check, so it returned `true` when a vehicle occupied the target cell
- The placement sound then played and `placeItem()` was called, but `canPlaceStructureAt()` correctly blocked it and returned `nullptr` — silent failure
- Removing `SLAB1` from the exception means `mayPlaceIt()` returns `false` when a unit is on the cell, so the cursor shows an invalid placement indicator and the click is ignored

Closes #1198