### PR TITLE
SHIFT+select includes harvesters in existing selection

### DIFF
--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -110,7 +110,12 @@ void cMouseUnitsSelectedState::onMouseLeftButtonClicked()
 
         cRectangle boxSelectRectangle = m_mouse->getBoxSelectRectangle();
         const std::vector<int> &ids = m_player->getAllMyUnitsWithinViewportRect(boxSelectRectangle);
-        m_player->selectUnits(ids);
+        if (m_state == SELECTED_STATE_ADD_TO_SELECTION) {
+            m_player->selectAdditionalUnits(ids);
+        }
+        else {
+            m_player->selectUnits(ids);
+        }
     }
     else {
         // single click, no box select
@@ -201,15 +206,11 @@ void cMouseUnitsSelectedState::onMouseLeftButtonClicked()
             if (hoverUnitId > -1) {
                 cUnit *pUnit = m_context->getObjects()->getUnit(hoverUnitId);
                 if (pUnit->getPlayer() == m_player) {
-                    auto ids = m_player->getSelectedUnits();
-                    auto position = std::find(ids.begin(), ids.end(), hoverUnitId);
-                    if (position != ids.end()) {
+                    if (pUnit->isSelected()) {
                         m_player->deselectUnit(hoverUnitId);
                     }
                     else {
-                        // id not found, add it to the list
-                        ids.push_back(hoverUnitId); // add this unit
-                        m_player->selectUnits(ids);
+                        m_player->selectAdditionalUnits({hoverUnitId});
                     }
                 }
             }

--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -2586,6 +2586,15 @@ bool cPlayer::selectUnits(const std::vector<int> &ids) const
     return unitSelected || infantrySelected;
 }
 
+void cPlayer::selectAdditionalUnits(const std::vector<int> &ids) const
+{
+    for (auto id : ids) {
+        cUnit *pUnit = m_objects->getUnit(id);
+        if (pUnit->isAirbornUnit()) continue;
+        pUnit->select();
+    }
+}
+
 void cPlayer::setContextMouseState(eMouseState newState)
 {
     gameControlsContext->setMouseState(newState);

--- a/src/gameobjects/players/cPlayer.h
+++ b/src/gameobjects/players/cPlayer.h
@@ -555,6 +555,12 @@ public:
      */
     bool selectUnits(const std::vector<int> &ids) const;
 
+    /**
+     * Adds all non-airborn units in ids to the current selection without harvester filtering.
+     * Used when SHIFT is held to add units to an existing selection.
+     */
+    void selectAdditionalUnits(const std::vector<int> &ids) const;
+
     void thinkSlow();
 
     void deselectUnit(const int &unitId);


### PR DESCRIPTION
## Root cause

`cPlayer::selectUnits()` filters harvesters out whenever non-harvesters are also in the list. This is the correct behaviour for a fresh drag-select (where you don't normally want to accidentally grab a harvester), but it was also being called in `SELECTED_STATE_ADD_TO_SELECTION` — the state active when SHIFT is held. So SHIFT+drag-select and SHIFT+click on a harvester were silently discarded when other unit types were already selected.

## Changes

- Added `cPlayer::selectAdditionalUnits(ids)` — selects all non-airborn units in the list with no harvester filter
- In `cMouseUnitsSelectedState::onMouseLeftButtonClicked()`:
  - Box-select in `SELECTED_STATE_ADD_TO_SELECTION` now calls `selectAdditionalUnits` instead of `selectUnits`
  - Single-click in `SELECTED_STATE_ADD_TO_SELECTION` now calls `selectAdditionalUnits({id})` directly instead of rebuilding the full selection list and running it through `selectUnits`

## Test plan

- [ ] Select troopers, then SHIFT+drag-select over a harvester — harvester should be added to the group
- [ ] Select troopers, then SHIFT+click on a harvester — harvester should be added to the group
- [ ] Fresh drag-select over mixed units (no prior selection) — harvesters should still be excluded when other units are in the box