### PR TITLE
Back up log.txt before overwriting on startup

### DIFF
--- a/src/utils/Log.cpp
+++ b/src/utils/Log.cpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <chrono>
+#include <filesystem>
 #include <iostream>
 #include <string>
 #include <string_view>
@@ -87,6 +88,10 @@ std::string_view getLogHouseString(int houseId)
 cLog::cLog(std::string_view filename)
     : m_startTime(std::chrono::steady_clock::now())
 {
+    std::filesystem::path logPath(filename);
+    if (std::filesystem::exists(logPath)) {
+        std::filesystem::rename(logPath, std::string(filename) + ".backup");
+    }
     m_file.open(std::string(filename), std::ofstream::out);
     if (!m_file.is_open()) {
         throw std::system_error(errno, std::generic_category());


### PR DESCRIPTION
## Summary

When the game starts it opens `log.txt` for writing, destroying any previous log. If a player forgets to save their log before launching the game again, it is gone.

Fix: before opening `log.txt`, rename any existing file to `log.txt.backup`. A previous backup is replaced (only one backup is kept).

## Test plan

- [ ] Run the game once — `log.txt` is created
- [ ] Run the game again — `log.txt.backup` contains the previous session's log, new `log.txt` is fresh
- [ ] Run a third time — `log.txt.backup` is overwritten with the second session's log

Closes #1308