### PR TITLE
Harvesters fixate on top-left corner on some maps

### DIFF
--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -126,6 +126,7 @@ void cUnit::init(int i)
 
     // harv
     iCredits = 0;
+    iHarvestCellMemory = -1;
 
     // Drawing
     rendering.iBodyFacing = Facing::UP;    // Body of tanks facing


### PR DESCRIPTION
## Summary

`iHarvestCellMemory` was never initialised in `cUnit::init()`. The field stores the last spice cell a harvester worked on so the next search starts nearby. Without initialisation it held garbage memory, causing `findHarvestSpot()` to do a local search around a random cell — frequently resolving to cell 0 (top-left corner) — instead of searching the full map.

One-line fix: add `iHarvestCellMemory = -1` in `cUnit::init()`.

## Test plan

- [ ] Start a skirmish on a map where the enemy spawns far from the top-left corner
- [ ] Confirm enemy harvesters harvest from spice near their base, not from the top-left corner

Closes #1236