### PR TITLE
Cheat mode resets to disabled when returning to main menu

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1006,6 +1006,7 @@ void cGame::setState(int newState)
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             }
             else if (newState == GAME_BRIEFING) {
+                m_gameSettings->m_cheatMode = false;
                 newStatePtr = new cMentatState(m_services.get(), MentatMode::Briefing, m_cIni.get(), m_dataCampaign.get());
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             } else if (newState == GAME_WINBRIEF) {

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -939,6 +939,7 @@ void cGame::setState(int newState)
                 newStatePtr = new cEditorState(m_services.get());
             }
             else if (newState == GAME_MENU) {
+                m_gameSettings->m_cheatMode = false;
                 newStatePtr = new cMainMenuState(m_services.get());
                 playMusicByTypeForStateTransition(MUSIC_MENU);
             }


### PR DESCRIPTION
## Summary

Cheat mode was never reset between sessions. Once enabled it would persist through game-over, into the editor, and carry over into subsequent games.

Fix: reset `m_cheatMode = false` on transition to `GAME_MENU` and on transition to `GAME_BRIEFING` (mission select path).

## Test plan

- [ ] Enable cheat mode during a skirmish game
- [ ] Return to main menu — confirm cheat mode is off
- [ ] Start a new game — confirm cheat mode is still off
- [ ] Confirm cheat mode does not bleed into the editor
- [ ] Enable cheat mode mid-mission, select next mission from mission select — confirm cheat mode is off on briefing screen

Closes #1103