### PR TITLE
Game no longer hangs when all players are assigned to random house in skirmish

### DIFF
--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -26,9 +26,10 @@
 #include "include/Texture.hpp"
 #include "gui/GuiButton.h"
 
-#include <format>
 #include <algorithm>
+#include <format>
 #include <utility>
+#include <vector>
 #include "include/cAssert.h"
 
 #include "config.h"
@@ -726,29 +727,21 @@ void cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState(in
 
             // house = 0 means pick random house
             if (iHouse == 0) {
-                bool bOk = false;
-
-                while (bOk == false) {
-                    iHouse = RNG::rnd(4) + 1; // hark = 1, atr = 2, ord = 3, sar = 4
-
-                    bool houseInUse = false;
-                    for (int pl = 0; pl < AI_WORM; pl++) {
-                        // already in use by other skirmish set-up players
-                        if (skirmishPlayer[pl].iHouse > 0 &&
-                                skirmishPlayer[pl].iHouse == iHouse) {
-                            houseInUse = true;
-                        }
-
-                        if (m_objects->getPlayer(pl)->getHouse() == iHouse) {
-                            // already in use by a already-setup player
-                            houseInUse = true;
-                        }
-                    }
-
-                    if (!houseInUse) {
-                        bOk = true;
-                    }
+                std::vector<int> available = {HARKONNEN, ATREIDES, ORDOS, SARDAUKAR};
+                for (int pl = 0; pl < AI_WORM; pl++) {
+                    int usedHouse = (skirmishPlayer[pl].iHouse > 0)
+                        ? skirmishPlayer[pl].iHouse
+                        : m_objects->getPlayer(pl)->getHouse();
+                    available.erase(
+                        std::remove(available.begin(), available.end(), usedHouse),
+                        available.end());
                 }
+                if (available.empty()) {
+                    cPlayer* pSkipPlayer = m_objects->getPlayer(p);
+                    pSkipPlayer->init(p, nullptr);
+                    continue;
+                }
+                iHouse = available[RNG::rnd(available.size())];
             }
         }
         else {

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -737,6 +737,12 @@ void cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState(in
                         available.end());
                 }
                 if (available.empty()) {
+                    Logger::warn(COMP_SKIRMISHSETUP, "cSetupSkirmishState",
+                        "Player [{}] wanted a random house but all houses are taken — skipping. House setup: [0]={} [1]={} [2]={} [3]={} [4]={}",
+                        p,
+                        skirmishPlayer[0].iHouse, skirmishPlayer[1].iHouse,
+                        skirmishPlayer[2].iHouse, skirmishPlayer[3].iHouse,
+                        skirmishPlayer[4].iHouse);
                     cPlayer* pSkipPlayer = m_objects->getPlayer(p);
                     pSkipPlayer->init(p, nullptr);
                     continue;

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -738,14 +738,12 @@ void cSetupSkirmishState::prepareSkirmishGameToPlayAndTransitionToCombatState(in
                 }
                 if (available.empty()) {
                     Logger::warn(COMP_SKIRMISHSETUP, "cSetupSkirmishState",
-                        "Player [{}] wanted a random house but all houses are taken — skipping. House setup: [0]={} [1]={} [2]={} [3]={} [4]={}",
+                        "Player [{}] wanted a random house but all houses are taken — assigning duplicate. House setup: [0]={} [1]={} [2]={} [3]={} [4]={}",
                         p,
                         skirmishPlayer[0].iHouse, skirmishPlayer[1].iHouse,
                         skirmishPlayer[2].iHouse, skirmishPlayer[3].iHouse,
                         skirmishPlayer[4].iHouse);
-                    cPlayer* pSkipPlayer = m_objects->getPlayer(p);
-                    pSkipPlayer->init(p, nullptr);
-                    continue;
+                    available = {HARKONNEN, ATREIDES, ORDOS, SARDAUKAR};
                 }
                 iHouse = available[RNG::rnd(available.size())];
             }


### PR DESCRIPTION
## Summary

There are only 4 playable houses (Harkonnen, Atreides, Ordos, Sardaukar) but 5 playable player slots. With all 5 set to Random, the 5th player could never find an unused house and would spin in an infinite loop, freezing the game.

Fix: build the set of available houses upfront. If none are left (all 4 taken), log a warning and assign a random house anyway — allowing a duplicate house/colour — rather than skipping the player slot.

## Test plan

- [ ] Start a skirmish with 5 Random players — game should start normally with all 5 active (one will share a house colour)
- [ ] Confirm the warning appears in the log when all houses are taken
- [ ] Confirm normal skirmish works with 2-4 random players

Closes #1058