### PR TITLE
Starport frigate arrives after a longer delay

### DIFF
--- a/src/gameobjects/structures/cOrderProcesser.cpp
+++ b/src/gameobjects/structures/cOrderProcesser.cpp
@@ -129,7 +129,6 @@ void cOrderProcesser::think()
 {
     if (m_secondsUntilArrival > 0) {
         m_secondsUntilArrival--;
-        std::string msg = std::format("T-{} before Frigate arrival.", m_secondsUntilArrival);
 
         if (m_secondsUntilArrival <= 5 && m_player->getId() == HUMAN) {
             playTMinusSound(m_secondsUntilArrival);
@@ -139,7 +138,8 @@ void cOrderProcesser::think()
             sendFrigate();
             m_interface->getDrawManager()->setMessage("Frigate is arriving...");
         }
-        else {
+        else if (m_secondsUntilArrival <= 10) {
+            std::string msg = std::format("T-{} before Frigate arrival.", m_secondsUntilArrival);
             m_interface->getDrawManager()->setMessage(msg);
         }
     }
@@ -233,7 +233,7 @@ void cOrderProcesser::placeOrder()
 {
     m_orderPlaced = true;
     m_frigateSent = false;
-    m_secondsUntilArrival = 10; // wait 10 seconds
+    m_secondsUntilArrival = 25;
 }
 
 int cOrderProcesser::getRandomizedSecondsToWait()


### PR DESCRIPTION
## Summary

- Increased the total wait time from 10 to 25 seconds when a starport order is placed
- The visible T-minus countdown only appears in the final 10 seconds, creating a hidden pre-delay before the countdown shows up
- Voice lines still play at T-5 and below; countdown message runs T-9 through T-0

Closes #1214