### PR TITLE
Right-click deselects all selected units and buildings

### DIFF
--- a/src/controls/mousestates/cMouseNormalState.cpp
+++ b/src/controls/mousestates/cMouseNormalState.cpp
@@ -161,6 +161,10 @@ void cMouseNormalState::onMouseRightButtonPressed()
 
 void cMouseNormalState::onMouseRightButtonClicked()
 {
+    if (!m_mouse->isMapScrolling()) {
+        m_player->deselectAllUnits();
+        m_player->deselectStructure();
+    }
     m_mouse->resetDragViewportInteraction();
 }
 

--- a/src/controls/mousestates/cMouseUnitsSelectedState.cpp
+++ b/src/controls/mousestates/cMouseUnitsSelectedState.cpp
@@ -244,6 +244,7 @@ void cMouseUnitsSelectedState::onMouseRightButtonClicked()
     // if we were dragging the viewport, keep the units and this state.
     if (!m_mouse->isMapScrolling()) {
         m_player->deselectAllUnits();
+        m_player->deselectStructure();
         // back to "select" state
         m_context->setMouseState(MOUSESTATE_SELECT);
     }


### PR DESCRIPTION
## Summary

- Right-clicking on the battlefield now clears all selected units and the selected building
- This works in both normal/select state (building selected) and units-selected state
- The deselection is skipped if the player was dragging the viewport (map scrolling), to avoid accidental deselection

Closes #1201