### PR TITLE
Mouse cursor no longer sticks in rally state after CTRL+select commands

### DIFF
--- a/src/controls/mousestates/cMouseNormalState.cpp
+++ b/src/controls/mousestates/cMouseNormalState.cpp
@@ -191,6 +191,7 @@ int cMouseNormalState::getMouseTileForNormalState() const
 
 void cMouseNormalState::onStateSet()
 {
+    setState(SELECT_STATE_NORMAL);
     m_mouseTile = MOUSE_NORMAL;
     m_mouse->setTile(m_mouseTile);
 }


### PR DESCRIPTION
## Summary

- When CTRL was held over a unit-producing structure, the normal mouse state entered rally mode (`SELECT_STATE_RALLY`)
- If units were then selected via a CTRL+key shortcut (e.g. CTRL+W to select all wheeled units) and later deselected, the normal state was re-entered but its internal `m_state` was still `SELECT_STATE_RALLY`
- This caused every subsequent mouse move to show the rally/targeting cursor instead of the normal cursor
- Adding `setState(SELECT_STATE_NORMAL)` to `onStateSet()` ensures the normal state always resets cleanly when entered

Closes #1049