### PR TITLE
Bandbox selection clears when mouse state changes

### DIFF
--- a/src/controls/cGameControlsContext.cpp
+++ b/src/controls/cGameControlsContext.cpp
@@ -275,6 +275,7 @@ void cGameControlsContext::setMouseState(eMouseState newState)
         }
 
         Logger::info(COMP_NONE, "cGameControlsContext::setMouseState", "changing state from [{}] to [{}] (prevState=[{}], prevStateBeforeRepair=[{}])", mouseStateString(m_state), mouseStateString(newState), mouseStateString(m_prevState), mouseStateString(m_prevStateBeforeRepair));
+        onBlurMouseStateEvent();
         m_state = newState;
         switch (m_state) {
             case MOUSESTATE_SELECT:


### PR DESCRIPTION
## Summary

- When the mouse state transitioned (e.g. pressing/releasing R while a box-select drag was in progress), the previous state's `onBlur()` was never called
- This left the bandbox rectangle rendered on screen even after the selection mode ended
- The fix calls `onBlurMouseStateEvent()` (which resets box-select and drag viewport for the current state) just before updating `m_state` in `setMouseState()`

Closes #988