### PR TITLE
Ravenborn credits description expanded

### DIFF
--- a/src/gamestates/cCreditsState.cpp
+++ b/src/gamestates/cCreditsState.cpp
@@ -159,7 +159,7 @@ void cCreditsState::prepareCrawlerLines()
     });
     m_lines.push_back(s_CreditLine {
         .name = "Ravenborn",
-        .txt = "Graphics for editor UI, sonic tank weapon, worm attack & turret directions",
+        .txt = "Internal Editor UI graphics and miscellaneous assets",
         .color = Color::White,
         .height = fontHeightWithALittlePadding
     });

--- a/src/gamestates/cCreditsState.cpp
+++ b/src/gamestates/cCreditsState.cpp
@@ -159,7 +159,7 @@ void cCreditsState::prepareCrawlerLines()
     });
     m_lines.push_back(s_CreditLine {
         .name = "Ravenborn",
-        .txt = "Graphics",
+        .txt = "Graphics for editor UI, sonic tank weapon, worm attack & turret directions",
         .color = Color::White,
         .height = fontHeightWithALittlePadding
     });


### PR DESCRIPTION
## Summary

Updated Ravenborn's credits line to accurately reflect only the work currently integrated: internal editor UI graphics and miscellaneous assets.

The previous text listed sonic tank weapon and worm animations which have not been integrated yet; those can be added to credits when that work lands.

Closes #1035