### PR TITLE
Music plays on Windows by building SDL3_mixer with MIDI support

### DIFF
--- a/install_dependencies_ubuntu.sh
+++ b/install_dependencies_ubuntu.sh
@@ -56,10 +56,12 @@ cmake -S "$BUILD_DIR/SDL3_ttf" -B "$BUILD_DIR/SDL3_ttf/build" $CMAKE_FLAGS \
   -DSDLTTF_SAMPLES=OFF
 sudo cmake --build "$BUILD_DIR/SDL3_ttf/build" --target install -j4
 
-# SDL3_mixer
+# SDL3_mixer (SDLMIXER_MIDI_TIMIDITY compiles in a MIDI synthesizer with no external files needed)
 git clone --depth 1 --branch release-3.2.4 https://github.com/libsdl-org/SDL_mixer.git "$BUILD_DIR/SDL3_mixer"
 cmake -S "$BUILD_DIR/SDL3_mixer" -B "$BUILD_DIR/SDL3_mixer/build" $CMAKE_FLAGS \
-  -DSDLMIXER_SAMPLES=OFF
+  -DSDLMIXER_SAMPLES=OFF \
+  -DSDLMIXER_MIDI_TIMIDITY=ON \
+  -DSDLMIXER_MIDI_FLUIDSYNTH=OFF
 sudo cmake --build "$BUILD_DIR/SDL3_mixer/build" --target install -j4
 
 sudo ldconfig

--- a/install_dependencies_windows.ps1
+++ b/install_dependencies_windows.ps1
@@ -1,0 +1,91 @@
+# Install SDL3 dependencies from source on Windows (MinGW/MSYS2).
+# Run once before building the game. Requires git and cmake in PATH.
+#
+# Usage: pwsh -ExecutionPolicy Bypass -File install_dependencies_windows.ps1
+
+param(
+    [string]$InstallPrefix = "$PSScriptRoot\deps"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "---------------------------------"
+Write-Host "---                           ---"
+Write-Host "---  Installing dependencies  ---"
+Write-Host "---                           ---"
+Write-Host "---------------------------------"
+
+$BuildDir = Join-Path $env:TEMP "d2tm-build-deps"
+if (Test-Path $BuildDir) { Remove-Item -Recurse -Force $BuildDir }
+New-Item -ItemType Directory -Path $BuildDir | Out-Null
+
+$CMakeFlags = @(
+    "-DCMAKE_BUILD_TYPE=Release",
+    "-DCMAKE_INSTALL_PREFIX=$InstallPrefix",
+    "-G", "MinGW Makefiles",
+    "-DCMAKE_PREFIX_PATH=$InstallPrefix"
+)
+
+function Build-Project {
+    param(
+        [string]$Name,
+        [string]$Url,
+        [string]$Tag,
+        [string[]]$ExtraFlags = @()
+    )
+
+    Write-Host ""
+    Write-Host "=== $Name ===" -ForegroundColor Cyan
+    $SrcDir = Join-Path $BuildDir $Name
+    $BldDir = Join-Path $SrcDir "build"
+
+    git clone --depth 1 --branch $Tag $Url $SrcDir
+    if ($LASTEXITCODE -ne 0) { throw "git clone failed for $Name" }
+
+    $allFlags = $CMakeFlags + $ExtraFlags
+    cmake -S $SrcDir -B $BldDir @allFlags
+    if ($LASTEXITCODE -ne 0) { throw "cmake configure failed for $Name" }
+
+    cmake --build $BldDir --target install -- -j4
+    if ($LASTEXITCODE -ne 0) { throw "cmake build failed for $Name" }
+}
+
+# SDL3
+Build-Project "SDL3" "https://github.com/libsdl-org/SDL.git" "release-3.4.10" @(
+    "-DSDL_TEST_LIBRARY=OFF"
+)
+
+# SDL3_image
+Build-Project "SDL3_image" "https://github.com/libsdl-org/SDL_image.git" "release-3.4.4" @(
+    "-DSDLIMAGE_SAMPLES=OFF"
+)
+
+# SDL3_ttf
+Build-Project "SDL3_ttf" "https://github.com/libsdl-org/SDL_ttf.git" "release-3.2.2" @(
+    "-DSDLTTF_SAMPLES=OFF"
+)
+
+# SDL3_mixer with built-in Timidity MIDI synthesizer (no soundfont files needed)
+Build-Project "SDL3_mixer" "https://github.com/libsdl-org/SDL_mixer.git" "release-3.2.4" @(
+    "-DSDLMIXER_SAMPLES=OFF",
+    "-DSDLMIXER_MIDI_TIMIDITY=ON",
+    "-DSDLMIXER_MIDI_FLUIDSYNTH=OFF"
+)
+
+# Copy built DLLs into resources/dll so create_release.bat picks them up
+$DllSource = Join-Path $InstallPrefix "bin"
+$DllDest   = Join-Path $PSScriptRoot "resources\dll"
+Write-Host ""
+Write-Host "Copying DLLs to $DllDest ..." -ForegroundColor Yellow
+foreach ($dll in @("SDL3.dll", "SDL3_image.dll", "SDL3_ttf.dll", "SDL3_mixer.dll")) {
+    $src = Join-Path $DllSource $dll
+    if (Test-Path $src) {
+        Copy-Item $src $DllDest -Force
+        Write-Host "  Copied $dll"
+    } else {
+        Write-Warning "  $dll not found in $DllSource"
+    }
+}
+
+Write-Host ""
+Write-Host "Done. Now run rebuildwin.bat to build the game." -ForegroundColor Green

--- a/rebuildwin.bat
+++ b/rebuildwin.bat
@@ -1,7 +1,7 @@
 rm -rf build
 mkdir build
 cd build
-cmake .. -G "MinGW Makefiles"
+cmake .. -G "MinGW Makefiles" -DCMAKE_PREFIX_PATH=../deps
 cmake --build . --target all -- -j 6
 ctest --output-on-failure
 cd ..

--- a/rebuildwinrelease.bat
+++ b/rebuildwinrelease.bat
@@ -1,7 +1,7 @@
 rm -rf Release
 mkdir Release
 cd Release
-cmake -DCMAKE_BUILD_TYPE=Release .. -G "MinGW Makefiles"
+cmake -DCMAKE_BUILD_TYPE=Release .. -G "MinGW Makefiles" -DCMAKE_PREFIX_PATH=../deps
 cmake --build . --target all -- -j 6
 ctest --output-on-failure
 cd ..

--- a/src/game/cSDLSystem.cpp
+++ b/src/game/cSDLSystem.cpp
@@ -140,8 +140,17 @@ cSDLSystem::cSDLSystem(int desiredWidth, int desiredHeight, const std::string &t
     }
     else {
         Logger::info(COMP_SDL2, "SDL_mixer", "Initialized successfully");
-        for (auto i =0; i < MIX_GetNumAudioDecoders();i++) {
-            Logger::info(COMP_SDL2, "SDL_mixer", "Audio decoder {} : {}", i, MIX_GetAudioDecoder(i));
+        bool hasMidi = false;
+        for (auto i = 0; i < MIX_GetNumAudioDecoders(); i++) {
+            const char *name = MIX_GetAudioDecoder(i);
+            Logger::info(COMP_SDL2, "SDL_mixer", "Audio decoder {} : {}", i, name);
+            if (SDL_strcasecmp(name, "MIDI") == 0 || SDL_strcasecmp(name, "MID") == 0) {
+                hasMidi = true;
+            }
+        }
+        if (!hasMidi) {
+            Logger::warn(COMP_SDL2, "SDL_mixer", "No MIDI decoder found — music will not play. "
+                "On Windows, run install_dependencies_windows.ps1 to rebuild SDL3_mixer with MIDI support.");
         }
     }
 


### PR DESCRIPTION
Fixes #1363

## Root cause

The bundled `resources/dll/SDL3_mixer.dll` was built without any MIDI decoder.
The game's music tracks are all MIDI format, so `MIX_LoadAudio_IO` returned null for every track
and `cSoundPlayer::playMusic` silently disabled music entirely.

The macOS SDL3_mixer (Homebrew) has both Timidity and FluidSynth enabled, which is why music
works there. The Windows DLL had neither.

## What this PR does

- Adds `install_dependencies_windows.ps1` — a Windows equivalent of `install_dependencies_ubuntu.sh`
  that builds all SDL3 libraries from source, with `SDLMIXER_MIDI_TIMIDITY=ON` for SDL3_mixer.
  Timidity is a MIDI synthesizer compiled directly into the DLL; no extra soundfont files are needed.
  The script copies the resulting DLLs (including the new `SDL3_mixer.dll`) into `resources/dll/`.
- Updates `install_dependencies_ubuntu.sh` to also enable Timidity for consistency.
- Updates `rebuildwin.bat` and `rebuildwinrelease.bat` to pass `-DCMAKE_PREFIX_PATH=../deps`
  so CMake finds the locally built libraries.
- Adds a startup warning when no MIDI decoder is found, so the failure is visible in the log.

## How to test (Windows)

Requirements: `git`, `cmake`, and MinGW (`g++`) in PATH.

```powershell
pwsh -ExecutionPolicy Bypass -File install_dependencies_windows.ps1
```

Then rebuild and run the game:

```bat
rebuildwin.bat
create_release.bat
cd bin
d2tm.exe
```

Music should play in the main menu and during gameplay.

If music still does not play, check the startup log for the line:
`SDL_mixer: Audio decoder N : MIDI` — it should now appear.
If it does not, the Timidity build may need investigation.