### PR TITLE
Fix for attreides scenario 04

### DIFF
--- a/resources/bin/campaign/maps/scena004.ini
+++ b/resources/bin/campaign/maps/scena004.ini
@@ -8,8 +8,8 @@ TimeOut=0
 MapScale=1
 CursorPos=1313
 TacticalPos=1050
-LoseFlags=4
-WinFlags=6
+LoseFlags=5
+WinFlags=7
 
 [MAP]
 Bloom=1239,1363


### PR DESCRIPTION
Fix for `Mission does not end for attreides (scena004.ini)`

[issue #1373](https://github.com/stefanhendriks/Dune-II---The-Maker/issues/1373)

## **Goal**

Fix Win Conditions for mission 2, choice 3

### Changes

Updated win flag
Updates lose flag


## Testing Steps
Play attreides campaign, ensure you can win mission 2 by mining spice OR by removing the enemy bases.

## Screenshots (optional)