### PR TITLE
Corrections to house of WOR techtree for Ordos/Sardaukar

### DIFF
--- a/src/sidebar/cBuildingListUpdater.cpp
+++ b/src/sidebar/cBuildingListUpdater.cpp
@@ -263,7 +263,7 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
     }
 
 	if (structureType == BARRACKS) {
-		if (techLevel >= 3) {
+		if (techLevel >= 4) {
 			if (house == SARDAUKAR) {
 				listConstYard->addStructureToList(WOR, 0);
 				m_player->log("onStructureCreated - added WOR to list");
@@ -309,7 +309,7 @@ void cBuildingListUpdater::onStructureCreatedSkirmishMode(int structureType) con
                     house == FREMEN) {
                 listConstYard->addStructureToList(BARRACKS, 0);
 
-                if (house == ORDOS && techLevel >= 5) {
+                if (house == ORDOS && techLevel >= 4) {
                     listConstYard->addStructureToList(WOR, 0);
                 }
             }


### PR DESCRIPTION
Changed tech level requirement for sarduakar from 3 to 4 Changed tech level requirement for ordos from 5 to 4

[Issue #1378](https://github.com/stefanhendriks/Dune-II---The-Maker/issues/1378)

## **Goal**

Correct changes to tech level for house Sarduakar and House Ordos

### Changes

Changes to cBuildingListUpdater.cpp


## Testing Steps

Play Ordos Campaign, Compare it to original, report anything not correct.
Play Sarduakar Campaign, Ensure WOR is not available on level 3 and only on level 4

## Screenshots (optional)