### PR TITLE
Refactor state creation

### DIFF
--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -247,10 +247,11 @@ private:
     void thinkFast_fading();
 
 
-    int m_state;
-    int m_nextState;
-    // the current game state we are running
+    int m_state; // TODO: Replace with enum, and later even remove with pointer to state
+    int m_nextState; // TODO: Replace with enum, and later even remove with pointer to state
+    
     cGameState *m_currentState;
+
     void transitionStateIfRequired();
     void setState(int newState);
 

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -61,6 +61,7 @@ class cStructureUtils;
 class Texture;
 class cIni;
 class cEventEmitter;
+class CreatorState;
 
 struct s_DataCampaign;
 // struct s_PreviewMap;
@@ -282,4 +283,5 @@ private:
     std::unique_ptr<sGameServices> m_services;
     std::unique_ptr<cIni> m_cIni;
     std::unique_ptr<cEventEmitter> m_eventEmitter;
+    std::unique_ptr<CreatorState> m_creatorState;
 };

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -61,7 +61,7 @@ class cStructureUtils;
 class Texture;
 class cIni;
 class cEventEmitter;
-class CreatorState;
+class cCreatorState;
 
 struct s_DataCampaign;
 // struct s_PreviewMap;
@@ -279,5 +279,5 @@ private:
     std::unique_ptr<sGameServices> m_services;
     std::unique_ptr<cIni> m_cIni;
     std::unique_ptr<cEventEmitter> m_eventEmitter;
-    std::unique_ptr<CreatorState> m_creatorState;
+    std::unique_ptr<cCreatorState> m_creatorState;
 };

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -185,7 +185,6 @@ public:
     void applySettings(std::unique_ptr<InitialGameSettings> gs);
     void changeStateFromMentat();
     void loadMapFromEditor(int map);
-    // void loadMapFromEditor(s_PreviewMap *map);
 
     Texture* getScreenTexture() const {
         return screenTexture;
@@ -217,8 +216,6 @@ private:
     std::unique_ptr<cFocusManager> m_focusManager;
 
     cSoundPlayer* m_soundPlayer;
-
-    // std::shared_ptr<cPreviewMaps> m_PreviewMaps;
 
     std::unique_ptr<InitialGameSettings> m_initialGameSettings;
 

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -251,7 +251,6 @@ private:
     int m_nextState;
     // the current game state we are running
     cGameState *m_currentState;
-    cGameState *m_states[GAME_MAX_STATES];
     void transitionStateIfRequired();
     void setState(int newState);
 

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -249,7 +249,7 @@ private:
 
     int m_state; // TODO: Replace with enum, and later even remove with pointer to state
     int m_nextState; // TODO: Replace with enum, and later even remove with pointer to state
-    
+
     cGameState *m_currentState;
 
     void transitionStateIfRequired();

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -133,8 +133,6 @@ void cGame::syncTextInputState() const
 
 cGame::cGame()
 {
-    std::fill(std::begin(m_states), std::end(m_states), nullptr);
-
     m_nextState = -1;
     m_currentState = nullptr;
 
@@ -506,6 +504,7 @@ void cGame::run()
 
         updateMouseAndKeyboardState();
         m_currentState->update();
+        //Logger::print(LOG_INFO , COMP_NONE, "m_currentState", "m_currentState {}", gameStateToString(m_currentState->getType()));
 
         m_renderDrawer->beginDrawingToTexture(actualRenderer);
         m_renderDrawer->renderClearToColor();
@@ -534,36 +533,8 @@ void cGame::shutdown()
     m_gameObjectsContext->getParticles().reset();
     Logger::info(COMP_NONE, "cGame::shutdown", "=== SHUTDOWN ===");
 
-    for (int i = 0; i < GAME_MAX_STATES; i++) {
-        cGameState *pState = m_states[i];
-        if (pState) {
-            if (pState->getType() != eGameStateType::GAMESTATE_SELECT_YOUR_NEXT_CONQUEST) {
-                if (m_currentState == pState) {
-                    m_currentState = nullptr; // reset
-                }
-                delete pState;
-                m_states[i] = nullptr;
-            }
-            else {
-                if (m_currentState == pState) {
-                    m_currentState = nullptr; // reset
-                }
-                m_states[i] = nullptr;
-            }
-        }
-    }
-
-    if (m_currentState != nullptr) {
-        d2tm_assert(false);
-        if (m_currentState->getType() != eGameStateType::GAMESTATE_SELECT_YOUR_NEXT_CONQUEST) {
-            // destroy game state object, unless we talk about the region select
-            delete m_currentState;
-        }
-        else {
-            m_currentState = nullptr;
-        }
-    }
-
+    m_currentState = nullptr;
+    m_creatorState->destroyAllStates();
 
     delete m_mapViewport;
 
@@ -782,14 +753,12 @@ bool cGame::isState(int thisState) const
 
 void cGame::jumpToSelectYourNextConquestMission(int missionNr)
 {
-    cGameState *existingStatePtr = m_states[GAME_REGION];
-    if (existingStatePtr) {
-        delete existingStatePtr;
-        m_states[GAME_REGION] = nullptr;
+    cGameState *state = m_creatorState->getState(eGameState::REGION, true);
+    auto *pState = dynamic_cast<cSelectYourNextConquestState *>(state);
+    if (!pState) {
+        Logger::error(COMP_GAME, "cGame::jumpToSelectYourNextConquestMission", "Failed to create cSelectYourNextConquestState for mission {}. Aborting.", missionNr);
+        return;
     }
-
-    cSelectYourNextConquestState *pState = new cSelectYourNextConquestState(m_services.get(), m_cIni.get(), m_dataCampaign.get());
-    m_states[GAME_REGION] = pState;
 
     pState->calculateOffset();
     pState->installWorld();
@@ -818,38 +787,73 @@ void cGame::setState(int newState)
         bool deleteOldState = (newState != GAME_REGION &&
                                newState != GAME_PLAYING &&
                                newState != GAME_EDITOR &&
-                               newState != GAME_OPTIONS); // don't delete these m_states, but re-use!
+                               newState != GAME_OPTIONS); // don't delete these states, but re-use!
+
+        auto mapToCreatorState = [](int state, eGameState &mapped) -> bool {
+            switch (state) {
+                case GAME_MENU: mapped = eGameState::MENU; return true;
+                case GAME_PLAYING: mapped = eGameState::PLAYING; return true;
+                case GAME_BRIEFING: mapped = eGameState::BRIEFING; return true;
+                case GAME_EDITOR: mapped = eGameState::EDITOR; return true;
+                case GAME_OPTIONS: mapped = eGameState::OPTIONS; return true;
+                case GAME_REGION: mapped = eGameState::REGION; return true;
+                case GAME_SELECT_HOUSE: mapped = eGameState::SELECT_HOUSE; return true;
+                case GAME_TELLHOUSE: mapped = eGameState::TELLHOUSE; return true;
+                case GAME_WINNING: mapped = eGameState::WINNING; return true;
+                case GAME_WINBRIEF: mapped = eGameState::WINBRIEF; return true;
+                case GAME_LOSEBRIEF: mapped = eGameState::LOSEBRIEF; return true;
+                case GAME_LOSING: mapped = eGameState::LOSING; return true;
+                case GAME_SETUPSKIRMISH: mapped = eGameState::SETUPSKIRMISH; return true;
+                case GAME_CREDITS: mapped = eGameState::CREDITS; return true;
+                case GAME_MISSIONSELECT: mapped = eGameState::MISSIONSELECT; return true;
+                case GAME_NEW_MAP_EDITOR: mapped = eGameState::NEW_MAP_EDITOR; return true;
+                default:
+                    return false;
+            }
+        };
 
         if (newState == GAME_PLAYING) {
             // make sure to delete options menu now
-            if (m_currentState == m_states[GAME_OPTIONS]) {
+            cGameState *optionsState = nullptr;
+            if (m_creatorState->hasState(eGameState::OPTIONS)) {
+                optionsState = m_creatorState->getState(eGameState::OPTIONS);
+            }
+
+            if (m_currentState == optionsState) {
                 m_currentState = nullptr;
             }
-            delete m_states[GAME_OPTIONS];
-            m_states[GAME_OPTIONS] = nullptr;
+            m_creatorState->destroyState(eGameState::OPTIONS);
         }
 
         if (newState == GAME_REGION) {
             // make sure to delete options menu now
-            if (m_currentState == m_states[GAME_OPTIONS]) {
+            cGameState *optionsState = nullptr;
+            if (m_creatorState->hasState(eGameState::OPTIONS)) {
+                optionsState = m_creatorState->getState(eGameState::OPTIONS);
+            }
+
+            if (m_currentState == optionsState) {
                 m_currentState = nullptr;
             }
-            delete m_states[GAME_OPTIONS];
-            m_states[GAME_OPTIONS] = nullptr;
+            m_creatorState->destroyState(eGameState::OPTIONS);
         }
 
         if (newState == GAME_MISSIONSELECT) {
-            deleteOldState = true; // delete old options state everytime
-        }
-
-        if (deleteOldState) {
-            delete m_states[newState];
-            m_states[newState] = nullptr;
+            deleteOldState = true; // delete old missionselect state everytime
         }
 
         cPlayer *humanPlayer = m_gameObjectsContext->getPlayer(HUMAN);
 
-        cGameState *existingStatePtr = m_states[newState];
+        cGameState *existingStatePtr = nullptr;
+        eGameState targetCreatorState = eGameState::MENU;
+        if (mapToCreatorState(newState, targetCreatorState)) {
+            if (deleteOldState) {
+                m_creatorState->destroyState(targetCreatorState);
+            }
+            if (m_creatorState->hasState(targetCreatorState)) {
+                existingStatePtr = m_creatorState->getState(targetCreatorState);
+            }
+        }
 
         if (existingStatePtr) {
             // no need for re-creating state
@@ -889,6 +893,8 @@ void cGame::setState(int newState)
                 }
             }
             else if (newState == GAME_PLAYING) {
+                    m_currentState = existingStatePtr;
+
                     m_drawManager->reset();
                     // evaluate all players, so we have initial 'alive' values set properly
                     m_players->evaluateStillAliveForAI();
@@ -911,8 +917,7 @@ void cGame::setState(int newState)
             cGameState *newStatePtr = nullptr;
 
             if (newState == GAME_REGION) {
-                cSelectYourNextConquestState *pState = new cSelectYourNextConquestState(m_services.get(), m_cIni.get(), m_dataCampaign.get());
-
+                auto *pState = dynamic_cast<cSelectYourNextConquestState *>(m_creatorState->getState(eGameState::REGION));
                 pState->calculateOffset();
                 Logger::info(COMP_INIT, "cGame::loadScenario", "Setup:  WORLD");
                 pState->installWorld();
@@ -921,37 +926,35 @@ void cGame::setState(int newState)
                 }
                 // first creation
                 pState->regionSetupNextMission(m_dataCampaign->mission, humanPlayer->getHouse());
-
                 playMusicByTypeForStateTransition(MUSIC_CONQUEST);
 
                 newStatePtr = pState;
             }
             else if (newState == GAME_SETUPSKIRMISH) {
                 m_players->initPlayers(false, m_gameSettings.get(), m_dataCampaign.get(), m_services.get());
-                auto previewMaps = m_gameObjectsContext->getPreviewMaps();
-                newStatePtr = new cSetupSkirmishState(m_services.get(), previewMaps, m_dataCampaign.get());
+                newStatePtr = m_creatorState->getState(eGameState::SETUPSKIRMISH);
                 playMusicByTypeForStateTransition(MUSIC_MENU);
             }
             else if (newState == GAME_CREDITS) {
-                newStatePtr = new cCreditsState(m_services.get());
+                newStatePtr = m_creatorState->getState(eGameState::CREDITS);
             }
             else if (newState == GAME_EDITOR) {
-                newStatePtr = new cEditorState(m_services.get());
+                newStatePtr = m_creatorState->getState(eGameState::EDITOR);
             }
             else if (newState == GAME_MENU) {
                 m_gameSettings->m_cheatMode = false;
-                newStatePtr = new cMainMenuState(m_services.get());
+                newStatePtr = m_creatorState->getState(eGameState::MENU);
                 playMusicByTypeForStateTransition(MUSIC_MENU);
             }
             else if (newState == GAME_NEW_MAP_EDITOR) {
-                newStatePtr = new cNewMapEditorState(m_services.get());
+                newStatePtr = m_creatorState->getState(eGameState::NEW_MAP_EDITOR);
             }
             else if (newState == GAME_SELECT_HOUSE) {
-                newStatePtr = new cChooseHouseState(m_services.get());
+                newStatePtr = m_creatorState->getState(eGameState::SELECT_HOUSE);
             }
             else if (newState == GAME_MISSIONSELECT) {
                 m_mouse->setTile(MOUSE_NORMAL);
-                newStatePtr = new cSelectMissionState(m_services.get(), m_state);
+                newStatePtr = m_creatorState->getState(eGameState::MISSIONSELECT);
             }
             else if (newState == GAME_OPTIONS) {
                 takeBackGroundScreen();
@@ -964,8 +967,7 @@ void cGame::setState(int newState)
                 else {
                     // we fall back what was on screen, (which includes mouse cursor for now)
                 }
-
-                newStatePtr = new cOptionsState(m_services.get(), m_state);
+                newStatePtr = m_creatorState->getState(eGameState::OPTIONS);
             }
             else if (newState == GAME_PLAYING) {
                 if (m_state == GAME_OPTIONS) {
@@ -975,10 +977,10 @@ void cGame::setState(int newState)
                     humanPlayer->getGameControlsContext()->onFocusMouseStateEvent();
                 }
                 else {
-                    newStatePtr = new cGamePlaying(m_services.get());
+                    newStatePtr = m_creatorState->getState(eGameState::PLAYING);
+                    m_currentState = newStatePtr;
 
                     m_drawManager->reset();
-
                     // evaluate all players, so we have initial 'alive' values set properly
                     m_players->evaluateStillAliveForAI();
                     m_gameObjectsContext->getParticles().reset();
@@ -995,29 +997,28 @@ void cGame::setState(int newState)
                 }
             }
             else if (newState == GAME_LOSING) {
-                newStatePtr = new cWinLoseState(m_services.get(), Outcome::Lose);
+                newStatePtr = m_creatorState->getState(eGameState::LOSING);
             }
             else if (newState == GAME_WINNING) {
-                newStatePtr = new cWinLoseState(m_services.get(), Outcome::Win);
+                newStatePtr = m_creatorState->getState(eGameState::WINNING);
             }
             else if (newState == GAME_TELLHOUSE) {
                 m_dataCampaign->housePlayer = m_gameObjectsContext->getPlayer(HUMAN)->getHouse();
-                newStatePtr = new cTellHouseState(m_services.get(), m_cIni.get(), m_dataCampaign.get());
+                newStatePtr = m_creatorState->getState(eGameState::TELLHOUSE);
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             }
             else if (newState == GAME_BRIEFING) {
                 m_gameSettings->m_cheatMode = false;
-                newStatePtr = new cMentatState(m_services.get(), MentatMode::Briefing, m_cIni.get(), m_dataCampaign.get());
+                newStatePtr = m_creatorState->getState(eGameState::BRIEFING);
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             } else if (newState == GAME_WINBRIEF) {
-                newStatePtr = new cMentatState(m_services.get(), MentatMode::WinBrief, m_cIni.get(), m_dataCampaign.get());
+                newStatePtr = m_creatorState->getState(eGameState::WINBRIEF);
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             } else if (newState == GAME_LOSEBRIEF) {
-                newStatePtr = new cMentatState(m_services.get(), MentatMode::LoseBrief, m_cIni.get(), m_dataCampaign.get());
+                newStatePtr = m_creatorState->getState(eGameState::LOSEBRIEF);
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             }
 
-            m_states[newState] = newStatePtr;
             m_currentState = newStatePtr;
         }
     }
@@ -1038,15 +1039,15 @@ void cGame::prepareMentatForPlayer()
     if (m_state == GAME_BRIEFING) {
         missionInit();
         setupPlayers();
-        auto *pState = dynamic_cast<cMentatState *>(m_states[GAME_BRIEFING]);
+        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getState(eGameState::BRIEFING));
         pState->prepareMentat(m_dataCampaign->housePlayer);
     }
     else if (m_state == GAME_WINBRIEF) {
-        auto *pState = dynamic_cast<cMentatState *>(m_states[GAME_WINBRIEF]);
+        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getState(eGameState::WINBRIEF));
         pState->prepareMentat(m_dataCampaign->housePlayer);
     }
     else if (m_state == GAME_LOSEBRIEF) {
-        auto *pState = dynamic_cast<cMentatState *>(m_states[GAME_LOSEBRIEF]);
+        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getState(eGameState::LOSEBRIEF));
         pState->prepareMentat(m_dataCampaign->housePlayer);
     }
 }
@@ -1055,15 +1056,22 @@ void cGame::prepareMentatToTellAboutHouse(int house)
 {
     m_gameObjectsContext->getPlayer(HUMAN)->setHouse(house);
     m_dataCampaign->housePlayer = house;
-    if (!m_states[GAME_TELLHOUSE]) {
-        m_states[GAME_TELLHOUSE] = new cTellHouseState(m_services.get(), m_cIni.get(), m_dataCampaign.get());
+    if (!m_creatorState->hasState(eGameState::TELLHOUSE)) {
+        m_creatorState->getState(eGameState::TELLHOUSE);
         playMusicByTypeForStateTransition(MUSIC_BRIEFING);
+    } else {
+        Logger::warn(COMP_GAME, "cGame::prepareMentatToTellAboutHouse", "cMentatState for TELLHOUSE already exists. Not creating a new one.");
     }
 }
 
 void cGame::loadScenario()
 {
-    auto *pState = dynamic_cast<cMentatState *>(m_states[GAME_BRIEFING]);
+    if (!m_creatorState->hasState(eGameState::BRIEFING)) {
+        Logger::error(COMP_GAME, "cGame::loadScenario", "Failed to load scenario because cMentatState is not yet created. Aborting.");
+        return;
+    }
+
+    auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getState(eGameState::BRIEFING));
     if (!pState) return; // state not yet created; prepareMentat() in the constructor will load the scenario
     pState->loadScenario(m_reinforcements.get());
 }

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -564,9 +564,6 @@ void cGame::shutdown()
         }
     }
 
-    // if (m_PreviewMaps != nullptr) {
-    //     m_PreviewMaps->destroy();
-    // }
 
     delete m_mapViewport;
 
@@ -1667,15 +1664,6 @@ void cGame::checkMissionWinOrFail()
 void cGame::loadMapFromEditor(int map)
 {
     setState(GAME_EDITOR);
-    auto *pState = dynamic_cast<cEditorState*>(m_states[GAME_EDITOR]);
-    // auto previewMaps = m_gameObjectsContext->getPreviewMaps();
-    // s_PreviewMap *selectedMap = &previewMaps->getMap(map);
+    auto *pState = dynamic_cast<cEditorState*>(m_creatorState->getState(eGameState::EDITOR));
     pState->loadMap(map);
 }
-
-// void cGame::loadMapFromEditor(s_PreviewMap *map)
-// {
-//     setState(GAME_EDITOR);
-//     auto *pState = dynamic_cast<cEditorState*>(m_states[GAME_EDITOR]);
-//     pState->loadMap(map);
-// }

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -782,10 +782,10 @@ void cGame::setState(int newState)
         return;
     }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     Logger::info(COMP_GAME, "cGame::setState", "Setting state from {}(={}) to {}(={})", m_state, stateToString(m_state), newState, stateToString(newState));
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
     if (newState > -1) {
         bool deleteOldState = (newState != GAME_REGION &&

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -753,7 +753,7 @@ bool cGame::isState(int thisState) const
 
 void cGame::jumpToSelectYourNextConquestMission(int missionNr)
 {
-    cGameState *state = m_creatorState->getState(eGameState::REGION, true);
+    cGameState *state = m_creatorState->getOrCreateState(eGameState::REGION, true);
     auto *pState = dynamic_cast<cSelectYourNextConquestState *>(state);
     if (!pState) {
         Logger::error(COMP_GAME, "cGame::jumpToSelectYourNextConquestMission", "Failed to create cSelectYourNextConquestState for mission {}. Aborting.", missionNr);
@@ -816,7 +816,7 @@ void cGame::setState(int newState)
             // make sure to delete options menu now
             cGameState *optionsState = nullptr;
             if (m_creatorState->hasState(eGameState::OPTIONS)) {
-                optionsState = m_creatorState->getState(eGameState::OPTIONS);
+                optionsState = m_creatorState->getOrCreateState(eGameState::OPTIONS);
             }
 
             if (m_currentState == optionsState) {
@@ -829,7 +829,7 @@ void cGame::setState(int newState)
             // make sure to delete options menu now
             cGameState *optionsState = nullptr;
             if (m_creatorState->hasState(eGameState::OPTIONS)) {
-                optionsState = m_creatorState->getState(eGameState::OPTIONS);
+                optionsState = m_creatorState->getOrCreateState(eGameState::OPTIONS);
             }
 
             if (m_currentState == optionsState) {
@@ -851,7 +851,7 @@ void cGame::setState(int newState)
                 m_creatorState->destroyState(targetCreatorState);
             }
             if (m_creatorState->hasState(targetCreatorState)) {
-                existingStatePtr = m_creatorState->getState(targetCreatorState);
+                existingStatePtr = m_creatorState->getOrCreateState(targetCreatorState);
             }
         }
 
@@ -917,7 +917,7 @@ void cGame::setState(int newState)
             cGameState *newStatePtr = nullptr;
 
             if (newState == GAME_REGION) {
-                auto *pState = dynamic_cast<cSelectYourNextConquestState *>(m_creatorState->getState(eGameState::REGION));
+                auto *pState = dynamic_cast<cSelectYourNextConquestState *>(m_creatorState->getOrCreateState(eGameState::REGION));
                 pState->calculateOffset();
                 Logger::info(COMP_INIT, "cGame::loadScenario", "Setup:  WORLD");
                 pState->installWorld();
@@ -932,29 +932,29 @@ void cGame::setState(int newState)
             }
             else if (newState == GAME_SETUPSKIRMISH) {
                 m_players->initPlayers(false, m_gameSettings.get(), m_dataCampaign.get(), m_services.get());
-                newStatePtr = m_creatorState->getState(eGameState::SETUPSKIRMISH);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::SETUPSKIRMISH);
                 playMusicByTypeForStateTransition(MUSIC_MENU);
             }
             else if (newState == GAME_CREDITS) {
-                newStatePtr = m_creatorState->getState(eGameState::CREDITS);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::CREDITS);
             }
             else if (newState == GAME_EDITOR) {
-                newStatePtr = m_creatorState->getState(eGameState::EDITOR);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::EDITOR);
             }
             else if (newState == GAME_MENU) {
                 m_gameSettings->m_cheatMode = false;
-                newStatePtr = m_creatorState->getState(eGameState::MENU);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::MENU);
                 playMusicByTypeForStateTransition(MUSIC_MENU);
             }
             else if (newState == GAME_NEW_MAP_EDITOR) {
-                newStatePtr = m_creatorState->getState(eGameState::NEW_MAP_EDITOR);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::NEW_MAP_EDITOR);
             }
             else if (newState == GAME_SELECT_HOUSE) {
-                newStatePtr = m_creatorState->getState(eGameState::SELECT_HOUSE);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::SELECT_HOUSE);
             }
             else if (newState == GAME_MISSIONSELECT) {
                 m_mouse->setTile(MOUSE_NORMAL);
-                newStatePtr = m_creatorState->getState(eGameState::MISSIONSELECT);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::MISSIONSELECT);
             }
             else if (newState == GAME_OPTIONS) {
                 takeBackGroundScreen();
@@ -967,7 +967,7 @@ void cGame::setState(int newState)
                 else {
                     // we fall back what was on screen, (which includes mouse cursor for now)
                 }
-                newStatePtr = m_creatorState->getState(eGameState::OPTIONS);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::OPTIONS);
             }
             else if (newState == GAME_PLAYING) {
                 if (m_state == GAME_OPTIONS) {
@@ -977,7 +977,7 @@ void cGame::setState(int newState)
                     humanPlayer->getGameControlsContext()->onFocusMouseStateEvent();
                 }
                 else {
-                    newStatePtr = m_creatorState->getState(eGameState::PLAYING);
+                    newStatePtr = m_creatorState->getOrCreateState(eGameState::PLAYING);
                     m_currentState = newStatePtr;
 
                     m_drawManager->reset();
@@ -997,25 +997,25 @@ void cGame::setState(int newState)
                 }
             }
             else if (newState == GAME_LOSING) {
-                newStatePtr = m_creatorState->getState(eGameState::LOSING);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::LOSING);
             }
             else if (newState == GAME_WINNING) {
-                newStatePtr = m_creatorState->getState(eGameState::WINNING);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::WINNING);
             }
             else if (newState == GAME_TELLHOUSE) {
                 m_dataCampaign->housePlayer = m_gameObjectsContext->getPlayer(HUMAN)->getHouse();
-                newStatePtr = m_creatorState->getState(eGameState::TELLHOUSE);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::TELLHOUSE);
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             }
             else if (newState == GAME_BRIEFING) {
                 m_gameSettings->m_cheatMode = false;
-                newStatePtr = m_creatorState->getState(eGameState::BRIEFING);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::BRIEFING);
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             } else if (newState == GAME_WINBRIEF) {
-                newStatePtr = m_creatorState->getState(eGameState::WINBRIEF);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::WINBRIEF);
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             } else if (newState == GAME_LOSEBRIEF) {
-                newStatePtr = m_creatorState->getState(eGameState::LOSEBRIEF);
+                newStatePtr = m_creatorState->getOrCreateState(eGameState::LOSEBRIEF);
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             }
 
@@ -1039,15 +1039,15 @@ void cGame::prepareMentatForPlayer()
     if (m_state == GAME_BRIEFING) {
         missionInit();
         setupPlayers();
-        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getState(eGameState::BRIEFING));
+        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getOrCreateState(eGameState::BRIEFING));
         pState->prepareMentat(m_dataCampaign->housePlayer);
     }
     else if (m_state == GAME_WINBRIEF) {
-        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getState(eGameState::WINBRIEF));
+        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getOrCreateState(eGameState::WINBRIEF));
         pState->prepareMentat(m_dataCampaign->housePlayer);
     }
     else if (m_state == GAME_LOSEBRIEF) {
-        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getState(eGameState::LOSEBRIEF));
+        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getOrCreateState(eGameState::LOSEBRIEF));
         pState->prepareMentat(m_dataCampaign->housePlayer);
     }
 }
@@ -1057,7 +1057,7 @@ void cGame::prepareMentatToTellAboutHouse(int house)
     m_gameObjectsContext->getPlayer(HUMAN)->setHouse(house);
     m_dataCampaign->housePlayer = house;
     if (!m_creatorState->hasState(eGameState::TELLHOUSE)) {
-        m_creatorState->getState(eGameState::TELLHOUSE);
+        m_creatorState->getOrCreateState(eGameState::TELLHOUSE);
         playMusicByTypeForStateTransition(MUSIC_BRIEFING);
     } else {
         Logger::warn(COMP_GAME, "cGame::prepareMentatToTellAboutHouse", "cMentatState for TELLHOUSE already exists. Not creating a new one.");
@@ -1071,7 +1071,7 @@ void cGame::loadScenario()
         return;
     }
 
-    auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getState(eGameState::BRIEFING));
+    auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getOrCreateState(eGameState::BRIEFING));
     if (!pState) return; // state not yet created; prepareMentat() in the constructor will load the scenario
     pState->loadScenario(m_reinforcements.get());
 }
@@ -1672,6 +1672,6 @@ void cGame::checkMissionWinOrFail()
 void cGame::loadMapFromEditor(int map)
 {
     setState(GAME_EDITOR);
-    auto *pState = dynamic_cast<cEditorState*>(m_creatorState->getState(eGameState::EDITOR));
+    auto *pState = dynamic_cast<cEditorState*>(m_creatorState->getOrCreateState(eGameState::EDITOR));
     pState->loadMap(map);
 }

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -133,6 +133,7 @@ void cGame::syncTextInputState() const
 
 cGame::cGame()
 {
+    m_state = -1;
     m_nextState = -1;
     m_currentState = nullptr;
 

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -110,7 +110,7 @@ bool isConsoleToggleTextInput(const cKeyboardEvent &event) {
 
     const std::string &textInput = event.getTextInput();
     return textInput == "`" || textInput == "~" || textInput == "²";
-}
+    }
 }
 
 bool cGame::shouldCaptureTextInput() const

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -781,7 +781,10 @@ void cGame::setState(int newState)
         return;
     }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     Logger::info(COMP_GAME, "cGame::setState", "Setting state from {}(={}) to {}(={})", m_state, stateToString(m_state), newState, stateToString(newState));
+#pragma clang diagnostic pop
 
     if (newState > -1) {
         bool deleteOldState = (newState != GAME_REGION &&

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -96,6 +96,7 @@
 #include "include/sGameServices.h"
 #include "game/cGameInterface.h"
 #include "game/cNotificationArea.h"
+#include "gamestates/cCreatorState.h"
 
 namespace {
 bool isConsoleToggleKey(const cKeyboardEvent &event) {
@@ -207,6 +208,8 @@ cGame::cGame()
     m_sideBarFactory = std::make_unique<cSideBarFactory>(m_buildingListFactory.get(), m_services.get());
 
     m_cIni = std::make_unique<cIni>(m_services.get());
+
+    m_creatorState = std::make_unique<CreatorState>(m_services.get(), m_cIni.get(), m_dataCampaign.get());
 }
 
 void cGame::applySettings(std::unique_ptr<InitialGameSettings> gs)

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -207,7 +207,7 @@ cGame::cGame()
 
     m_cIni = std::make_unique<cIni>(m_services.get());
 
-    m_creatorState = std::make_unique<CreatorState>(m_services.get(), m_cIni.get(), m_dataCampaign.get());
+    m_creatorState = std::make_unique<cCreatorState>(m_services.get(), m_cIni.get(), m_dataCampaign.get());
 }
 
 void cGame::applySettings(std::unique_ptr<InitialGameSettings> gs)

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -816,7 +816,7 @@ void cGame::setState(int newState)
             // make sure to delete options menu now
             cGameState *optionsState = nullptr;
             if (m_creatorState->hasState(eGameState::OPTIONS)) {
-                optionsState = m_creatorState->getOrCreateState(eGameState::OPTIONS);
+                optionsState = m_creatorState->getState(eGameState::OPTIONS);
             }
 
             if (m_currentState == optionsState) {
@@ -829,7 +829,7 @@ void cGame::setState(int newState)
             // make sure to delete options menu now
             cGameState *optionsState = nullptr;
             if (m_creatorState->hasState(eGameState::OPTIONS)) {
-                optionsState = m_creatorState->getOrCreateState(eGameState::OPTIONS);
+                optionsState = m_creatorState->getState(eGameState::OPTIONS);
             }
 
             if (m_currentState == optionsState) {
@@ -851,7 +851,7 @@ void cGame::setState(int newState)
                 m_creatorState->destroyState(targetCreatorState);
             }
             if (m_creatorState->hasState(targetCreatorState)) {
-                existingStatePtr = m_creatorState->getOrCreateState(targetCreatorState);
+                existingStatePtr = m_creatorState->getState(targetCreatorState);
             }
         }
 
@@ -917,7 +917,7 @@ void cGame::setState(int newState)
             cGameState *newStatePtr = nullptr;
 
             if (newState == GAME_REGION) {
-                auto *pState = dynamic_cast<cSelectYourNextConquestState *>(m_creatorState->getOrCreateState(eGameState::REGION));
+                auto *pState = dynamic_cast<cSelectYourNextConquestState *>(m_creatorState->getState(eGameState::REGION));
                 pState->calculateOffset();
                 Logger::info(COMP_INIT, "cGame::loadScenario", "Setup:  WORLD");
                 pState->installWorld();
@@ -932,29 +932,29 @@ void cGame::setState(int newState)
             }
             else if (newState == GAME_SETUPSKIRMISH) {
                 m_players->initPlayers(false, m_gameSettings.get(), m_dataCampaign.get(), m_services.get());
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::SETUPSKIRMISH);
+                newStatePtr = m_creatorState->getState(eGameState::SETUPSKIRMISH);
                 playMusicByTypeForStateTransition(MUSIC_MENU);
             }
             else if (newState == GAME_CREDITS) {
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::CREDITS);
+                newStatePtr = m_creatorState->getState(eGameState::CREDITS);
             }
             else if (newState == GAME_EDITOR) {
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::EDITOR);
+                newStatePtr = m_creatorState->getState(eGameState::EDITOR);
             }
             else if (newState == GAME_MENU) {
                 m_gameSettings->m_cheatMode = false;
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::MENU);
+                newStatePtr = m_creatorState->getState(eGameState::MENU);
                 playMusicByTypeForStateTransition(MUSIC_MENU);
             }
             else if (newState == GAME_NEW_MAP_EDITOR) {
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::NEW_MAP_EDITOR);
+                newStatePtr = m_creatorState->getState(eGameState::NEW_MAP_EDITOR);
             }
             else if (newState == GAME_SELECT_HOUSE) {
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::SELECT_HOUSE);
+                newStatePtr = m_creatorState->getState(eGameState::SELECT_HOUSE);
             }
             else if (newState == GAME_MISSIONSELECT) {
                 m_mouse->setTile(MOUSE_NORMAL);
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::MISSIONSELECT);
+                newStatePtr = m_creatorState->getState(eGameState::MISSIONSELECT);
             }
             else if (newState == GAME_OPTIONS) {
                 takeBackGroundScreen();
@@ -967,7 +967,7 @@ void cGame::setState(int newState)
                 else {
                     // we fall back what was on screen, (which includes mouse cursor for now)
                 }
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::OPTIONS);
+                newStatePtr = m_creatorState->getState(eGameState::OPTIONS);
             }
             else if (newState == GAME_PLAYING) {
                 if (m_state == GAME_OPTIONS) {
@@ -977,7 +977,7 @@ void cGame::setState(int newState)
                     humanPlayer->getGameControlsContext()->onFocusMouseStateEvent();
                 }
                 else {
-                    newStatePtr = m_creatorState->getOrCreateState(eGameState::PLAYING);
+                    newStatePtr = m_creatorState->getState(eGameState::PLAYING);
                     m_currentState = newStatePtr;
 
                     m_drawManager->reset();
@@ -997,25 +997,25 @@ void cGame::setState(int newState)
                 }
             }
             else if (newState == GAME_LOSING) {
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::LOSING);
+                newStatePtr = m_creatorState->getState(eGameState::LOSING);
             }
             else if (newState == GAME_WINNING) {
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::WINNING);
+                newStatePtr = m_creatorState->getState(eGameState::WINNING);
             }
             else if (newState == GAME_TELLHOUSE) {
                 m_dataCampaign->housePlayer = m_gameObjectsContext->getPlayer(HUMAN)->getHouse();
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::TELLHOUSE);
+                newStatePtr = m_creatorState->getState(eGameState::TELLHOUSE);
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             }
             else if (newState == GAME_BRIEFING) {
                 m_gameSettings->m_cheatMode = false;
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::BRIEFING);
+                newStatePtr = m_creatorState->getState(eGameState::BRIEFING);
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             } else if (newState == GAME_WINBRIEF) {
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::WINBRIEF);
+                newStatePtr = m_creatorState->getState(eGameState::WINBRIEF);
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             } else if (newState == GAME_LOSEBRIEF) {
-                newStatePtr = m_creatorState->getOrCreateState(eGameState::LOSEBRIEF);
+                newStatePtr = m_creatorState->getState(eGameState::LOSEBRIEF);
                 playMusicByTypeForStateTransition(MUSIC_BRIEFING);
             }
 
@@ -1039,15 +1039,15 @@ void cGame::prepareMentatForPlayer()
     if (m_state == GAME_BRIEFING) {
         missionInit();
         setupPlayers();
-        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getOrCreateState(eGameState::BRIEFING));
+        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getState(eGameState::BRIEFING));
         pState->prepareMentat(m_dataCampaign->housePlayer);
     }
     else if (m_state == GAME_WINBRIEF) {
-        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getOrCreateState(eGameState::WINBRIEF));
+        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getState(eGameState::WINBRIEF));
         pState->prepareMentat(m_dataCampaign->housePlayer);
     }
     else if (m_state == GAME_LOSEBRIEF) {
-        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getOrCreateState(eGameState::LOSEBRIEF));
+        auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getState(eGameState::LOSEBRIEF));
         pState->prepareMentat(m_dataCampaign->housePlayer);
     }
 }
@@ -1057,7 +1057,7 @@ void cGame::prepareMentatToTellAboutHouse(int house)
     m_gameObjectsContext->getPlayer(HUMAN)->setHouse(house);
     m_dataCampaign->housePlayer = house;
     if (!m_creatorState->hasState(eGameState::TELLHOUSE)) {
-        m_creatorState->getOrCreateState(eGameState::TELLHOUSE);
+        m_creatorState->getState(eGameState::TELLHOUSE);
         playMusicByTypeForStateTransition(MUSIC_BRIEFING);
     } else {
         Logger::warn(COMP_GAME, "cGame::prepareMentatToTellAboutHouse", "cMentatState for TELLHOUSE already exists. Not creating a new one.");
@@ -1071,7 +1071,7 @@ void cGame::loadScenario()
         return;
     }
 
-    auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getOrCreateState(eGameState::BRIEFING));
+    auto *pState = dynamic_cast<cMentatState *>(m_creatorState->getState(eGameState::BRIEFING));
     if (!pState) return; // state not yet created; prepareMentat() in the constructor will load the scenario
     pState->loadScenario(m_reinforcements.get());
 }
@@ -1672,6 +1672,6 @@ void cGame::checkMissionWinOrFail()
 void cGame::loadMapFromEditor(int map)
 {
     setState(GAME_EDITOR);
-    auto *pState = dynamic_cast<cEditorState*>(m_creatorState->getOrCreateState(eGameState::EDITOR));
+    auto *pState = dynamic_cast<cEditorState*>(m_creatorState->getState(eGameState::EDITOR));
     pState->loadMap(map);
 }

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -22,8 +22,12 @@
 #include "context/cGameObjectContext.h"
 #include "include/cAssert.h"
 
-cCreatorState::cCreatorState(sGameServices *services, cIni *ini, s_DataCampaign *dataCampaign)
-    : m_services(services) {
+cCreatorState::cCreatorState(sGameServices *services, cIni *ini, s_DataCampaign *dataCampaign) :
+    m_services(services),
+    m_dataCampaign(dataCampaign),
+    m_interface(m_services->ctx->getGameInterface()),
+    m_cIni(ini)
+{
     d2tm_assert(m_services != nullptr);
     d2tm_assert(m_cIni != nullptr);
     d2tm_assert(m_dataCampaign != nullptr);

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -88,7 +88,7 @@ void CreatorState::createStateFromScratch(eGameState gameState)
         break;
 
     case eGameState::WINNING:
-        m_states[eGameState::WINNING] = std::make_unique<cWinLoseState>(m_services, Outcome::Lose);
+        m_states[eGameState::WINNING] = std::make_unique<cWinLoseState>(m_services, Outcome::Win);
         break;
 
     case eGameState::LOSING:

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -70,6 +70,11 @@ cGameState* CreatorState::getState(eGameState gameState, bool forceRecreate)
     }
 }
 
+bool CreatorState::hasState(eGameState gameState) const
+{
+    return m_states[gameState].has_value();
+}
+
 void CreatorState::destroyState(eGameState gameState)
 {
     m_states[gameState].reset();

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -38,8 +38,8 @@ cCreatorState::~cCreatorState() {
 }
 
 
-cGameState *cCreatorState::getState(eGameState gameState, bool forceRecreate) {
-    // no existing state ...
+cGameState *cCreatorState::getOrCreateState(eGameState gameState, bool forceRecreate) {
+
     if (!m_states[gameState].has_value()) {
         createStateFromScratch(gameState);
         return m_states[gameState].value().get();

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -27,6 +27,8 @@ CreatorState::CreatorState(sGameServices* services, cIni* ini, s_DataCampaign* d
     m_cIni = ini;
     d2tm_assert(m_cIni != nullptr);
     d2tm_assert(m_dataCampaign != nullptr);
+    m_interface = m_services->ctx->getGameInterface();
+    d2tm_assert(m_interface != nullptr);
     // all State should be recreate when needed to use
     needToRecreateState.fill(true);
     // this States should not be recreated when we need to use

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -84,7 +84,7 @@ void CreatorState::createStateFromScratch(eGameState gameState)
         break;
 
     case eGameState::NEW_MAP_EDITOR:
-        m_states[eGameState::EDITOR] = std::make_unique<cNewMapEditorState>(m_services);
+        m_states[eGameState::NEW_MAP_EDITOR] = std::make_unique<cNewMapEditorState>(m_services);
         break;
 
     case eGameState::WINNING:

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -25,15 +25,14 @@
 cCreatorState::cCreatorState(sGameServices* services, cIni* ini, s_DataCampaign* dataCampaign)
     : m_services(services)
 {
-    m_dataCampaign = dataCampaign;
     d2tm_assert(m_services != nullptr);
-    m_cIni = ini;
     d2tm_assert(m_cIni != nullptr);
     d2tm_assert(m_dataCampaign != nullptr);
-    m_interface = m_services->ctx->getGameInterface();
     d2tm_assert(m_interface != nullptr);
-    // Reuse states by default. Recreate only when explicitly requested via forceRecreate.
-    needToRecreateState.fill(false);
+
+    m_dataCampaign = dataCampaign;
+    m_cIni = ini;
+    m_interface = m_services->ctx->getGameInterface();
 }
 
 cCreatorState::~cCreatorState()
@@ -51,12 +50,10 @@ cGameState* cCreatorState::getState(eGameState gameState, bool forceRecreate)
     }
 
     // state already exist
-    if (needToRecreateState[gameState] || forceRecreate) {
+    if (forceRecreate) {
         createStateFromScratch(gameState);
-        return m_states[gameState].value().get();
-    } else {
-        return m_states[gameState].value().get();
     }
+    return m_states[gameState].value().get();
 }
 
 bool cCreatorState::hasState(eGameState gameState) const

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -14,6 +14,8 @@
 #include "gamestates/cGamePlaying.h"
 #include "gamestates/cSelectYourNextConquestState.h"
 #include "gamestates/cOptionsState.h"
+#include "gamestates/cSelectMissionState.h"
+#include "gamestates/cSetupSkirmishState.h"
 #include "game/cGameInterface.h"
 
 #include "context/GameContext.hpp"
@@ -125,6 +127,17 @@ void CreatorState::createStateFromScratch(eGameState gameState)
 
     case eGameState::OPTIONS:
         m_states[eGameState::OPTIONS] = std::make_unique<cOptionsState>(m_services, m_interface->getCurrentState());
+        break;
+
+    case eGameState::MISSIONSELECT:
+        m_states[eGameState::MISSIONSELECT] = std::make_unique<cSelectMissionState>(m_services, m_interface->getCurrentState());
+        break;
+
+    case eGameState::SETUPSKIRMISH:
+        m_states[eGameState::SETUPSKIRMISH] = std::make_unique<cSetupSkirmishState>(
+            m_services,
+            m_services->objects->getPreviewMaps(),
+            m_dataCampaign);
         break;
 
     // @mira : i prefer to rip default mode and have the compiler tell me what I've forgotten

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -155,7 +155,7 @@ void CreatorState::createStateFromScratch(eGameState gameState)
 
     // @mira : i prefer to rip default mode and have the compiler tell me what I've forgotten
     default:
-        Logger::error(COMP_SETUP, "CreatorState", "Forget gameState {}",gameStateToString(gameState));
+        Logger::fatal(COMP_SETUP, "CreatorState", "Forget gameState {}",gameStateToString(gameState));
         break;
     }
 }

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -48,15 +48,12 @@ cGameState *cCreatorState::getState(eGameState gameState) {
 
 cGameState *cCreatorState::getOrCreateState(eGameState gameState, bool forceRecreate) {
 
-    if (!m_states[gameState].has_value()) {
+    if (!hasState(gameState)) {
         createStateFromScratch(gameState);
-        return m_states[gameState].value().get();
+    } else if (forceRecreate) {
+        createStateFromScratch(gameState);
     }
 
-    // state already exist
-    if (forceRecreate) {
-        createStateFromScratch(gameState);
-    }
     return m_states[gameState].value().get();
 }
 

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -70,6 +70,18 @@ cGameState* CreatorState::getState(eGameState gameState, bool forceRecreate)
     }
 }
 
+void CreatorState::destroyState(eGameState gameState)
+{
+    m_states[gameState].reset();
+}
+
+void CreatorState::destroyAllStates()
+{
+    for (int i = 0; i < static_cast<int>(eGameState::COUNT); ++i) {
+        destroyState(static_cast<eGameState>(i));
+    }
+}
+
 void CreatorState::createStateFromScratch(eGameState gameState)
 {
     switch (gameState)

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -38,6 +38,10 @@ cCreatorState::~cCreatorState() {
 }
 
 
+cGameState *cCreatorState::getState(eGameState gameState) {
+    return getOrCreateState(gameState, false);
+}
+
 cGameState *cCreatorState::getOrCreateState(eGameState gameState, bool forceRecreate) {
 
     if (!m_states[gameState].has_value()) {

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -19,6 +19,7 @@
 #include "game/cGameInterface.h"
 
 #include "context/GameContext.hpp"
+#include "context/cGameObjectContext.h"
 #include "include/cAssert.h"
 
 CreatorState::CreatorState(sGameServices* services, cIni* ini, s_DataCampaign* dataCampaign)

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -22,7 +22,7 @@
 #include "context/cGameObjectContext.h"
 #include "include/cAssert.h"
 
-CreatorState::CreatorState(sGameServices* services, cIni* ini, s_DataCampaign* dataCampaign)
+cCreatorState::cCreatorState(sGameServices* services, cIni* ini, s_DataCampaign* dataCampaign)
     : m_services(services)
 {
     m_dataCampaign = dataCampaign;
@@ -36,13 +36,13 @@ CreatorState::CreatorState(sGameServices* services, cIni* ini, s_DataCampaign* d
     needToRecreateState.fill(false);
 }
 
-CreatorState::~CreatorState()
+cCreatorState::~cCreatorState()
 {
 
 }
 
 
-cGameState* CreatorState::getState(eGameState gameState, bool forceRecreate)
+cGameState* cCreatorState::getState(eGameState gameState, bool forceRecreate)
 {
     // no existing state ...
     if (!m_states[gameState].has_value()) {
@@ -59,24 +59,24 @@ cGameState* CreatorState::getState(eGameState gameState, bool forceRecreate)
     }
 }
 
-bool CreatorState::hasState(eGameState gameState) const
+bool cCreatorState::hasState(eGameState gameState) const
 {
     return m_states[gameState].has_value();
 }
 
-void CreatorState::destroyState(eGameState gameState)
+void cCreatorState::destroyState(eGameState gameState)
 {
     m_states[gameState].reset();
 }
 
-void CreatorState::destroyAllStates()
+void cCreatorState::destroyAllStates()
 {
     for (int i = 0; i < static_cast<int>(eGameState::COUNT); ++i) {
         destroyState(static_cast<eGameState>(i));
     }
 }
 
-void CreatorState::createStateFromScratch(eGameState gameState)
+void cCreatorState::createStateFromScratch(eGameState gameState)
 {
     switch (gameState)
     {

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -22,9 +22,8 @@
 #include "context/cGameObjectContext.h"
 #include "include/cAssert.h"
 
-cCreatorState::cCreatorState(sGameServices* services, cIni* ini, s_DataCampaign* dataCampaign)
-    : m_services(services)
-{
+cCreatorState::cCreatorState(sGameServices *services, cIni *ini, s_DataCampaign *dataCampaign)
+    : m_services(services) {
     d2tm_assert(m_services != nullptr);
     d2tm_assert(m_cIni != nullptr);
     d2tm_assert(m_dataCampaign != nullptr);
@@ -35,14 +34,11 @@ cCreatorState::cCreatorState(sGameServices* services, cIni* ini, s_DataCampaign*
     m_interface = m_services->ctx->getGameInterface();
 }
 
-cCreatorState::~cCreatorState()
-{
-
+cCreatorState::~cCreatorState() {
 }
 
 
-cGameState* cCreatorState::getState(eGameState gameState, bool forceRecreate)
-{
+cGameState *cCreatorState::getState(eGameState gameState, bool forceRecreate) {
     // no existing state ...
     if (!m_states[gameState].has_value()) {
         createStateFromScratch(gameState);
@@ -56,97 +52,97 @@ cGameState* cCreatorState::getState(eGameState gameState, bool forceRecreate)
     return m_states[gameState].value().get();
 }
 
-bool cCreatorState::hasState(eGameState gameState) const
-{
+bool cCreatorState::hasState(eGameState gameState) const {
     return m_states[gameState].has_value();
 }
 
-void cCreatorState::destroyState(eGameState gameState)
-{
+void cCreatorState::destroyState(eGameState gameState) {
     m_states[gameState].reset();
 }
 
-void cCreatorState::destroyAllStates()
-{
+void cCreatorState::destroyAllStates() {
     for (int i = 0; i < static_cast<int>(eGameState::COUNT); ++i) {
         destroyState(static_cast<eGameState>(i));
     }
 }
 
-void cCreatorState::createStateFromScratch(eGameState gameState)
-{
-    switch (gameState)
-    {
-    case eGameState::MENU:
-        m_states[eGameState::MENU] = std::make_unique<cMainMenuState>(m_services);
-        break;
+void cCreatorState::createStateFromScratch(eGameState gameState) {
+    switch (gameState) {
+        case eGameState::MENU:
+            m_states[eGameState::MENU] = std::make_unique<cMainMenuState>(m_services);
+            break;
 
-    case eGameState::CREDITS:
-        m_states[eGameState::CREDITS] = std::make_unique<cCreditsState>(m_services);
-        break;
+        case eGameState::CREDITS:
+            m_states[eGameState::CREDITS] = std::make_unique<cCreditsState>(m_services);
+            break;
 
-    case eGameState::EDITOR:
-        m_states[eGameState::EDITOR] = std::make_unique<cEditorState>(m_services);
-        break;
+        case eGameState::EDITOR:
+            m_states[eGameState::EDITOR] = std::make_unique<cEditorState>(m_services);
+            break;
 
-    case eGameState::NEW_MAP_EDITOR:
-        m_states[eGameState::NEW_MAP_EDITOR] = std::make_unique<cNewMapEditorState>(m_services);
-        break;
+        case eGameState::NEW_MAP_EDITOR:
+            m_states[eGameState::NEW_MAP_EDITOR] = std::make_unique<cNewMapEditorState>(m_services);
+            break;
 
-    case eGameState::WINNING:
-        m_states[eGameState::WINNING] = std::make_unique<cWinLoseState>(m_services, Outcome::Win);
-        break;
+        case eGameState::WINNING:
+            m_states[eGameState::WINNING] = std::make_unique<cWinLoseState>(m_services, Outcome::Win);
+            break;
 
-    case eGameState::LOSING:
-        m_states[eGameState::LOSING] = std::make_unique<cWinLoseState>(m_services, Outcome::Lose);
-        break;
+        case eGameState::LOSING:
+            m_states[eGameState::LOSING] = std::make_unique<cWinLoseState>(m_services, Outcome::Lose);
+            break;
 
-    case eGameState::BRIEFING:
-        m_states[eGameState::BRIEFING] = std::make_unique<cMentatState>(m_services, MentatMode::Briefing, m_cIni, m_dataCampaign);
-        break;
+        case eGameState::BRIEFING:
+            m_states[eGameState::BRIEFING] = std::make_unique<cMentatState>(
+                m_services, MentatMode::Briefing, m_cIni, m_dataCampaign);
+            break;
 
-    case eGameState::WINBRIEF:
-        m_states[eGameState::WINBRIEF] = std::make_unique<cMentatState>(m_services, MentatMode::WinBrief, m_cIni, m_dataCampaign);
-        break;
+        case eGameState::WINBRIEF:
+            m_states[eGameState::WINBRIEF] = std::make_unique<cMentatState>(
+                m_services, MentatMode::WinBrief, m_cIni, m_dataCampaign);
+            break;
 
-    case eGameState::LOSEBRIEF:
-        m_states[eGameState::LOSEBRIEF] = std::make_unique<cMentatState>(m_services, MentatMode::LoseBrief, m_cIni, m_dataCampaign);
-        break;
+        case eGameState::LOSEBRIEF:
+            m_states[eGameState::LOSEBRIEF] = std::make_unique<cMentatState>(
+                m_services, MentatMode::LoseBrief, m_cIni, m_dataCampaign);
+            break;
 
-    case eGameState::TELLHOUSE:
-        m_states[eGameState::TELLHOUSE] = std::make_unique<cTellHouseState>(m_services, m_cIni, m_dataCampaign);
-        break;
+        case eGameState::TELLHOUSE:
+            m_states[eGameState::TELLHOUSE] = std::make_unique<cTellHouseState>(m_services, m_cIni, m_dataCampaign);
+            break;
 
-    case eGameState::SELECT_HOUSE:
-        m_states[eGameState::SELECT_HOUSE] = std::make_unique<cChooseHouseState>(m_services);
-        break;
+        case eGameState::SELECT_HOUSE:
+            m_states[eGameState::SELECT_HOUSE] = std::make_unique<cChooseHouseState>(m_services);
+            break;
 
-    case eGameState::REGION:
-        m_states[eGameState::REGION] = std::make_unique<cSelectYourNextConquestState>(m_services, m_cIni, m_dataCampaign);
-        break;
+        case eGameState::REGION:
+            m_states[eGameState::REGION] = std::make_unique<cSelectYourNextConquestState>(
+                m_services, m_cIni, m_dataCampaign);
+            break;
 
-    case eGameState::PLAYING:
-        m_states[eGameState::PLAYING] = std::make_unique<cGamePlaying>(m_services);
-        break;
+        case eGameState::PLAYING:
+            m_states[eGameState::PLAYING] = std::make_unique<cGamePlaying>(m_services);
+            break;
 
-    case eGameState::OPTIONS:
-        m_states[eGameState::OPTIONS] = std::make_unique<cOptionsState>(m_services, m_interface->getCurrentState());
-        break;
+        case eGameState::OPTIONS:
+            m_states[eGameState::OPTIONS] = std::make_unique<cOptionsState>(m_services, m_interface->getCurrentState());
+            break;
 
-    case eGameState::MISSIONSELECT:
-        m_states[eGameState::MISSIONSELECT] = std::make_unique<cSelectMissionState>(m_services, m_interface->getCurrentState());
-        break;
+        case eGameState::MISSIONSELECT:
+            m_states[eGameState::MISSIONSELECT] = std::make_unique<cSelectMissionState>(
+                m_services, m_interface->getCurrentState());
+            break;
 
-    case eGameState::SETUPSKIRMISH:
-        m_states[eGameState::SETUPSKIRMISH] = std::make_unique<cSetupSkirmishState>(
-            m_services,
-            m_services->objects->getPreviewMaps(),
-            m_dataCampaign);
-        break;
+        case eGameState::SETUPSKIRMISH:
+            m_states[eGameState::SETUPSKIRMISH] = std::make_unique<cSetupSkirmishState>(
+                m_services,
+                m_services->objects->getPreviewMaps(),
+                m_dataCampaign);
+            break;
 
-    // @mira : i prefer to rip default mode and have the compiler tell me what I've forgotten
-    default:
-        Logger::fatal(COMP_SETUP, "CreatorState", "Forget gameState {}",gameStateToString(gameState));
-        break;
+        // @mira : i prefer to rip default mode and have the compiler tell me what I've forgotten
+        default:
+            Logger::fatal(COMP_SETUP, "CreatorState", "Forget gameState {}", gameStateToString(gameState));
+            break;
     }
 }

--- a/src/gamestates/cCreatorState.cpp
+++ b/src/gamestates/cCreatorState.cpp
@@ -32,19 +32,8 @@ CreatorState::CreatorState(sGameServices* services, cIni* ini, s_DataCampaign* d
     d2tm_assert(m_dataCampaign != nullptr);
     m_interface = m_services->ctx->getGameInterface();
     d2tm_assert(m_interface != nullptr);
-    // all State should be recreate when needed to use
-    needToRecreateState.fill(true);
-    // this States should not be recreated when we need to use
-    needToRecreateState[eGameState::OPTIONS] = false;
-    needToRecreateState[eGameState::PLAYING] = false;
-    needToRecreateState[eGameState::SETUPSKIRMISH] = false;
-    needToRecreateState[eGameState::CREDITS] = false;
-    needToRecreateState[eGameState::MISSIONSELECT] = false;
-    needToRecreateState[eGameState::MENU] = false;
-    needToRecreateState[eGameState::EDITOR] = false;
-    needToRecreateState[eGameState::NEW_MAP_EDITOR] = false;
-    needToRecreateState[eGameState::WINNING] = false;
-    needToRecreateState[eGameState::LOSING] = false;
+    // Reuse states by default. Recreate only when explicitly requested via forceRecreate.
+    needToRecreateState.fill(false);
 }
 
 CreatorState::~CreatorState()

--- a/src/gamestates/cCreatorState.h
+++ b/src/gamestates/cCreatorState.h
@@ -18,6 +18,8 @@ public:
 
     ~cCreatorState();
 
+    cGameState *getState(eGameState gameState);
+
     cGameState *getOrCreateState(eGameState gameState, bool forceRecreate = false);
 
     [[nodiscard]] bool hasState(eGameState gameState) const;

--- a/src/gamestates/cCreatorState.h
+++ b/src/gamestates/cCreatorState.h
@@ -24,7 +24,6 @@ public:
 
 private:
     EnumArray<std::optional<std::unique_ptr<cGameState>>,eGameState> m_states;
-    EnumArray<bool, eGameState> needToRecreateState;
     sGameServices* m_services = nullptr;
     s_DataCampaign* m_dataCampaign = nullptr;
     cGameInterface* m_interface = nullptr;

--- a/src/gamestates/cCreatorState.h
+++ b/src/gamestates/cCreatorState.h
@@ -19,6 +19,8 @@ public:
     ~CreatorState();
 
     cGameState *getState(eGameState gameState, bool forceRecreate = false);
+    void destroyState(eGameState gameState);
+    void destroyAllStates();
 private:
     //cGameState *m_states[GameState::MAX];
     EnumArray<std::optional<std::unique_ptr<cGameState>>,eGameState> m_states;

--- a/src/gamestates/cCreatorState.h
+++ b/src/gamestates/cCreatorState.h
@@ -18,7 +18,7 @@ public:
 
     ~cCreatorState();
 
-    cGameState *getState(eGameState gameState, bool forceRecreate = false);
+    cGameState *getOrCreateState(eGameState gameState, bool forceRecreate = false);
 
     [[nodiscard]] bool hasState(eGameState gameState) const;
 

--- a/src/gamestates/cCreatorState.h
+++ b/src/gamestates/cCreatorState.h
@@ -14,20 +14,24 @@ class cIni;
 
 class cCreatorState {
 public:
-    explicit cCreatorState(sGameServices* services, cIni* ini, s_DataCampaign* dataCampaign);
+    explicit cCreatorState(sGameServices *services, cIni *ini, s_DataCampaign *dataCampaign);
+
     ~cCreatorState();
 
     cGameState *getState(eGameState gameState, bool forceRecreate = false);
+
     [[nodiscard]] bool hasState(eGameState gameState) const;
+
     void destroyState(eGameState gameState);
+
     void destroyAllStates();
 
 private:
-    EnumArray<std::optional<std::unique_ptr<cGameState>>,eGameState> m_states;
-    sGameServices* m_services = nullptr;
-    s_DataCampaign* m_dataCampaign = nullptr;
-    cGameInterface* m_interface = nullptr;
-    cIni* m_cIni = nullptr;
+    EnumArray<std::optional<std::unique_ptr<cGameState> >, eGameState> m_states;
+    sGameServices *m_services = nullptr;
+    s_DataCampaign *m_dataCampaign = nullptr;
+    cGameInterface *m_interface = nullptr;
+    cIni *m_cIni = nullptr;
 
     void createStateFromScratch(eGameState gameState);
 };

--- a/src/gamestates/cCreatorState.h
+++ b/src/gamestates/cCreatorState.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "include/enums.h"
 #include "include/eGameState.h"
 #include "gamestates/cGameState.h"
 #include "utils/cEnumArray.h"
@@ -13,22 +12,23 @@ class GameContext;
 class cGameInterface;
 class cIni;
 
-class CreatorState {
+class cCreatorState {
 public:
-    explicit CreatorState(sGameServices* services, cIni* ini, s_DataCampaign* dataCampaign);
-    ~CreatorState();
+    explicit cCreatorState(sGameServices* services, cIni* ini, s_DataCampaign* dataCampaign);
+    ~cCreatorState();
 
     cGameState *getState(eGameState gameState, bool forceRecreate = false);
-    bool hasState(eGameState gameState) const;
+    [[nodiscard]] bool hasState(eGameState gameState) const;
     void destroyState(eGameState gameState);
     void destroyAllStates();
+
 private:
-    //cGameState *m_states[GameState::MAX];
     EnumArray<std::optional<std::unique_ptr<cGameState>>,eGameState> m_states;
     EnumArray<bool, eGameState> needToRecreateState;
-    void createStateFromScratch(eGameState gameState);
     sGameServices* m_services = nullptr;
     s_DataCampaign* m_dataCampaign = nullptr;
     cGameInterface* m_interface = nullptr;
     cIni* m_cIni = nullptr;
+
+    void createStateFromScratch(eGameState gameState);
 };

--- a/src/gamestates/cCreatorState.h
+++ b/src/gamestates/cCreatorState.h
@@ -19,6 +19,7 @@ public:
     ~CreatorState();
 
     cGameState *getState(eGameState gameState, bool forceRecreate = false);
+    bool hasState(eGameState gameState) const;
     void destroyState(eGameState gameState);
     void destroyAllStates();
 private:

--- a/src/gamestates/cGameState.cpp
+++ b/src/gamestates/cGameState.cpp
@@ -11,6 +11,27 @@ cGameState::cGameState(sGameServices* services) :
     d2tm_assert(m_ctx != nullptr);
 }
 
+const char *gameStateToString(eGameStateType state)
+{
+    switch (state) {
+        case GAMESTATE_CHOOSE_HOUSE: return "GAMESTATE_CHOOSE_HOUSE";
+        case GAMESTATE_CREDITS: return "GAMESTATE_CREDITS";
+        case GAMESTATE_EDITOR: return "GAMESTATE_EDITOR";
+        case GAMESTATE_NEW_MAP_EDITOR: return "GAMESTATE_NEW_MAP_EDITOR";
+        case GAMESTATE_MAIN_MENU: return "GAMESTATE_MAIN_MENU";
+        case GAMESTATE_MENTAT: return "GAMESTATE_MENTAT";
+        case GAMESTATE_OPTIONS: return "GAMESTATE_OPTIONS";
+        case GAMESTATE_PLAYING: return "GAMESTATE_PLAYING";
+        case GAMESTATE_SELECT_MISSION: return "GAMESTATE_SELECT_MISSION";
+        case GAMESTATE_SELECT_YOUR_NEXT_CONQUEST: return "GAMESTATE_SELECT_YOUR_NEXT_CONQUEST";
+        case GAMESTATE_SETUP_SKIRMISH: return "GAMESTATE_SETUP_SKIRMISH";
+        case GAMESTATE_TELLHOUSE: return "GAMESTATE_TELLHOUSE";
+        case GAMESTATE_WINLOSE: return "GAMESTATE_WINLOSE";
+    }
+    // Handling unrecognized values ​​(if the enum is cast from an arbitrary character)
+    return "Unknown GameState value";
+}
+
 
 const char *gameStateToString(eGameState state)
 {

--- a/src/gamestates/cGameState.cpp
+++ b/src/gamestates/cGameState.cpp
@@ -11,7 +11,7 @@ cGameState::cGameState(sGameServices* services) :
     d2tm_assert(m_ctx != nullptr);
 }
 
-const char *gameStateToString(eGameStateType state)
+const char *gameStateTypeToString(eGameStateType state)
 {
     switch (state) {
         case GAMESTATE_CHOOSE_HOUSE: return "GAMESTATE_CHOOSE_HOUSE";
@@ -30,38 +30,6 @@ const char *gameStateToString(eGameStateType state)
     }
     // Handling unrecognized values ​​(if the enum is cast from an arbitrary character)
     return "Unknown GameState value";
-}
-
-
-const char *gameStateToString(eGameState state)
-{
-    switch (state) {
-        case eGameState::INITIALIZE: return "INITIALIZE";
-        case eGameState::OVER: return "OVER";
-        case eGameState::MENU: return "MENU";
-        case eGameState::PLAYING: return "PLAYING";
-        case eGameState::BRIEFING: return "BRIEFING";
-        case eGameState::EDITOR: return "EDITOR";
-        case eGameState::NEW_MAP_EDITOR: return "NEW_MAP_EDITOR";
-        case eGameState::OPTIONS: return "OPTIONS";
-        case eGameState::REGION: return "REGION";
-        case eGameState::SELECT_HOUSE: return "SELECT_HOUSE";
-        case eGameState::INTRO: return "INTRO";
-        case eGameState::TELLHOUSE: return "TELLHOUSE";
-        case eGameState::WINNING: return "WINNING";
-        case eGameState::WINBRIEF: return "WINBRIEF";
-        case eGameState::LOSEBRIEF: return "LOSEBRIEF";
-        case eGameState::LOSING: return "LOSING";
-        case eGameState::SKIRMISH: return "SKIRMISH";
-        case eGameState::SETUPSKIRMISH: return "SETUPSKIRMISH";
-        case eGameState::CREDITS: return "CREDITS";
-        case eGameState::MISSIONSELECT: return "MISSIONSELECT";
-        // COUNT is not a valid state for the game, but it is for the iteration.
-        // We return a special string. Maybe an out of range error is better ?
-        case eGameState::COUNT: return "[Error: GameState::COUNT]";
-    }
-    // Handling unrecognized values ​​(if the enum is cast from an arbitrary character)
-    throw std::out_of_range("Unknown GameState value");
 }
 
 void cGameState::thinkNormal()

--- a/src/gamestates/cGameState.h
+++ b/src/gamestates/cGameState.h
@@ -30,7 +30,7 @@ enum eGameStateType {
                                             // #define GAME_WINBRIEF    12      // mentat chatter when won the mission
 };
 
-const char *gameStateToString(eGameStateType state);
+const char *gameStateTypeToString(eGameStateType state);
 // #define GAME_INITIALIZE  -1      // initialize game
 // #define GAME_OVER         0      // game over
 
@@ -70,5 +70,3 @@ protected:
 private:
 
 };
-
-const char *gameStateToString(eGameState state);

--- a/src/gamestates/cGameState.h
+++ b/src/gamestates/cGameState.h
@@ -30,6 +30,7 @@ enum eGameStateType {
                                             // #define GAME_WINBRIEF    12      // mentat chatter when won the mission
 };
 
+const char *gameStateToString(eGameStateType state);
 // #define GAME_INITIALIZE  -1      // initialize game
 // #define GAME_OVER         0      // game over
 

--- a/src/gamestates/cMentatState.cpp
+++ b/src/gamestates/cMentatState.cpp
@@ -23,7 +23,7 @@ cMentatState::cMentatState(sGameServices* services, MentatMode mode, cIni* cini,
       m_dataCampaign(dataCampaign),
       m_settings(services->settings),
       m_interface(m_ctx->getGameInterface()),
-      m_objets(services->objects),
+      m_objects(services->objects),
       m_cIni(cini),
       m_mode(mode),
       m_house(dataCampaign->housePlayer)
@@ -32,7 +32,7 @@ cMentatState::cMentatState(sGameServices* services, MentatMode mode, cIni* cini,
     d2tm_assert(m_dataCampaign != nullptr);
     d2tm_assert(m_settings != nullptr);
     d2tm_assert(m_interface != nullptr);
-    d2tm_assert(m_objets != nullptr);
+    d2tm_assert(m_objects != nullptr);
     d2tm_assert(m_cIni != nullptr);
     prepareMentat(m_house);
 }
@@ -47,7 +47,7 @@ eGameStateType cMentatState::getType()
 
 void cMentatState::prepareMentat(int house)
 {
-    auto* humanPlayer = m_objets->getPlayer(HUMAN);
+    auto* humanPlayer = m_objects->getPlayer(HUMAN);
     house = (m_house > GENERALHOUSE) ? m_house : humanPlayer->getHouse();
     bool allowMissionSelect = !m_settings->isSkirmish();
     switch (m_mode) {

--- a/src/gamestates/cMentatState.cpp
+++ b/src/gamestates/cMentatState.cpp
@@ -26,7 +26,8 @@ cMentatState::cMentatState(sGameServices* services, MentatMode mode, cIni* cini,
       m_objects(services->objects),
       m_cIni(cini),
       m_mode(mode),
-      m_house(dataCampaign->housePlayer)
+      m_house(dataCampaign->housePlayer),
+      m_allowMissionSelect(!m_settings->isSkirmish())
 {
     d2tm_assert(services != nullptr);
     d2tm_assert(m_dataCampaign != nullptr);
@@ -49,17 +50,16 @@ void cMentatState::prepareMentat(int house)
 {
     auto* humanPlayer = m_objects->getPlayer(HUMAN);
     house = (m_house > GENERALHOUSE) ? m_house : humanPlayer->getHouse();
-    bool allowMissionSelect = !m_settings->isSkirmish();
     switch (m_mode) {
         case MentatMode::Briefing:
             if (house == ATREIDES)
-                m_mentat = std::make_unique<AtreidesMentat>(m_ctx, allowMissionSelect);
+                m_mentat = std::make_unique<AtreidesMentat>(m_ctx, m_allowMissionSelect);
             else if (house == HARKONNEN)
-                m_mentat = std::make_unique<HarkonnenMentat>(m_ctx, allowMissionSelect);
+                m_mentat = std::make_unique<HarkonnenMentat>(m_ctx, m_allowMissionSelect);
             else if (house == ORDOS)
-                m_mentat = std::make_unique<OrdosMentat>(m_ctx, allowMissionSelect);
+                m_mentat = std::make_unique<OrdosMentat>(m_ctx, m_allowMissionSelect);
             else if (house == SARDAUKAR)
-                m_mentat = std::make_unique<SardaukarMentat>(m_ctx, allowMissionSelect);
+                m_mentat = std::make_unique<SardaukarMentat>(m_ctx, m_allowMissionSelect);
             else 
                 m_mentat = std::make_unique<BeneMentat>(m_ctx, m_dataCampaign);
             m_interface->missionInit();
@@ -69,13 +69,13 @@ void cMentatState::prepareMentat(int house)
             break;
         case MentatMode::WinBrief:
             if (house == ATREIDES)
-                m_mentat = std::make_unique<AtreidesMentat>(m_ctx, allowMissionSelect);
+                m_mentat = std::make_unique<AtreidesMentat>(m_ctx, m_allowMissionSelect);
             else if (house == HARKONNEN)
-                m_mentat = std::make_unique<HarkonnenMentat>(m_ctx, allowMissionSelect);
+                m_mentat = std::make_unique<HarkonnenMentat>(m_ctx, m_allowMissionSelect);
             else if (house == ORDOS) 
-                m_mentat = std::make_unique<OrdosMentat>(m_ctx, allowMissionSelect);
+                m_mentat = std::make_unique<OrdosMentat>(m_ctx, m_allowMissionSelect);
             else if (house == SARDAUKAR)
-                m_mentat = std::make_unique<SardaukarMentat>(m_ctx, allowMissionSelect);
+                m_mentat = std::make_unique<SardaukarMentat>(m_ctx, m_allowMissionSelect);
             else 
                 m_mentat = std::make_unique<BeneMentat>(m_ctx,m_dataCampaign);
             
@@ -87,13 +87,13 @@ void cMentatState::prepareMentat(int house)
             break;
         case MentatMode::LoseBrief:
             if (house == ATREIDES) 
-                m_mentat = std::make_unique<AtreidesMentat>(m_ctx, allowMissionSelect);
+                m_mentat = std::make_unique<AtreidesMentat>(m_ctx, m_allowMissionSelect);
             else if (house == HARKONNEN)
-                m_mentat = std::make_unique<HarkonnenMentat>(m_ctx, allowMissionSelect);
+                m_mentat = std::make_unique<HarkonnenMentat>(m_ctx, m_allowMissionSelect);
             else if (house == ORDOS)
-                m_mentat = std::make_unique<OrdosMentat>(m_ctx, allowMissionSelect);
+                m_mentat = std::make_unique<OrdosMentat>(m_ctx, m_allowMissionSelect);
             else if (house == SARDAUKAR)
-                m_mentat = std::make_unique<SardaukarMentat>(m_ctx, allowMissionSelect);
+                m_mentat = std::make_unique<SardaukarMentat>(m_ctx, m_allowMissionSelect);
             else 
                 m_mentat = std::make_unique<BeneMentat>(m_ctx,m_dataCampaign);
             

--- a/src/gamestates/cMentatState.h
+++ b/src/gamestates/cMentatState.h
@@ -36,7 +36,7 @@ private:
     s_DataCampaign* m_dataCampaign = nullptr;
     cGameSettings* m_settings = nullptr;
     cGameInterface* m_interface = nullptr;
-    cGameObjectContext* m_objets = nullptr;
+    cGameObjectContext* m_objects = nullptr;
     cIni* m_cIni = nullptr;
     MentatMode m_mode;
     int m_house;

--- a/src/gamestates/cMentatState.h
+++ b/src/gamestates/cMentatState.h
@@ -33,6 +33,7 @@ public:
     void prepareMentat(int house);
 private:
     std::unique_ptr<AbstractMentat> m_mentat;
+
     s_DataCampaign* m_dataCampaign = nullptr;
     cGameSettings* m_settings = nullptr;
     cGameInterface* m_interface = nullptr;
@@ -40,4 +41,5 @@ private:
     cIni* m_cIni = nullptr;
     MentatMode m_mode;
     int m_house;
+    bool m_allowMissionSelect;
 };

--- a/src/gamestates/cSelectYourNextConquestState.cpp
+++ b/src/gamestates/cSelectYourNextConquestState.cpp
@@ -54,7 +54,7 @@ cSelectYourNextConquestState::cSelectYourNextConquestState(sGameServices* servic
     m_interface(m_ctx->getGameInterface()),
     m_textDrawer(m_ctx->getTextContext()->getBeneTextDrawer()),
     m_objects(services->objects),
-    m_dataCompaign(dataCompaign),
+    m_dataCampaign(dataCompaign),
     m_gfxworld(m_ctx->getGraphicsContext()->gfxworld.get()),
     m_gfxinter(m_ctx->getGraphicsContext()->gfxinter.get()),
     m_cIni(ini)
@@ -62,7 +62,7 @@ cSelectYourNextConquestState::cSelectYourNextConquestState(sGameServices* servic
     d2tm_assert(m_settings != nullptr);
     d2tm_assert(m_interface != nullptr);
     d2tm_assert(m_textDrawer != nullptr);
-    d2tm_assert(m_dataCompaign != nullptr);
+    d2tm_assert(m_dataCampaign != nullptr);
     d2tm_assert(m_gfxworld != nullptr);
     d2tm_assert(m_gfxinter != nullptr);
     d2tm_assert(m_cIni != nullptr);
@@ -135,7 +135,7 @@ void cSelectYourNextConquestState::thinkFast()
         }
 
         int iHouse = m_objects->getPlayer(0)->getHouse();
-        int iMission = m_dataCompaign->mission;
+        int iMission = m_dataCampaign->mission;
 
         bool hasMessage = m_drawManager->hasMessage();
 
@@ -416,8 +416,8 @@ void cSelectYourNextConquestState::loadScenarioAndTransitionToNextState(int iMis
 
     m_interface->missionInit();
     m_interface->setNextStateToTransitionTo(GAME_BRIEFING);
-    m_dataCompaign->region = iNewReg;
-    m_dataCompaign->mission++;                        // FINALLY ADD MISSION NUMBER...
+    m_dataCampaign->region = iNewReg;
+    m_dataCampaign->mission++;                        // FINALLY ADD MISSION NUMBER...
 
     // set up drawStateMentat
     m_interface->prepareMentatForPlayer();
@@ -682,7 +682,7 @@ void cSelectYourNextConquestState::onMouseLeftButtonClicked(const s_MouseEvent &
 
     cRegion *pRegion = getRegionMouseIsOver();
     if (pRegion && pRegion->bSelectable) {
-        loadScenarioAndTransitionToNextState(m_dataCompaign->mission);
+        loadScenarioAndTransitionToNextState(m_dataCampaign->mission);
     }
 }
 

--- a/src/gamestates/cSelectYourNextConquestState.h
+++ b/src/gamestates/cSelectYourNextConquestState.h
@@ -96,7 +96,7 @@ private:
     cGameInterface* m_interface = nullptr;
     cTextDrawer* m_textDrawer = nullptr;
     cGameObjectContext* m_objects = nullptr;
-    s_DataCampaign* m_dataCompaign = nullptr;
+    s_DataCampaign* m_dataCampaign = nullptr;
     Graphics* m_gfxworld = nullptr;
     Graphics* m_gfxinter = nullptr;
     cMouse* m_mouse = nullptr;

--- a/src/include/eGameState.cpp
+++ b/src/include/eGameState.cpp
@@ -1,6 +1,8 @@
 #include "include/cAssert.h"
 #include "include/eGameState.h"
 
+#include "utils/Log.h"
+
 const char *stateToString(const int &state)
 {
     switch (state) {
@@ -41,6 +43,7 @@ const char *stateToString(const int &state)
         case GAME_MISSIONSELECT:
             return "GAME_MISSIONSELECT";
         default:
+            Logger::fatal( eLogComponent::COMP_GAMESTATE , "operator[]", "State index {} is out of range", state);
             d2tm_assert(false);
             break;
     }

--- a/src/include/eGameState.cpp
+++ b/src/include/eGameState.cpp
@@ -1,7 +1,6 @@
 #include "include/cAssert.h"
 #include "include/eGameState.h"
 
-
 const char *stateToString(const int &state)
 {
     switch (state) {
@@ -46,4 +45,35 @@ const char *stateToString(const int &state)
             break;
     }
     return "";
+}
+
+const char *gameStateToString(eGameState state)
+{
+    switch (state) {
+        case eGameState::INITIALIZE: return "INITIALIZE";
+        case eGameState::OVER: return "OVER";
+        case eGameState::MENU: return "MENU";
+        case eGameState::PLAYING: return "PLAYING";
+        case eGameState::BRIEFING: return "BRIEFING";
+        case eGameState::EDITOR: return "EDITOR";
+        case eGameState::NEW_MAP_EDITOR: return "NEW_MAP_EDITOR";
+        case eGameState::OPTIONS: return "OPTIONS";
+        case eGameState::REGION: return "REGION";
+        case eGameState::SELECT_HOUSE: return "SELECT_HOUSE";
+        case eGameState::INTRO: return "INTRO";
+        case eGameState::TELLHOUSE: return "TELLHOUSE";
+        case eGameState::WINNING: return "WINNING";
+        case eGameState::WINBRIEF: return "WINBRIEF";
+        case eGameState::LOSEBRIEF: return "LOSEBRIEF";
+        case eGameState::LOSING: return "LOSING";
+        case eGameState::SKIRMISH: return "SKIRMISH";
+        case eGameState::SETUPSKIRMISH: return "SETUPSKIRMISH";
+        case eGameState::CREDITS: return "CREDITS";
+        case eGameState::MISSIONSELECT: return "MISSIONSELECT";
+            // COUNT is not a valid state for the game, but it is for the iteration.
+            // We return a special string. Maybe an out of range error is better ?
+        case eGameState::COUNT: return "[Error: GameState::COUNT]";
+    }
+    // Handling unrecognized values ​​(if the enum is cast from an arbitrary character)
+    throw std::out_of_range("Unknown GameState value");
 }

--- a/src/include/eGameState.h
+++ b/src/include/eGameState.h
@@ -24,6 +24,8 @@ enum class eGameState : char {
     COUNT            
 };
 
+const char *gameStateToString(eGameState state);
+
 // Game states (state machine)
 #define GAME_INITIALIZE  -1      // initialize game
 #define GAME_OVER         0      // game over
@@ -47,4 +49,5 @@ enum class eGameState : char {
 #define GAME_NEW_MAP_EDITOR 19    // new map editor
 #define GAME_MAX_STATES 20
 
+[[deprecated]] // We should start using eGameState enum, get rid of int state
 const char *stateToString(const int &state);


### PR DESCRIPTION
For #1377 

## **Goal**

Using `StateCreator` to avoid memory corruption on Windows 
`StateCreator` is now used after long shadow unused code

if @claude  can make a detailled review ...