### PR TITLE
Add missing sardaukar campaign data to create_release.sh

### DIFF
--- a/create_release.sh
+++ b/create_release.sh
@@ -11,6 +11,7 @@ mkdir bin/campaign
 mkdir bin/campaign/atreides
 mkdir bin/campaign/ordos
 mkdir bin/campaign/harkonnen
+mkdir bin/campaign/sardaukar
 mkdir bin/campaign/maps
 mkdir bin/campaign/maps/seed
 mkdir bin/campaign/briefings
@@ -18,6 +19,7 @@ echo "4. Copying campaign files"
 cp resources/bin/campaign/atreides/*.* bin/campaign/atreides
 cp resources/bin/campaign/ordos/*.* bin/campaign/ordos
 cp resources/bin/campaign/harkonnen/*.* bin/campaign/harkonnen
+cp resources/bin/campaign/sardaukar/*.* bin/campaign/sardaukar
 cp resources/bin/campaign/maps/*.* bin/campaign/maps
 cp resources/bin/campaign/maps/seed/*.* bin/campaign/maps/seed
 cp resources/bin/campaign/briefings/*.* bin/campaign/briefings


### PR DESCRIPTION
## Summary

- Mirrors the fix from #1386 (`create_release.bat`) for the Mac/Linux shell script
- Adds `mkdir bin/campaign/sardaukar` so the directory exists before copying
- Adds `cp resources/bin/campaign/sardaukar/*.* bin/campaign/sardaukar` to include sardaukar mission data in Mac/Linux releases

## Test plan

- [ ] Run `./create_release.sh` on macOS or Linux
- [ ] Verify `bin/campaign/sardaukar/` is created and populated
- [ ] Play the sardaukar campaign to confirm data loads correctly