### PR TITLE
Main menu no longer responds to clicks during screen fade

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1233,7 +1233,7 @@ void cGame::onNotifyMouseEvent(const s_MouseEvent &event)
     }
 
     // pass through any classes that are interested
-    if (m_currentState) {
+    if (m_currentState && !m_cScreenFader->isFading()) {
         m_currentState->onNotifyMouseEvent(event);
     }
 


### PR DESCRIPTION
## Summary

- Rapid clicks on the main menu during a fade-out could forward events to the incoming state before it was ready, causing double transitions (eg. two game sessions starting)
- Root cause: `onNotifyMouseEvent` forwarded to the current state unconditionally; `drawState` already blocks rendering during fade-out but event delivery continued
- Fix: added `!m_cScreenFader->isFading()` guard in `onNotifyMouseEvent` so the active state receives no mouse events while a fade is in progress

Fixes #1194

## Test plan

- [ ] On the main menu, click a button quickly and repeatedly while the fade plays — only one transition should occur
- [ ] Verify that normal (non-spammed) button clicks still work as expected