### PR TITLE
Correct house mentat shown after skirmish defeat

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -981,6 +981,7 @@ void cGame::setState(int newState)
                     humanPlayer->getGameControlsContext()->onFocusMouseStateEvent();
                 }
                 else {
+                    m_dataCampaign->housePlayer = humanPlayer->getHouse();
                     newStatePtr = m_creatorState->getState(eGameState::PLAYING);
                     m_currentState = newStatePtr;
 


### PR DESCRIPTION
## Summary

- After losing in skirmish, the game showed the Bene Gesserit mentat ("Do you wish to play as house X?") instead of the player's actual house mentat with the loss speech
- Root cause: `dataCampaign->housePlayer` is initialized to `-1` and only updated on the campaign TELLHOUSE path; in skirmish it was never set
- On defeat, `onPlayerDefeated` calls `player->setHouse(GENERALHOUSE)`, so the fallback `humanPlayer->getHouse()` in `prepareMentat` returned 0, matching no house-specific mentat
- Fix: snapshot `humanPlayer->getHouse()` into `dataCampaign->housePlayer` when entering `GAME_PLAYING`, before any defeat can change it

Fixes #1185

## Test plan

- [ ] Play skirmish as Atreides, lose — verify Atreides mentat plays the loss speech
- [ ] Play skirmish as Harkonnen, lose — verify Harkonnen mentat plays the loss speech
- [ ] Play campaign, verify briefing and win/lose mentats are unchanged