### PR TITLE
Button render cycling via right-click restricted to debug mode

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -50,6 +50,7 @@
 #include "gamestates/cTellHouseState.h"
 #include "gamestates/cWinLoseState.h"
 
+#include "gui/GuiButton.h"
 #include "gui/GuiConsole.h"
 
 #include "include/sDataCampaign.h"
@@ -244,6 +245,8 @@ void cGame::applySettings(std::unique_ptr<InitialGameSettings> gs)
     m_gameSettings->m_noAiRest = gs->noAiRest;
     m_gameSettings->m_drawUsages = gs->drawUsages;
     m_gameFilename = gs->gameFilename;
+
+    GuiButton::registerSettings(m_gameSettings.get());
 
     // save settings for later use
     m_initialGameSettings = std::move(gs);

--- a/src/gui/GuiButton.cpp
+++ b/src/gui/GuiButton.cpp
@@ -5,6 +5,8 @@
 #include "game/cGameSettings.h"
 #include "include/cAssert.h"
 
+cGameSettings* GuiButton::s_settings = nullptr;
+
 GuiButton::GuiButton(SDLDrawer* drawer, const cRectangle &rect, const std::string &btnText)
     : GuiObject(drawer, rect)
     , m_textDrawer(nullptr)
@@ -171,6 +173,9 @@ void GuiButton::onMouseRightButtonClicked(const s_MouseEvent &)
         if (m_enabled && m_onRightMouseButtonClickedAction) {
             m_onRightMouseButtonClickedAction();
         }
+        if (s_settings && s_settings->isDebugMode()) {
+            nextRenderKind();
+        }
     }
 }
 
@@ -211,6 +216,11 @@ void GuiButton::setOnRightMouseButtonClickedAction(std::function<void()> action)
 void GuiButton::setEnabled(bool value)
 {
     m_enabled = value;
+}
+
+void GuiButton::registerSettings(cGameSettings* settings)
+{
+    s_settings = settings;
 }
 
 void GuiButton::onNotifyKeyboardEvent(const cKeyboardEvent &)

--- a/src/gui/GuiButton.h
+++ b/src/gui/GuiButton.h
@@ -9,6 +9,7 @@
 
 class SDLDrawer;
 class cTextDrawer;
+class cGameSettings;
 
 
 class GuiButton : public GuiObject {
@@ -35,6 +36,8 @@ public:
     void setOnLeftMouseButtonClickedAction(std::function<void()> action);
     void setOnRightMouseButtonClickedAction(std::function<void()> action);
 
+    static void registerSettings(cGameSettings* settings);
+
     void setEnabled(bool value);
 
 private:
@@ -51,6 +54,8 @@ private:
     // pressed state
     bool m_pressed;
     bool m_enabled;
+
+    static cGameSettings* s_settings;
 
     // Functions
     void drawText() const;


### PR DESCRIPTION
Closes #1036

Right-clicking any `GuiButton` while focused previously cycled through render kinds (`nextRenderKind()`), changing the button's visual appearance. This was a developer tool that leaked into non-debug builds.

`GuiButton` now holds a static `cGameSettings*` registered once at startup via `GuiButton::registerSettings()`. The `nextRenderKind()` call in `onMouseRightButtonClicked` is gated behind `s_settings->isDebugMode()`, so render cycling only works when the game is launched with debug mode enabled.

## Changes

- `GuiButton.h` / `GuiButton.cpp` — static `s_settings` pointer; `registerSettings()` setter; debug-mode guard in `onMouseRightButtonClicked`
- `cGame_logic.cpp` — calls `GuiButton::registerSettings(m_gameSettings.get())` at end of `applySettings()`