### PR TITLE
Bandbox selection cleared when rally key released while dragging

### DIFF
--- a/src/controls/mousestates/cMouseNormalState.cpp
+++ b/src/controls/mousestates/cMouseNormalState.cpp
@@ -330,6 +330,7 @@ void cMouseNormalState::onKeyPressed(const cKeyboardEvent &event)
         // actual group creation is at cGameLogic onKeyPressed
         setState(SELECT_STATE_NORMAL);
         m_mouseTile = MOUSE_NORMAL;
+        m_mouse->resetBoxSelect();
     }
     else {
         // select group


### PR DESCRIPTION
Closes #988

When the rally key (R) was released while a bandbox drag-select was in progress, the selection box visual persisted because `onKeyPressed(ATTACK_MODE)` transitioned the sub-state back to `SELECT_STATE_NORMAL` without clearing the box.

Added `m_mouse->resetBoxSelect()` to the `ATTACK_MODE` key-pressed handler in `cMouseNormalState` so the bandbox is cleared immediately when R is released.