### PR TITLE
Mouse clicks unblocked during fade-in transitions

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1233,7 +1233,7 @@ void cGame::onNotifyMouseEvent(const s_MouseEvent &event)
     }
 
     // pass through any classes that are interested
-    if (m_currentState && !m_cScreenFader->isFading()) {
+    if (m_currentState && m_cScreenFader->getAction() != eFadeAction::FadeOut) {
         m_currentState->onNotifyMouseEvent(event);
     }
 


### PR DESCRIPTION
## Summary

- `isFading()` returns true during both `FadeOut` and `FadeIn`
- `drawState()` continuously cycles through `FadeIn` after every state transition, so `isFading()` was almost always true during normal gameplay
- This caused all mouse clicks to be permanently suppressed after commit 9775afdd

## Root cause

The double-transition bug (#1194) occurs when a player clicks during `FadeOut` (the screen going dark). Clicks during `FadeIn` (new state brightening in) are harmless. The original fix used `isFading()` which covers both phases.

## Fix

Narrow the guard to `FadeOut` only:

```cpp
if (m_currentState && m_cScreenFader->getAction() != eFadeAction::FadeOut) {
```

## Test plan

- [ ] Launch game, verify clicks on main menu buttons work
- [ ] Rapidly click a menu button during a transition — confirm no double-transition occurs
- [ ] Play a skirmish match and confirm in-game clicks (unit selection, orders) all register

Fixes #1194