### PR TITLE
Button render cycling via right-click available in debug mode only

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -50,6 +50,7 @@
 #include "gamestates/cTellHouseState.h"
 #include "gamestates/cWinLoseState.h"
 
+#include "gui/GuiButton.h"
 #include "gui/GuiConsole.h"
 
 #include "include/sDataCampaign.h"
@@ -244,6 +245,8 @@ void cGame::applySettings(std::unique_ptr<InitialGameSettings> gs)
     m_gameSettings->m_noAiRest = gs->noAiRest;
     m_gameSettings->m_drawUsages = gs->drawUsages;
     m_gameFilename = gs->gameFilename;
+
+    GuiButton::registerSettings(m_gameSettings.get());
 
     // save settings for later use
     m_initialGameSettings = std::move(gs);

--- a/src/gui/GuiButton.cpp
+++ b/src/gui/GuiButton.cpp
@@ -5,6 +5,13 @@
 #include "game/cGameSettings.h"
 #include "include/cAssert.h"
 
+cGameSettings *GuiButton::s_settings = nullptr;
+
+void GuiButton::registerSettings(cGameSettings *settings)
+{
+    s_settings = settings;
+}
+
 GuiButton::GuiButton(SDLDrawer* drawer, const cRectangle &rect, const std::string &btnText)
     : GuiObject(drawer, rect)
     , m_textDrawer(nullptr)
@@ -167,6 +174,9 @@ void GuiButton::onMouseMovedTo(const s_MouseEvent &event)
 
 void GuiButton::onMouseRightButtonClicked(const s_MouseEvent &)
 {
+    if (m_focus && s_settings && s_settings->isDebugMode()) {
+        nextRenderKind();
+    }
     if (m_focus) {
         if (m_enabled && m_onRightMouseButtonClickedAction) {
             m_onRightMouseButtonClickedAction();

--- a/src/gui/GuiButton.h
+++ b/src/gui/GuiButton.h
@@ -9,6 +9,7 @@
 
 class SDLDrawer;
 class cTextDrawer;
+class cGameSettings;
 
 
 class GuiButton : public GuiObject {
@@ -37,7 +38,10 @@ public:
 
     void setEnabled(bool value);
 
+    static void registerSettings(cGameSettings *settings);
+
 private:
+    static cGameSettings *s_settings;
     cTextDrawer *m_textDrawer;
     std::string m_buttonText;
     GuiRenderKind m_renderKind;


### PR DESCRIPTION
## Summary

- Commit 6f9726dd ("Remove graphical debug") by Mira removed the `nextRenderKind()` debug tool from `GuiButton::onMouseRightButtonClicked` entirely, including the `isDebugMode()` guard
- This was too aggressive: the feature is useful for layout inspection during development
- Restore it, gated behind `isDebugMode()`, so regular players can never trigger it accidentally

## Implementation

Rather than re-coupling `GuiButton` to the global `game` instance, a static `cGameSettings* s_settings` is added and registered from `cGame::applySettings()` once settings are known.

Right-clicking a focused button in debug mode cycles through:
`OPAQUE_WITH_BORDER → OPAQUE_WITHOUT_BORDER → TRANSPARENT_WITH_BORDER → TRANSPARENT_WITHOUT_BORDER`

## Test plan

- [ ] In debug mode (`-debug` flag): right-click a button and confirm render kind cycles
- [ ] Without debug mode: right-click a button and confirm no visual change occurs
- [ ] Skirmish "Next" map button: confirm right-click no longer breaks its appearance in non-debug builds

Fixes #1036