### PR TITLE
GUI button debug render cycling removed

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -50,7 +50,6 @@
 #include "gamestates/cTellHouseState.h"
 #include "gamestates/cWinLoseState.h"
 
-#include "gui/GuiButton.h"
 #include "gui/GuiConsole.h"
 
 #include "include/sDataCampaign.h"
@@ -245,8 +244,6 @@ void cGame::applySettings(std::unique_ptr<InitialGameSettings> gs)
     m_gameSettings->m_noAiRest = gs->noAiRest;
     m_gameSettings->m_drawUsages = gs->drawUsages;
     m_gameFilename = gs->gameFilename;
-
-    GuiButton::registerSettings(m_gameSettings.get());
 
     // save settings for later use
     m_initialGameSettings = std::move(gs);

--- a/src/gui/GuiButton.cpp
+++ b/src/gui/GuiButton.cpp
@@ -5,13 +5,6 @@
 #include "game/cGameSettings.h"
 #include "include/cAssert.h"
 
-cGameSettings *GuiButton::s_settings = nullptr;
-
-void GuiButton::registerSettings(cGameSettings *settings)
-{
-    s_settings = settings;
-}
-
 GuiButton::GuiButton(SDLDrawer* drawer, const cRectangle &rect, const std::string &btnText)
     : GuiObject(drawer, rect)
     , m_textDrawer(nullptr)
@@ -174,9 +167,6 @@ void GuiButton::onMouseMovedTo(const s_MouseEvent &event)
 
 void GuiButton::onMouseRightButtonClicked(const s_MouseEvent &)
 {
-    if (m_focus && s_settings && s_settings->isDebugMode()) {
-        nextRenderKind();
-    }
     if (m_focus) {
         if (m_enabled && m_onRightMouseButtonClickedAction) {
             m_onRightMouseButtonClickedAction();

--- a/src/gui/GuiButton.h
+++ b/src/gui/GuiButton.h
@@ -9,7 +9,6 @@
 
 class SDLDrawer;
 class cTextDrawer;
-class cGameSettings;
 
 
 class GuiButton : public GuiObject {
@@ -38,10 +37,7 @@ public:
 
     void setEnabled(bool value);
 
-    static void registerSettings(cGameSettings *settings);
-
 private:
-    static cGameSettings *s_settings;
     cTextDrawer *m_textDrawer;
     std::string m_buttonText;
     GuiRenderKind m_renderKind;


### PR DESCRIPTION
## Summary

Reverts 83faef82 (Button render cycling via right-click restricted to debug mode).

The right-click render cycling on `GuiButton` was intentionally removed by Mira in 6f9726dd. PR #1399 incorrectly restored it behind a debug flag. This revert brings the codebase back in line with that decision.

Closes #1400
Closes #1036