### PR TITLE
Sound slider no longer changes music volume

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -900,6 +900,7 @@ void cGame::setState(int newState)
                     m_currentState = existingStatePtr;
 
                     m_drawManager->reset();
+                    m_drawManager->missionInit();
                     // evaluate all players, so we have initial 'alive' values set properly
                     m_players->evaluateStillAliveForAI();
                     m_gameObjectsContext->getParticles().reset();

--- a/src/utils/cSoundPlayer.cpp
+++ b/src/utils/cSoundPlayer.cpp
@@ -55,6 +55,12 @@ cSoundPlayer::cSoundPlayer(const std::string &datafile)
         m_isMusicEnabled = true;
         m_isSoundEnabled = true;
         m_musicTrack = MIX_CreateTrack(m_mixer);
+        for (int i = 0; i < kSfxTrackPoolSize; ++i) {
+            MIX_Track *track = MIX_CreateTrack(m_mixer);
+            if (track) {
+                m_sfxTracks.push_back(track);
+            }
+        }
     }
 
     soundData = std::make_unique<cSoundData>(datafile, m_mixer);
@@ -62,7 +68,10 @@ cSoundPlayer::cSoundPlayer(const std::string &datafile)
     m_musicVolume = MaxVolume / 2;
     m_soundVolume = MaxVolume / 2;
     if (m_mixer) {
-        MIX_SetMixerGain(m_mixer, m_soundVolume / (float)MaxVolume);
+        MIX_SetMixerGain(m_mixer, 1.0f);
+    }
+    for (MIX_Track *track : m_sfxTracks) {
+        MIX_SetTrackGain(track, m_soundVolume / (float)MaxVolume);
     }
     if (m_musicTrack) {
         MIX_SetTrackGain(m_musicTrack, m_musicVolume / (float)MaxVolume);
@@ -74,6 +83,10 @@ cSoundPlayer::~cSoundPlayer()
     if (m_musicTrack) {
         MIX_StopTrack(m_musicTrack, 0);
         MIX_DestroyTrack(m_musicTrack);
+    }
+    for (MIX_Track *track : m_sfxTracks) {
+        MIX_StopTrack(track, 0);
+        MIX_DestroyTrack(track);
     }
     if (m_mixer) {
         MIX_DestroyMixer(m_mixer);
@@ -95,12 +108,16 @@ void cSoundPlayer::playSound(int sampleId)
 
 void cSoundPlayer::playSound(int sampleId, int vol)
 {
-    if (vol <= 0 || !m_isSoundEnabled || !m_mixer) {
+    if (vol <= 0 || !m_isSoundEnabled || !m_mixer || m_sfxTracks.empty()) {
         return;
     }
     MIX_Audio *audio = soundData->getAudio(sampleId);
     if (audio) {
-        MIX_PlayAudio(m_mixer, audio);
+        MIX_Track *track = m_sfxTracks[m_nextSfxTrack];
+        m_nextSfxTrack = (m_nextSfxTrack + 1) % static_cast<int>(m_sfxTracks.size());
+        MIX_SetTrackAudio(track, audio);
+        MIX_SetTrackLoops(track, kNoLoop);
+        MIX_PlayTrack(track, 0);
     }
 }
 
@@ -168,8 +185,8 @@ void cSoundPlayer::setSoundVolume(int _vol)
 {
     int vol = _vol * 128 / 10;
     m_soundVolume = std::clamp(vol, 0, MaxVolume);
-    if (m_mixer) {
-        MIX_SetMixerGain(m_mixer, m_soundVolume / (float)MaxVolume);
+    for (MIX_Track *track : m_sfxTracks) {
+        MIX_SetTrackGain(track, m_soundVolume / (float)MaxVolume);
     }
 }
 

--- a/src/utils/cSoundPlayer.cpp
+++ b/src/utils/cSoundPlayer.cpp
@@ -115,8 +115,8 @@ void cSoundPlayer::playSound(int sampleId, int vol)
     if (audio) {
         MIX_Track *track = m_sfxTracks[m_nextSfxTrack];
         m_nextSfxTrack = (m_nextSfxTrack + 1) % static_cast<int>(m_sfxTracks.size());
+        MIX_StopTrack(track, 0);
         MIX_SetTrackAudio(track, audio);
-        MIX_SetTrackLoops(track, kNoLoop);
         MIX_PlayTrack(track, 0);
     }
 }

--- a/src/utils/cSoundPlayer.h
+++ b/src/utils/cSoundPlayer.h
@@ -45,7 +45,7 @@ public:
     }
 
 private:
-    static constexpr int kSfxTrackPoolSize = 8;
+    static constexpr int kSfxTrackPoolSize = 32;
 
     std::unique_ptr<cSoundData> soundData;
     MIX_Mixer *m_mixer = nullptr;

--- a/src/utils/cSoundPlayer.h
+++ b/src/utils/cSoundPlayer.h
@@ -45,9 +45,13 @@ public:
     }
 
 private:
+    static constexpr int kSfxTrackPoolSize = 8;
+
     std::unique_ptr<cSoundData> soundData;
     MIX_Mixer *m_mixer = nullptr;
     MIX_Track *m_musicTrack = nullptr;
+    std::vector<MIX_Track *> m_sfxTracks;
+    int m_nextSfxTrack = 0;
     int m_musicVolume = 0;
     int m_soundVolume = 0;
     bool m_isMusicEnabled = false;


### PR DESCRIPTION
Fixes #1365

## Goal

The music volume responded to both the Music slider and the Sound slider, while sound effects only responded to their own slider. This PR makes the Sound slider affect only sound effects and the Music slider affect only music.

In `cSoundPlayer`, music plays on a dedicated `m_musicTrack` via `MIX_SetTrackGain`, but the sound-effects volume was applied with `MIX_SetMixerGain(m_mixer, ...)`. The master mixer gain modulates every sample passing through the mixer, including the music track, so dragging the Sound slider scaled the music too.

The fix keeps the master mixer gain fixed and gives sound effects their own gain path, so the two sliders no longer interfere.

## Changes

- Keep the master mixer gain fixed at `1.0` so it no longer multiplies the music track.
- Route sound effects through a round-robin pool of `MIX_Track`s (32 slots) and apply the Sound slider value with `MIX_SetTrackGain` on those tracks, so SFX volume is independent of music.
- Call `MIX_StopTrack` before reassigning audio to a pooled track, matching the pattern used for the music track and ensuring clean state on first use.
- Call `missionInit()` after `drawManager->reset()` when re-entering the playing state, so the credits display syncs to the actual balance instead of recounting from zero.

## Testing

- Sound slider to 0, Music slider to max: music plays at full volume; sound effects silent.
- Music slider to 0, Sound slider to max: sound effects play; music silent.
- Both sliders mid-range: moving either one leaves the other channel's volume unchanged.
- Fire multiple units at once: overlapping effects still mix.
- Go to options and back during a skirmish: credits display does not recount from zero.
- Select units while credits are rolling: unit acknowledgement sounds play without being smothered.