### PR TITLE
Matt Van Horn added to credits

### DIFF
--- a/resources/doc/versionhistory.txt
+++ b/resources/doc/versionhistory.txt
@@ -179,6 +179,7 @@ rphl
 Rene
 Paul (code contributions)
 Miria (code contributions)
+Matt Van Horn (code contributions)
 
 
 Books / Must reads:

--- a/resources/doc/versionhistory.txt
+++ b/resources/doc/versionhistory.txt
@@ -178,7 +178,7 @@ Ruurd Nijdam
 rphl
 Rene
 Paul (code contributions)
-Miria (code contributions)
+Mira (code contributions)
 Matt Van Horn (code contributions)
 
 

--- a/src/gamestates/cCreditsState.cpp
+++ b/src/gamestates/cCreditsState.cpp
@@ -128,6 +128,12 @@ void cCreditsState::prepareCrawlerLines()
         .height = fontHeightWithALittlePadding
     });
     m_lines.push_back(s_CreditLine {
+        .name = "Matt Van Horn",
+        .txt = "Developer",
+        .color = Color::White,
+        .height = fontHeightWithALittlePadding
+    });
+    m_lines.push_back(s_CreditLine {
         .name = "Rozmy",
         .txt = "Graphics",
         .color = Color::White,

--- a/src/gamestates/cCreditsState.cpp
+++ b/src/gamestates/cCreditsState.cpp
@@ -129,7 +129,7 @@ void cCreditsState::prepareCrawlerLines()
     });
     m_lines.push_back(s_CreditLine {
         .name = "Matt Van Horn",
-        .txt = "Developer",
+        .txt = "Bugfixes",
         .color = Color::White,
         .height = fontHeightWithALittlePadding
     });


### PR DESCRIPTION
## Summary

- Added Matt Van Horn to the contributors section in `resources/doc/versionhistory.txt`
- Added Matt Van Horn to the in-game credits roll (`cCreditsState.cpp`) with role "Bugfixes"
- Fixed typo: "Miria" corrected to "Mira" in `versionhistory.txt`

## Test plan

- [ ] Launch game, navigate to credits screen, verify Matt Van Horn appears under Contributors with "Bugfixes"
- [ ] Verify Mira is spelled correctly in the credits roll