### PR TITLE
Guard against dead-unit dereference in saboteur self-destruct path

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -1169,6 +1169,9 @@ void cGame::setPlayerToInteractFor(cPlayer *pPlayer)
 void cGame::emitGameEvent(const s_GameEvent &event)
 {
     if (m_eventEmitter) {
+        if (m_gameSettings->isDebugMode()) {
+            Logger::trace(eLogComponent::COMP_NONE, "cGame::emitGameEvent", "event {}", s_GameEvent::toString(event));
+        }
         m_eventEmitter->emit(event);
     }
 }

--- a/src/gameobjects/players/brains/cPlayerBrainCampaign.cpp
+++ b/src/gameobjects/players/brains/cPlayerBrainCampaign.cpp
@@ -273,6 +273,11 @@ void cPlayerBrainCampaign::onMyStructureAttacked(const DamagedEvent &event)
     if (unitIdThatAttacks > -1) {
         // respond to something that attacks us
         cUnit *originUnit = m_objects->getUnit(unitIdThatAttacks);
+        if (!originUnit->isValid()) {
+            // attacker (e.g. saboteur) may have self-destructed by the time the damage event is processed
+            log(std::format("Unit {} that attacked my structure is no longer valid, ignoring.", unitIdThatAttacks).c_str());
+            return;
+        }
         if (originUnit->getPlayer()->isSameTeamAs(player)) {
             // friendly fire, ignore
             log(std::format("Unit {} who damaged my structure is from friendly player, ignoring.", unitIdThatAttacks).c_str());

--- a/src/gameobjects/players/brains/cPlayerBrainCampaign.cpp
+++ b/src/gameobjects/players/brains/cPlayerBrainCampaign.cpp
@@ -273,11 +273,6 @@ void cPlayerBrainCampaign::onMyStructureAttacked(const DamagedEvent &event)
     if (unitIdThatAttacks > -1) {
         // respond to something that attacks us
         cUnit *originUnit = m_objects->getUnit(unitIdThatAttacks);
-        if (!originUnit->isValid()) {
-            // attacker (e.g. saboteur) may have self-destructed by the time the damage event is processed
-            log(std::format("Unit {} that attacked my structure is no longer valid, ignoring.", unitIdThatAttacks).c_str());
-            return;
-        }
         if (originUnit->getPlayer()->isSameTeamAs(player)) {
             // friendly fire, ignore
             log(std::format("Unit {} who damaged my structure is from friendly player, ignoring.", unitIdThatAttacks).c_str());

--- a/src/gameobjects/players/cPlayers.cpp
+++ b/src/gameobjects/players/cPlayers.cpp
@@ -67,7 +67,7 @@ const cPlayer* cPlayers::operator[](int index) const {
 }
 
 cPlayer* cPlayers::getPlayer(int index) {
-    d2tm_assert(index >= 0 && index < MAX_PLAYERS_CAPACITY && "cPlayers::getPlayer out of bounds");
+    d2tm_assert(index >= 0 && index < MAX_PLAYERS_CAPACITY && std::format("cPlayers::getPlayer out of bounds: {}\n\n", index).c_str());
     if (index < 0 || index >= MAX_PLAYERS_CAPACITY) {
         return nullptr;
     }

--- a/src/gameobjects/structures/cAbstractStructure.cpp
+++ b/src/gameobjects/structures/cAbstractStructure.cpp
@@ -193,7 +193,14 @@ void cAbstractStructure::die()
 
     // UnitID > -1, means the unit inside will die too
     if (iUnitIDWithinStructure > -1) {
-        m_objects->getUnit(iUnitIDWithinStructure)->init(iUnitIDWithinStructure); // die here... softly
+        cUnit *pUnit = m_objects->getUnit(iUnitIDWithinStructure);
+        if (!pUnit->isMarkedForRemoval()) {
+            pUnit->init(iUnitIDWithinStructure); // die here... softly
+        }
+        else {
+            Logger::debug(COMP_STRUCTURES, "cAbstractStructure::die",
+                "Unit [{}] inside structure [{}] already marked for removal, skipping init.", iUnitIDWithinStructure, id);
+        }
     }
 
     if (iUnitIDEnteringStructure > -1) {

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -186,6 +186,17 @@ void cUnit::setBoundParticleId(int particleId)
 
 void cUnit::die(bool bBlowUp, bool bSquish)
 {
+    // Guard against die() running on a unit that has already been destroyed and re-initialized
+    // this tick. die() ends by calling init(iID), which resets iPlayer to -1. If a unit destroys
+    // something and then dies within the same thinkFast pass, die() can be invoked a second time
+    // on the now re-initialized unit; the GAME_EVENT_DESTROYED event below calls getPlayer() ->
+    // cPlayers::getPlayer(-1), which asserts (see #1404). iPlayer < 0 only after init(), so it is a
+    // reliable "already dead" sentinel. isValid() cannot be used here: a legitimate first death has
+    // iHitPoints < 0 with bRemoveMe still false, which already makes isValid() return false.
+    if (iPlayer < 0) {
+        return;
+    }
+
     // DO NOTE: We do *not* set the HP to -1 here for a reason. Being: that the isValid() function checks for
     // health and that will give us a unit ID that is the *same* as this unit ID. (see UNIT_NEW() implementation).
     // hence we don't want to fiddle with that (for now), but instead we set a "removeMe" flag.

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -259,6 +259,11 @@ void cUnit::die(bool bBlowUp, bool bSquish)
         }
     }
 
+    if (iPlayer < 0) {
+        Logger::info(COMP_UNITS, "die()", "iPlayer became < 0 while it was >= 0 just a moment ago!");
+        return;
+    }
+
     // before re-initing, send out event, so in case we need to handle the event and fetch the data from that
     // entity then we can atleast pry it for data...
     const s_GameEvent event {
@@ -397,13 +402,17 @@ void cUnit::createExplosionParticle()
                 int idOfUnitAtCell = m_map->getCellIdUnitLayer(cll);
                 if (idOfUnitAtCell > -1) {
                     int id = idOfUnitAtCell;
+                    cUnit *pHitUnit = m_objects->getUnit(id);
 
-                    if (m_objects->getUnit(id)->iHitPoints > 0) {
-                        m_objects->getUnit(id)->iHitPoints -= 150;
+                    // Skip units already dying: a saboteur/devastator dies with positive HP (die() is
+                    // called before taking damage), so the HP check alone does not guard against a
+                    // recursive die() being triggered by a chained explosion (see #1404).
+                    if (!pHitUnit->bRemoveMe && pHitUnit->iHitPoints > 0) {
+                        pHitUnit->iHitPoints -= 150;
 
                         // NO HP LEFT, DIE
-                        if (m_objects->getUnit(id)->iHitPoints <= 1)
-                            m_objects->getUnit(id)->die(true, false);
+                        if (pHitUnit->iHitPoints <= 1)
+                            pHitUnit->die(true, false);
                     } // only die when the unit is going to die
                 }
 

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -408,11 +408,13 @@ void cUnit::createExplosionParticle()
                     // called before taking damage), so the HP check alone does not guard against a
                     // recursive die() being triggered by a chained explosion (see #1404).
                     if (!pHitUnit->bRemoveMe && pHitUnit->iHitPoints > 0) {
-                        pHitUnit->iHitPoints -= 150;
+                        pHitUnit->iHitPoints -= 150; //TODO: make use of takeDamage or something
 
                         // NO HP LEFT, DIE
-                        if (pHitUnit->iHitPoints <= 1)
+                        if (pHitUnit->iHitPoints <= 1) {
+                            //TODO: make use of takeDamage so that it determines then to call die
                             pHitUnit->die(true, false);
+                        }
                     } // only die when the unit is going to die
                 }
 

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -187,17 +187,6 @@ void cUnit::setBoundParticleId(int particleId)
 
 void cUnit::die(bool bBlowUp, bool bSquish)
 {
-    // Guard against die() running on a unit that has already been destroyed and re-initialized
-    // this tick. die() ends by calling init(iID), which resets iPlayer to -1. If a unit destroys
-    // something and then dies within the same thinkFast pass, die() can be invoked a second time
-    // on the now re-initialized unit; the GAME_EVENT_DESTROYED event below calls getPlayer() ->
-    // cPlayers::getPlayer(-1), which asserts (see #1404). iPlayer < 0 only after init(), so it is a
-    // reliable "already dead" sentinel. isValid() cannot be used here: a legitimate first death has
-    // iHitPoints < 0 with bRemoveMe still false, which already makes isValid() return false.
-    if (iPlayer < 0) {
-        return;
-    }
-
     // DO NOTE: We do *not* set the HP to -1 here for a reason. Being: that the isValid() function checks for
     // health and that will give us a unit ID that is the *same* as this unit ID. (see UNIT_NEW() implementation).
     // hence we don't want to fiddle with that (for now), but instead we set a "removeMe" flag.
@@ -207,6 +196,16 @@ void cUnit::die(bool bBlowUp, bool bSquish)
     //
     // TODO: this should be revisited and fixed in a later version properly!
     bRemoveMe = true;
+
+    // Guard against die() running on a unit that has already been destroyed and re-initialized
+    // this tick. die() ends by calling init(iID), which resets iPlayer to -1. If a unit destroys
+    // something and then dies within the same thinkFast pass, die() can be invoked a second time
+    // on the now re-initialized unit; the GAME_EVENT_DESTROYED event below calls getPlayer() ->
+    // cPlayers::getPlayer(-1), which asserts (see #1404). bRemoveMe is set above so that isValid()
+    // skips its HP check and reliably returns false only for re-initialized slots.
+    if (!isValid()) {
+        return;
+    }
 
     // any damage particle dies with the unit?
     if (boundParticleId > -1) {

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -260,8 +260,7 @@ void cUnit::die(bool bBlowUp, bool bSquish)
     }
 
     if (iPlayer < 0) {
-        Logger::info(COMP_UNITS, "die()", "iPlayer became < 0 while it was >= 0 just a moment ago!");
-        return;
+        Logger::fatal(COMP_UNITS, "die()", "iPlayer became < 0 while it was >= 0 just a moment ago!");
     }
 
     // before re-initing, send out event, so in case we need to handle the event and fetch the data from that

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -54,6 +54,7 @@
 
 void cUnit::init(int i)
 {
+    Logger::debug(eLogComponent::COMP_UNITS, "Initialization", "Initializing unit {}", i);
     mission = -1;
     boundParticleId = -1;
     m_bSelected = false;

--- a/src/include/sGameEvent.cpp
+++ b/src/include/sGameEvent.cpp
@@ -67,7 +67,8 @@ const std::string s_GameEvent::toString(const s_GameEvent &event)
 {
     if (const auto *deployEvent = std::get_if<DeployUnitEvent>(&event.data)) {
         return std::format(
-            "DeployUnitEvent[cell={}, unitType={}, playerId={}, onStart={}, reinforcement={}, hp={}]",
+            "DeployUnitEvent[type={}, cell={}, unitType={}, playerId={}, onStart={}, reinforcement={}, hp={}]",
+            toString(event.eventType),
             deployEvent->iCell,
             deployEvent->unitType,
             deployEvent->iPlayer,
@@ -79,7 +80,8 @@ const std::string s_GameEvent::toString(const s_GameEvent &event)
 
     if (const auto *launchEvent = std::get_if<LaunchDeathHandEvent>(&event.data)) {
         return std::format(
-            "LaunchDeathHandEvent[targetCell={}, itemToLaunch={}, playerId={}]",
+            "LaunchDeathHandEvent[type={}, targetCell={}, itemToLaunch={}, playerId={}]",
+            toString(event.eventType),
             launchEvent->targetCell,
             launchEvent->itemToLaunch ? "present" : "nullptr",
             launchEvent->playerID
@@ -88,7 +90,8 @@ const std::string s_GameEvent::toString(const s_GameEvent &event)
 
     if (const auto *damagedEvent = std::get_if<DamagedEvent>(&event.data)) {
         return std::format(
-            "DamagedEvent[entityType={}, entityId={}, player={}, entitySpecificType={}, atCell={}, originId={}, originType={}]",
+            "DamagedEvent[type={}, entityType={}, entityId={}, player={}, entitySpecificType={}, atCell={}, originId={}, originType={}]",
+            toString(event.eventType),
             eBuildTypeString(damagedEvent->entityType),
             damagedEvent->entityID,
             damagedEvent->player ? "present" : "nullptr",
@@ -101,7 +104,8 @@ const std::string s_GameEvent::toString(const s_GameEvent &event)
 
     if (const auto *buildingEvent = std::get_if<BuildingEvent>(&event.data)) {
         return std::format(
-            "BuildingEvent[entityType={}, player={}, entitySpecificType={}, buildingListItem={}, buildingList={}]",
+            "BuildingEvent[type={}, entityType={}, player={}, entitySpecificType={}, buildingListItem={}, buildingList={}]",
+            toString(event.eventType),
             eBuildTypeString(buildingEvent->entityType),
             buildingEvent->player ? "present" : "nullptr",
             buildingEvent->entitySpecificType,
@@ -112,7 +116,8 @@ const std::string s_GameEvent::toString(const s_GameEvent &event)
 
     if (const auto *commonEvent = std::get_if<CommonEvent>(&event.data)) {
         return std::format(
-            "CommonEvent[entityType={}, entityId={}, player={}, entitySpecificType={}, atCell={}, isReinforce={}]",
+            "CommonEvent[type={}, entityType={}, entityId={}, player={}, entitySpecificType={}, atCell={}, isReinforce={}]",
+            toString(event.eventType),
             eBuildTypeString(commonEvent->entityType),
             commonEvent->entityID,
             commonEvent->player ? "present" : "nullptr",


### PR DESCRIPTION
## Summary

- Guards `onMyStructureAttacked` in `cPlayerBrainCampaign` against accessing an attacker unit that died before the event was processed
- Guards `cUnit::die()` against being called a second time on a slot already reinitialized in the same tick — `bRemoveMe` is set first so `isValid()` reliably returns false only for re-initialized slots (see #1404)
- Includes `eventType` in all `s_GameEvent::toString()` variants for clearer debug output
- Event emission logging gated behind `-debug` mode; unit init logging downgraded to DEBUG level
- Guards `cAbstractStructure::die()` against calling `init()` on a unit already mid-execution in its own `die()` (defensive, for the `iUnitIDWithinStructure` path)
- Skips explosion damage in `createExplosionParticle()` for units already marked for removal — fixes the confirmed crash path

## Root causes

**Crash 1 — double-die:** When multiple saboteurs attack the same structure simultaneously, a unit slot can be killed and reinitialized in the same thinkFast pass. A second call to `die()` on that slot tries to build a `GAME_EVENT_DESTROYED` event using `getPlayer()`, which hits `cPlayers::getPlayer(-1)` and asserts. Making `die()` idempotent via `!isValid()` (with `bRemoveMe = true` set first) fixes this.

**Crash 2 — chained explosion causes recursive die():** A Saboteur or Devastator calls `die()` without first taking damage, so `iHitPoints` stays positive during `die()` execution. The unit is still registered in `MAPID_UNITS` until `remove_id` at the very end of `die()`. If the explosion hits a nearby Devastator, that Devastator's own explosion can re-hit the original dying unit's cell, pass the `iHitPoints > 0` check, and call `die()` recursively. The recursive `die()` passes `!isValid()` (because `bRemoveMe == true` suppresses the HP check) and runs to completion including `init()`, resetting `iPlayer = -1`. The outer `die()` then crashes at `getPlayer()`.

The fix is a `bRemoveMe` guard in the explosion unit-damage loop: units already in the process of dying are skipped entirely, preventing the recursive `die()`.

## Test plan

- Send multiple saboteurs simultaneously at a single structure (the repro from #1404)
- Send a Devastator into a cluster of structures to trigger chained explosions
- Confirm no crash and explosion animations play normally
- Test normal unit combat deaths for regressions