### PR TITLE
autoBuild restart scoped to the owning player when Palace special completes

### DIFF
--- a/src/gameobjects/players/cPlayer.cpp
+++ b/src/gameobjects/players/cPlayer.cpp
@@ -1724,7 +1724,7 @@ void cPlayer::onNotifyGameEvent(const s_GameEvent &event)
                     };
                     m_interface->onNotifyGameEvent(newEvent);
                 }
-                if (cBuildingListItem::isAutoBuild(buildEvent->entityType, buildEvent->entitySpecificType, m_infos)) {
+                if (buildEvent->player == this && cBuildingListItem::isAutoBuild(buildEvent->entityType, buildEvent->entitySpecificType, m_infos)) {
                     startBuilding(buildEvent->entityType, buildEvent->entitySpecificType);
                 }
             }


### PR DESCRIPTION
## Summary

- `GAME_EVENT_LIST_ITEM_FINISHED` is broadcast to all players, but the autoBuild restart check in `cPlayer::onNotifyGameEvent` was missing a `buildEvent->player == this` guard
- When an Ordos Palace finished charging its Saboteur special, every other player in the game called `startBuildingSpecial(0)` on their own empty sidebar, producing repeated `ERROR|SIDEBAR|cSideBar::startBuildingItemIfOk|listType[5] and buildId[0] did not find an item to build!` entries
- Added the same player guard that already exists in the `GAME_EVENT_LIST_ITEM_ADDED/CANCELLED` handler immediately below

Fixes #1401

## Test plan

- Start a skirmish game as a non-Ordos house against an Ordos AI
- Let the Ordos AI build a Palace and wait for it to charge the Saboteur special (~6 minutes)
- Confirm no `ERROR|SIDEBAR|cSideBar::startBuildingItemIfOk` errors appear in the log after the special fires
- Confirm the Ordos AI still deploys Saboteurs normally (autoBuild still works for the owning player)