### PR TITLE
Configurable attackIsEnterStructure and damageOnEnterStructure via game.ini

### DIFF
--- a/resources/game.ini
+++ b/resources/game.ini
@@ -515,6 +515,9 @@ Range=2
 BuildTime=5
 ; costs nothing
 Cost=0
+; enter-structure attack behaviour (saboteur destroys the structure it enters)
+AttackIsEnterStructure=true
+DamageOnEnterStructure=9999.99
 
 ; ========================================================
 ; Structure types

--- a/resources/game.ini.org
+++ b/resources/game.ini.org
@@ -544,6 +544,9 @@ Range=2
 ; supported in the game.ini file yet
 BuildTime=1000
 Cost=0
+; enter-structure attack behaviour (saboteur destroys the structure it enters)
+AttackIsEnterStructure=true
+DamageOnEnterStructure=9999.99
 
 ; ========================================================
 ; Structure types

--- a/src/include/iniDefine.h
+++ b/src/include/iniDefine.h
@@ -112,6 +112,8 @@
 #define WORD_UPON_DESTRUCTION_SPAWN_UNIT_AMOUNT_MIN 201  // (structures, how many units to spawn if destroyed? (min))
 #define WORD_UPON_DESTRUCTION_SPAWN_UNIT_AMOUNT_MAX 202  // (structures, how many units to spawn if destroyed? (max))
 #define WORD_UPON_DESTRUCTION_SPAWN_UNIT_TYPE  203  // (structures, which type of unit to spawn if destroyed?)
+#define WORD_ATTACK_IS_ENTER_STRUCTURE 204  // (unit attacks by entering a structure?)
+#define WORD_DAMAGE_ON_ENTER_STRUCTURE 205  // (damage dealt to structure on entry)
 
 
 #define WORD_BLOOMTIMERDURATION 241 // BLOOM TIMER DURATION

--- a/src/utils/ini.cpp
+++ b/src/utils/ini.cpp
@@ -297,6 +297,8 @@ int INI_WordType(const std::string& word, int section)
         if (cIniUtils::caseInsCompare(word, "SmokeHpFactor"))     return WORD_SMOKEHFACTOR;
         if (cIniUtils::caseInsCompare(word, "CanAttackAirUnits")) return WORD_CANATTACKAIRUNITS;
         if (cIniUtils::caseInsCompare(word, "CanAttackUnits"))    return WORD_CANATTACKUNITS;
+        if (cIniUtils::caseInsCompare(word, "AttackIsEnterStructure")) return WORD_ATTACK_IS_ENTER_STRUCTURE;
+        if (cIniUtils::caseInsCompare(word, "DamageOnEnterStructure")) return WORD_DAMAGE_ON_ENTER_STRUCTURE;
     }
     else if (section == INI_STRUCTURES) {
         if (word.length() > 1) {
@@ -1536,6 +1538,8 @@ void cIni::installGame(std::string filename)
                     if (wordtype == WORD_SQUISH) unitInfo.canBeSquished = ToBool(word_right);
                     if (wordtype == WORD_CANATTACKAIRUNITS) unitInfo.canAttackAirUnits = ToBool(word_right);
                     if (wordtype == WORD_CANATTACKUNITS) unitInfo.canAttackUnits = ToBool(word_right);
+                    if (wordtype == WORD_ATTACK_IS_ENTER_STRUCTURE) unitInfo.attackIsEnterStructure = ToBool(word_right);
+                    if (wordtype == WORD_DAMAGE_ON_ENTER_STRUCTURE) unitInfo.damageOnEnterStructure = ToFloat(word_right);
 
                     if (wordtype == WORD_PRODUCER) {
                         int type = cIniUtils::getStructureType(word_right);


### PR DESCRIPTION
Fixes #1347

## **Goal**

Make the per-unit enter-structure attack properties tunable from `game.ini` instead of requiring a recompile.

Previously `attackIsEnterStructure` and `damageOnEnterStructure` were hardcoded in the engine, so tuning a unit's enter-structure attack meant editing C++ and recompiling. This exposes both through `game.ini` like the rest of the unit stats. They can now be set under any `[UNIT: ...]` section, and fall back to the existing compiled defaults (`false` / `0`) when omitted, so behaviour is unchanged for units that do not declare them:

```
AttackIsEnterStructure=true
DamageOnEnterStructure=1000
```

### Changes

Reading the keys belongs in `ini.cpp`, where the `[UNIT: ...]` sections are already parsed and where `game.ini` overrides the compiled defaults, so that is where this change lands:

- Added two word-type defines (`WORD_ATTACK_IS_ENTER_STRUCTURE`, `WORD_DAMAGE_ON_ENTER_STRUCTURE`) in `src/include/iniDefine.h`.
- Recognized and applied the two new keys in `src/utils/ini.cpp`, in the same parsing path that already handles `SmokeHpFactor` / `CanAttackUnits`.
- Added the Saboteur's values to `resources/game.ini.org` and `resources/game.ini` (`AttackIsEnterStructure=true`, `DamageOnEnterStructure=9999.99`), matching its prior instant-destroy behaviour.

## Testing Steps

- Add `AttackIsEnterStructure=true` and `DamageOnEnterStructure=1000` to a `[UNIT: ...]` section in `game.ini` and confirm that unit attacks by entering the structure and deals the configured damage on entry.
- Omit both keys from a unit section and confirm it falls back to `false` / `0` and that the rest of the unit's properties still parse cleanly.
- Confirm the Saboteur retains its prior enter-structure behaviour now that `game.ini.org` carries its explicit values.

## Screenshots (optional)
