### PR TITLE
Sight range 1 units reveal their surrounding shroud while moving

### DIFF
--- a/src/gameobjects/map/cMap.cpp
+++ b/src/gameobjects/map/cMap.cpp
@@ -504,7 +504,8 @@ void cMap::clearShroud(int c, int size, int playerId)
     setVisibleFor(c, playerId);
 
     // go around 360 fDegrees and calculate new stuff.
-    for (float dr = 1; dr < size; dr++) {
+    int maxRadius = (size <= 1) ? size : (size - 1);
+    for (float dr = 1; dr <= maxRadius; dr++) {
         for (float d = 0; d < 360; d++) { // if we reduce the amount of degrees, we don't get full coverage.
             // need a smarter way to do this (less CPU intensive).
 


### PR DESCRIPTION
Fixes #1403

## **Goal**

Units with a sight range of 1 (the value used in the original Dune II) moved faster than they revealed terrain and ended up hidden behind their own shroud. As the reporter and owner confirmed on the issue, the reveal radius is the problem, not the movement code: a sight-1 unit never clears the cells around it, so it walks into fog it should have already uncovered.

`cMap::clearShroud` swept the rings `1 .. size - 1`:

```cpp
for (float dr = 1; dr < size; dr++) {
```

With `size == 1` the loop body never runs, so only the unit's own cell is made visible and none of its surrounding cells are cleared. The unit stays blind to its neighbors as it moves.

The fix sweeps the reveal rings up to `max(size - 1, 1)` for units with sight, while leaving every other sight value untouched.

### Changes

The reveal loop bound in `cMap::clearShroud` is the only thing that changes, and it is deliberately kept balance-preserving:

- A sight-1 unit now clears its immediate ring of eight neighbor cells (orthogonal and diagonal) instead of only its own cell.
- `size >= 2` is unchanged: `dr <= size - 1` sweeps exactly the same rings as the old `dr < size`, so vision range is not altered for any existing unit.
- `size == 0` is unchanged: sight-0 air units (Ornithopter, Carryall) keep revealing only their own cell and do not clear neighboring fog while travelling.

A single expression covers all three cases:

```cpp
int maxRadius = (size <= 1) ? size : (size - 1);
for (float dr = 1; dr <= maxRadius; dr++) {
```

## Testing Steps

1. Set a unit's `Sight` to `1` in `game.ini` (or use a unit already at sight 1).
2. Move it orthogonally: the tiles it enters and its immediate neighbors clear and stay visible instead of hiding behind shroud.
3. Move it diagonally: the diagonal neighbor tiles reveal as well (the case flagged in the issue).
4. Regression check: a unit with `Sight >= 2` reveals exactly the same radius as before, and a sight-0 air unit (Ornithopter/Carryall) still reveals only its own cell.

## Screenshots (optional)

Not applicable; the change is verified in-game by watching the shroud clear around a moving sight-1 unit.
