### PR TITLE
Skirmish maps with fewer than 2 start positions are marked invalid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ endif()
 
 message(STATUS "D2TM-Version determined to be: ${D2TM_VERSION}")
 
+string(TIMESTAMP D2TM_BUILD_DATETIME "Built at %d-%m-%Y %H:%M:%S")
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/create_release.sh
+++ b/create_release.sh
@@ -46,7 +46,7 @@ cp resources/bin/skirmish/*.ini bin/skirmish
 echo "10. Copying dll files"
 echo "TODO TODO TODO"
 echo "11. Copy executable"
-cp build/d2tm bin
+cp -p build/d2tm bin
 echo "12. Copy game rules file (game.ini)"
 cp resources/game.ini.org bin/game.ini
 cp resources/bin/settings.ini bin

--- a/src/gameobjects/map/cPreviewMaps.cpp
+++ b/src/gameobjects/map/cPreviewMaps.cpp
@@ -36,6 +36,14 @@ s_PreviewMap *cPreviewMaps::getMap(int i)
     return m_PreviewMap[i].get();
 }
 
+bool cPreviewMaps::isValidMap(int i) const
+{
+    if (i < 0 || i >= static_cast<int>(m_PreviewMap.size()) || m_PreviewMap[i] == nullptr) {
+        return false;
+    }
+    return m_PreviewMap[i]->validMap;
+}
+
 int cPreviewMaps::getMapCount() const
 {
     return static_cast<int>(m_PreviewMap.size()-1); // -1 because the first map is reserved for the random map, which is not a real skirmish map

--- a/src/gameobjects/map/cPreviewMaps.cpp
+++ b/src/gameobjects/map/cPreviewMaps.cpp
@@ -101,6 +101,7 @@ void cPreviewMaps::loadSkirmish(const std::string &filename)
         }
     }
 
+    int validStartCells = 0;
     for (int i = 0; i < std::min(static_cast<int>(numbers.size()), MAX_SKIRMISHMAP_PLAYERS); i++) {
         try {
             int startCell = numbers[i];
@@ -110,12 +111,18 @@ void cPreviewMaps::loadSkirmish(const std::string &filename)
             }
             else {
                 previewMap->iStartCell[i] = startCell;
+                validStartCells++;
             }
         }
         catch (std::invalid_argument const &e) {
             // could not perform conversion
             Logger::warn(COMP_MAP, "cPreviewMaps", "Could not convert startCell [{}] to an int. Reason: {}", numbers[i], e.what());
         }
+    }
+
+    if (validStartCells < 2) {
+        previewMap->validMap = false;
+        Logger::warn(COMP_MAP, "cPreviewMaps", "Map {} has only {} valid start cell(s); at least 2 are required - map is invalid", filename, validStartCells);
     }
 
     previewMap->width = maxWidth + 2;

--- a/src/gameobjects/map/cPreviewMaps.h
+++ b/src/gameobjects/map/cPreviewMaps.h
@@ -37,6 +37,7 @@ public:
     void destroy();
 
     s_PreviewMap *getMap(int i);
+    bool isValidMap(int i) const;
 
     std::string getMapSize(int i) const;
     int getMapCount() const;

--- a/src/gamestates/cMainMenuState.cpp
+++ b/src/gamestates/cMainMenuState.cpp
@@ -26,8 +26,6 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
     d2tm_assert(m_settings != nullptr);
     d2tm_assert(m_textDrawer != nullptr);
     d2tm_assert(m_interface != nullptr);
-    m_buildStr = D2TM_BUILD_DATETIME;
-
     auto *gfxinter = m_ctx->getGraphicsContext()->gfxinter.get();
     bmp_D2TM_Title = gfxinter->getTexture(BMP_D2TM);
 
@@ -245,7 +243,7 @@ void cMainMenuState::draw() const
     int versionX = m_settings->getScreenW() - m_textDrawer->getTextLength(D2TM_VERSION) - 20;
     int versionY = m_settings->getScreenH() - fontH * 2 - 42;
     m_textDrawer->drawText(versionX, versionY, Color{255,255,255,255}, D2TM_VERSION);
-    m_textDrawer->drawTextBottomRight(m_buildStr, 20);
+    m_textDrawer->drawTextBottomRight(D2TM_BUILD_DATETIME, 20);
 
     if (m_settings->isDebugMode()) {
         auto m_mouse = m_interface->getMouse();

--- a/src/gamestates/cMainMenuState.cpp
+++ b/src/gamestates/cMainMenuState.cpp
@@ -26,6 +26,8 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
     d2tm_assert(m_settings != nullptr);
     d2tm_assert(m_textDrawer != nullptr);
     d2tm_assert(m_interface != nullptr);
+    m_buildStr = D2TM_BUILD_DATETIME;
+
     auto *gfxinter = m_ctx->getGraphicsContext()->gfxinter.get();
     bmp_D2TM_Title = gfxinter->getTexture(BMP_D2TM);
 
@@ -39,8 +41,6 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
 
     mainMenuWidth = 130;
     mainMenuHeight = 183;
-
-    sdl2power = cRectangle{centerOfScreen+logoWidth/4, logoY+logoHeight+75,0,0};
 
     // adjust x and y according to resolution, we can add because the above values
     // assume 640x480 resolution, and logoX/logoY are already taking care of > resolutions
@@ -241,8 +241,11 @@ void cMainMenuState::draw() const
     gui_btn_credits->draw();
 
     // draw version
-    m_textDrawer->drawTextBottomRight(D2TM_VERSION,20);
-    m_textDrawer->drawText(sdl2power.getX(),sdl2power.getY(),Color{255,255,0,200},"SDL2 powered");
+    int fontH = m_textDrawer->getFontHeight();
+    int versionX = m_settings->getScreenW() - m_textDrawer->getTextLength(D2TM_VERSION) - 20;
+    int versionY = m_settings->getScreenH() - fontH * 2 - 42;
+    m_textDrawer->drawText(versionX, versionY, Color{255,255,255,255}, D2TM_VERSION);
+    m_textDrawer->drawTextBottomRight(m_buildStr, 20);
 
     if (m_settings->isDebugMode()) {
         auto m_mouse = m_interface->getMouse();

--- a/src/gamestates/cMainMenuState.h
+++ b/src/gamestates/cMainMenuState.h
@@ -6,6 +6,7 @@
 #include "controls/sMouseEvent.h"
 
 #include <memory>
+#include <string>
 
 class Texture;
 class cTextDrawer;
@@ -39,11 +40,10 @@ private:
     int mainMenuWidth;
     int mainMenuHeight;
 
-    cRectangle sdl2power;
-
     std::unique_ptr<GuiWindow> gui_window;
     std::unique_ptr<GuiButton> gui_btn_credits;
 
     Texture *bmp_D2TM_Title;
     Texture *backGroundDebug = nullptr;
+    std::string m_buildStr;
 };

--- a/src/gamestates/cMainMenuState.h
+++ b/src/gamestates/cMainMenuState.h
@@ -6,7 +6,6 @@
 #include "controls/sMouseEvent.h"
 
 #include <memory>
-#include <string>
 
 class Texture;
 class cTextDrawer;
@@ -45,5 +44,4 @@ private:
 
     Texture *bmp_D2TM_Title;
     Texture *backGroundDebug = nullptr;
-    std::string m_buildStr;
 };

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -1232,7 +1232,7 @@ void cSetupSkirmishState::surpriseMe()
     int mapCount = m_previewMaps->getMapCount();
     std::vector<int> validIndices;
     for (int i = 0; i < mapCount; i++) {
-        if (m_previewMaps->getMap(i)->validMap) {
+        if (m_previewMaps->isValidMap(i)) {
             validIndices.push_back(i);
         }
     }

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -277,7 +277,7 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
             .withTheme(theme)
             .withKind(GuiRenderKind::OPAQUE_WITH_BORDER)
             .onClick([this]() {
-                if (iSkirmishMap > -1 && m_previewMaps->getMap(iSkirmishMap)->validMap) {
+                if (m_previewMaps->isValidMap(iSkirmishMap)) {
                     prepareSkirmishGameToPlayAndTransitionToCombatState(iSkirmishMap);
                 }
             })
@@ -1477,7 +1477,7 @@ void cSetupSkirmishState::onNotifyKeyboardEvent(const cKeyboardEvent &event)
             moveCursor(0, 1);
         }
         if (event.isAction(eKeyAction::MENU_CONFIRM)) {
-            if (iSkirmishMap > -1 && m_previewMaps->getMap(iSkirmishMap)->validMap) {
+            if (m_previewMaps->isValidMap(iSkirmishMap)) {
                 prepareSkirmishGameToPlayAndTransitionToCombatState(iSkirmishMap);
             }
         }

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -277,7 +277,7 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
             .withTheme(theme)
             .withKind(GuiRenderKind::OPAQUE_WITH_BORDER)
             .onClick([this]() {
-                if (iSkirmishMap > -1) {
+                if (iSkirmishMap > -1 && m_previewMaps->getMap(iSkirmishMap)->validMap) {
                     prepareSkirmishGameToPlayAndTransitionToCombatState(iSkirmishMap);
                 }
             })

--- a/src/include/config.h.in
+++ b/src/include/config.h.in
@@ -5,3 +5,4 @@
 #include <string>
 
 const std::string D2TM_VERSION = "@D2TM_VERSION@";
+const std::string D2TM_BUILD_DATETIME = "@D2TM_BUILD_DATETIME@";


### PR DESCRIPTION
## Summary

- `cPreviewMaps::loadSkirmish()` now counts valid start cells after loading them. If fewer than 2 are found, `validMap` is set to `false` and a warning is logged. Such maps appear greyed-out and cannot be selected in the skirmish map list.
- Added `cPreviewMaps::isValidMap(int)` that combines the index bounds check and the `validMap` flag. Both the Start button and the Enter key path now use it.
- `D2TM_BUILD_DATETIME` is used directly at the draw call site in `cMainMenuState`; no member variable needed.

Previously a map with no start cells passed the validity check, leading to an out-of-bounds vector access in `prepareSkirmishGameToPlayAndTransitionToCombatState()` and an eventual broken game state (reported as the "Generalhouse (none)" mentat screen).

Closes #1070

## Test plan

- [ ] Create a map in the New Map Editor with no start cells, save it, open Skirmish — the map should appear greyed-out and be unselectable
- [ ] Create a map with exactly 1 start cell — same result
- [ ] Create a map with 2+ start cells — selectable and game starts normally
- [ ] Existing skirmish maps are unaffected