### PR TITLE
renderDrawer members renamed for consistency with SDLDrawer

### DIFF
--- a/src/controls/cMouse.cpp
+++ b/src/controls/cMouse.cpp
@@ -18,11 +18,11 @@
 
 cMouse::cMouse(GameContext *ctx) :
     m_ctx(ctx),
-    m_renderDrawer(ctx->getSDLDrawer()),
+    m_sdlDrawer(ctx->getSDLDrawer()),
     m_coords(cPoint(0,0))
 {
     d2tm_assert(m_ctx!=nullptr);
-    d2tm_assert(m_renderDrawer!=nullptr);
+    d2tm_assert(m_sdlDrawer!=nullptr);
     m_leftButtonPressed=false;
     m_rightButtonPressed=false;
     m_leftButtonReleased=false;
@@ -59,7 +59,7 @@ void cMouse::init()
 
 void cMouse::handleEvent(const SDL_Event &event)
 {
-    SDL_Renderer *renderer = m_renderDrawer->getRenderer();
+    SDL_Renderer *renderer = m_sdlDrawer->getRenderer();
     switch (event.type) {
         case SDL_EVENT_MOUSE_BUTTON_DOWN: {
             float px, py;
@@ -193,7 +193,7 @@ void cMouse::updateState()
 void cMouse::setCursorPosition(SDL_Window *_windows, int x, int y)
 {
     float wx, wy;
-    SDL_RenderCoordinatesToWindow(m_renderDrawer->getRenderer(), (float)x, (float)y, &wx, &wy);
+    SDL_RenderCoordinatesToWindow(m_sdlDrawer->getRenderer(), (float)x, (float)y, &wx, &wy);
     SDL_WarpMouseInWindow(_windows, wx, wy);
     if (m_mouseObserver) {
         s_MouseEvent event {
@@ -373,7 +373,7 @@ void cMouse::draw()
     }
 
     auto gfxdata = m_ctx->getGraphicsContext()->gfxdata;
-    m_renderDrawer->renderSprite(gfxdata->getTexture(m_mouseTile),mouseDrawX, mouseDrawY);
+    m_sdlDrawer->renderSprite(gfxdata->getTexture(m_mouseTile),mouseDrawX, mouseDrawY);
 }
 
 bool cMouse::isNormalRightClick()

--- a/src/controls/cMouse.h
+++ b/src/controls/cMouse.h
@@ -96,7 +96,7 @@ public:
 private:
     cInputObserver *m_mouseObserver = nullptr;
     GameContext* m_ctx = nullptr;
-    SDLDrawer* m_renderDrawer = nullptr;
+    SDLDrawer* m_sdlDrawer = nullptr;
     cGameSettings* m_settings = nullptr;
 
     bool m_leftButtonPressed;

--- a/src/drawers/CreditsDrawer.cpp
+++ b/src/drawers/CreditsDrawer.cpp
@@ -20,7 +20,7 @@ CreditsDrawer::CreditsDrawer(GameContext* ctx, cPlayer *player) :
     m_ctx(ctx),
     m_gfxinter(ctx->getGraphicsContext()->gfxinter.get()),
     m_gfxdata(ctx->getGraphicsContext()->gfxdata.get()),
-    m_renderDrawer(ctx->getSDLDrawer())
+    m_sdlDrawer(ctx->getSDLDrawer())
 {
     d2tm_assert(player!= nullptr);
     d2tm_assert(ctx != nullptr);
@@ -190,11 +190,11 @@ void CreditsDrawer::thinkAboutIndividualCreditOffsets()
 void CreditsDrawer::draw()
 {
     auto *tex = m_gfxinter->getTexture(CREDITS_BAR);
-    m_renderDrawer->renderSprite(tex, m_drawX, m_drawY);
-    m_renderDrawer->setClippingFor(m_drawX+1, m_drawY+5, m_drawX+tex->w-1, m_drawY+tex->h-5);
+    m_sdlDrawer->renderSprite(tex, m_drawX, m_drawY);
+    m_sdlDrawer->setClippingFor(m_drawX+1, m_drawY+5, m_drawX+tex->w-1, m_drawY+tex->h-5);
     drawCurrentCredits(m_drawX, m_drawY);
     drawPreviousCredits(m_drawX, m_drawY);
-    m_renderDrawer->resetClippingFor();
+    m_sdlDrawer->resetClippingFor();
 
 }
 
@@ -255,7 +255,7 @@ void CreditsDrawer::drawCurrentCredits(int drawX, int drawY)
         int nr = getCreditDrawId(credits[i]);
 
         if (nr != CREDITS_NONE) {
-            m_renderDrawer->renderSprite(m_gfxdata->getTexture(nr), drawX+dx+8, drawY+dy+8);
+            m_sdlDrawer->renderSprite(m_gfxdata->getTexture(nr), drawX+dx+8, drawY+dy+8);
         }
     }
 }
@@ -289,7 +289,7 @@ void CreditsDrawer::drawPreviousCredits(int drawX, int drawY)
         int nr = getCreditDrawId(credits[i]);
 
         if (nr != CREDITS_NONE) {
-            m_renderDrawer->renderSprite(m_gfxdata->getTexture(nr), drawX+dx+8, drawY+dy+8);
+            m_sdlDrawer->renderSprite(m_gfxdata->getTexture(nr), drawX+dx+8, drawY+dy+8);
         }
     }
 }

--- a/src/drawers/CreditsDrawer.h
+++ b/src/drawers/CreditsDrawer.h
@@ -37,7 +37,7 @@ private:
     cGameInterface* m_interface = nullptr;
     Graphics* m_gfxinter;
     Graphics* m_gfxdata;
-    SDLDrawer* m_renderDrawer = nullptr;
+    SDLDrawer* m_sdlDrawer = nullptr;
 
     void thinkAboutIndividualCreditOffsets();
     void drawCurrentCredits(int drawX, int drawY);

--- a/src/drawers/cBuildingListDrawer.cpp
+++ b/src/drawers/cBuildingListDrawer.cpp
@@ -22,7 +22,7 @@ cBuildingListDrawer::cBuildingListDrawer(const GameContext *ctx, cPlayer *player
     m_gameTextDrawer(ctx->getTextContext()->getGameTextDrawer()),
     m_smallTextDrawer(ctx->getTextContext()->getSmallTextDrawer()),
     m_gfxinter(ctx->getGraphicsContext()->gfxinter.get()),
-    m_renderDrawer(ctx->getSDLDrawer()),
+    m_sdlDrawer(ctx->getSDLDrawer()),
     m_player(player),
     m_renderListIds(false)
 {
@@ -69,8 +69,8 @@ void cBuildingListDrawer::drawButtonHoverRectangle(cBuildingList *list)
 
     Color color = m_player->getSelectFadingColor();
 
-    m_renderDrawer->renderRectColor(x, y, width, height, color);
-    m_renderDrawer->renderRectColor(x + 1, y + 1, width-2, height-2, color);
+    m_sdlDrawer->renderRectColor(x, y, width, height, color);
+    m_sdlDrawer->renderRectColor(x + 1, y + 1, width-2, height-2, color);
 }
 
 void cBuildingListDrawer::drawButton(cBuildingList *list, bool pressed)
@@ -96,13 +96,13 @@ void cBuildingListDrawer::drawButton(cBuildingList *list, bool pressed)
     int height = (m_gfxinter->getSurface(id))->h;
 
     // clear
-    m_renderDrawer->renderSprite(m_gfxinter->getTexture(list->getButtonIconIdUnpressed()), x, y);		// draw pressed button version (unpressed == default in gui)
+    m_sdlDrawer->renderSprite(m_gfxinter->getTexture(list->getButtonIconIdUnpressed()), x, y);		// draw pressed button version (unpressed == default in gui)
 
     // set blender
-    m_renderDrawer->renderSprite(m_gfxinter->getTexture(id), x, y,128);
+    m_sdlDrawer->renderSprite(m_gfxinter->getTexture(id), x, y,128);
 
     if (!list->isAvailable()) {
-        m_renderDrawer->renderRectFillColor(x, y, width, height, 0,0,0,96);
+        m_sdlDrawer->renderRectFillColor(x, y, width, height, 0,0,0,96);
     }
 
     if (pressed) {
@@ -110,16 +110,16 @@ void cBuildingListDrawer::drawButton(cBuildingList *list, bool pressed)
 
         Color color = m_player->getHouseFadingColor();
 
-        m_renderDrawer->renderRectColor(x, y, width, height, color);
-        m_renderDrawer->renderRectColor(x + 1, y + 1, width - 2, height - 2, color);
+        m_sdlDrawer->renderRectColor(x, y, width, height, color);
+        m_sdlDrawer->renderRectColor(x + 1, y + 1, width - 2, height - 2, color);
     }
     else {
         if (list->isFlashing()) {
             Color color = list->getFlashingColor();
 
-            m_renderDrawer->renderRectColor(x, y, width, height, color);
-            m_renderDrawer->renderRectColor(x + 1, y + 1, width - 2, height - 2, color);
-            m_renderDrawer->renderRectColor(x + 2, y + 2, width - 3, height - 3, color);
+            m_sdlDrawer->renderRectColor(x, y, width, height, color);
+            m_sdlDrawer->renderRectColor(x + 1, y + 1, width - 2, height - 2, color);
+            m_sdlDrawer->renderRectColor(x + 2, y + 2, width - 3, height - 3, color);
         }
     }
 }
@@ -175,7 +175,7 @@ void cBuildingListDrawer::drawList(cBuildingList *list, bool shouldDrawStructure
         // icon id must be set , assert it.
         d2tm_assert(item->getIconId() > -1);
 
-        m_renderDrawer->renderSprite(m_gfxinter->getTexture(item->getIconId()), iDrawX, iDrawY);
+        m_sdlDrawer->renderSprite(m_gfxinter->getTexture(item->getIconId()), iDrawX, iDrawY);
 
         if (shouldDrawStructureSize) {
             drawStructureSize(item->getBuildId(), iDrawX, iDrawY);
@@ -187,8 +187,8 @@ void cBuildingListDrawer::drawList(cBuildingList *list, bool shouldDrawStructure
 
             if (!item->isDoneBuilding() || iFrame < 31) {
                 // draw the other progress stuff
-                m_renderDrawer->renderSprite(m_gfxinter->getTexture(PROGRESSFIX), iDrawX+2, iDrawY+2,128);
-                m_renderDrawer->renderSprite(m_gfxinter->getTexture(PROGRESS001+iFrame), iDrawX+2, iDrawY+2,128);
+                m_sdlDrawer->renderSprite(m_gfxinter->getTexture(PROGRESSFIX), iDrawX+2, iDrawY+2,128);
+                m_sdlDrawer->renderSprite(m_gfxinter->getTexture(PROGRESS001+iFrame), iDrawX+2, iDrawY+2,128);
 
                 if (item->isPaused()) {
                     m_smallTextDrawer->drawTextCenteredInBox("Paused", iDrawX, iDrawY, withOfIcon, heightOfIcon, Color::Yellow);
@@ -201,7 +201,7 @@ void cBuildingListDrawer::drawList(cBuildingList *list, bool shouldDrawStructure
                     if (m_player->isContextMouseState(eMouseState::MOUSESTATE_PLACE)) {
                         icon = READY02;
                     }
-                    m_renderDrawer->renderSprite(m_gfxinter->getTexture(icon), iDrawX + 3, iDrawY + 16);
+                    m_sdlDrawer->renderSprite(m_gfxinter->getTexture(icon), iDrawX + 3, iDrawY + 16);
                 }
                 else if (item->shouldDeployIt()) {
                     // TODO: draw white/red (flicker)
@@ -210,7 +210,7 @@ void cBuildingListDrawer::drawList(cBuildingList *list, bool shouldDrawStructure
                     if (m_player->isContextMouseState(eMouseState::MOUSESTATE_DEPLOY)) {
                         icon = READY02;
                     }
-                    m_renderDrawer->renderSprite(m_gfxinter->getTexture(icon), iDrawX + 3, iDrawY + 16);
+                    m_sdlDrawer->renderSprite(m_gfxinter->getTexture(icon), iDrawX + 3, iDrawY + 16);
                 }
             }
         }
@@ -233,14 +233,14 @@ void cBuildingListDrawer::drawList(cBuildingList *list, bool shouldDrawStructure
             }
 
             if (!item->isAvailable() || isBuildingSameSubListItem) {
-                m_renderDrawer->renderSprite(m_gfxinter->getTexture(PROGRESSNA), iDrawX, iDrawY,64);
+                m_sdlDrawer->renderSprite(m_gfxinter->getTexture(PROGRESSNA), iDrawX, iDrawY,64);
 
                 // Pending upgrading (ie: an upgrade is progressing, blocking the construction of these items)
                 if (item->isPendingUpgrading()) {
                     Color errorFadingColor = m_player->getErrorFadingColor();
-                    m_renderDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, errorFadingColor);
-                    m_renderDrawer->renderLine( iDrawX, iDrawY, iDrawXEnd, iDrawYEnd, errorFadingColor);
-                    m_renderDrawer->renderLine( iDrawX, iDrawY + heightOfIcon, iDrawX + withOfIcon, iDrawY, errorFadingColor);
+                    m_sdlDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, errorFadingColor);
+                    m_sdlDrawer->renderLine( iDrawX, iDrawY, iDrawXEnd, iDrawYEnd, errorFadingColor);
+                    m_sdlDrawer->renderLine( iDrawX, iDrawY + heightOfIcon, iDrawX + withOfIcon, iDrawY, errorFadingColor);
 
                     Color red = Color{255, 0, 0,255};
                     m_smallTextDrawer->drawTextCenteredInBox("Upgrading", iDrawX, iDrawY, withOfIcon, heightOfIcon, red);
@@ -249,9 +249,9 @@ void cBuildingListDrawer::drawList(cBuildingList *list, bool shouldDrawStructure
                 // Pending building (ie: a build is progressing, blocking the upgrade)
                 if (item->isPendingBuilding()) {
                     Color errorFadingColor = m_player->getErrorFadingColor();
-                    m_renderDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, errorFadingColor);
-                    m_renderDrawer->renderLine( iDrawX, iDrawY, iDrawXEnd, iDrawYEnd, errorFadingColor);
-                    m_renderDrawer->renderLine( iDrawX, iDrawY + heightOfIcon, iDrawX + withOfIcon, iDrawY, errorFadingColor);
+                    m_sdlDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, errorFadingColor);
+                    m_sdlDrawer->renderLine( iDrawX, iDrawY, iDrawXEnd, iDrawYEnd, errorFadingColor);
+                    m_sdlDrawer->renderLine( iDrawX, iDrawY + heightOfIcon, iDrawX + withOfIcon, iDrawY, errorFadingColor);
 
                     Color red = Color{255, 0, 0, 255};
                     int height = heightOfIcon / 3;
@@ -267,18 +267,18 @@ void cBuildingListDrawer::drawList(cBuildingList *list, bool shouldDrawStructure
                 cOrderProcesser *orderProcesser = m_player->getOrderProcesser();
                 bool orderIsAwaitingFrigate = orderProcesser->isOrderPlaced() || orderProcesser->isFrigateSent();
                 if (cannotPayIt || orderIsAwaitingFrigate) {
-                    m_renderDrawer->renderSprite(m_gfxinter->getTexture(PROGRESSNA), iDrawX, iDrawY,64);
+                    m_sdlDrawer->renderSprite(m_gfxinter->getTexture(PROGRESSNA), iDrawX, iDrawY,64);
                     Color errorFadingColor = m_player->getErrorFadingColor();
-                    m_renderDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, errorFadingColor);
-                    m_renderDrawer->renderLine( iDrawX, iDrawY, iDrawXEnd, iDrawYEnd, errorFadingColor);
-                    m_renderDrawer->renderLine( iDrawX, iDrawY + heightOfIcon, iDrawX + withOfIcon, iDrawY, errorFadingColor);
+                    m_sdlDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, errorFadingColor);
+                    m_sdlDrawer->renderLine( iDrawX, iDrawY, iDrawXEnd, iDrawYEnd, errorFadingColor);
+                    m_sdlDrawer->renderLine( iDrawX, iDrawY + heightOfIcon, iDrawX + withOfIcon, iDrawY, errorFadingColor);
                 }
             }
 
             // last built id
             if (list->getLastClickedId() == i) {
-                m_renderDrawer->renderRectColor((iDrawX + 1), (iDrawY + 1), (iDrawXEnd - 1)-(iDrawX + 1), (iDrawYEnd - 1)-(iDrawY + 1), selectFadingColor);
-                m_renderDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, selectFadingColor);
+                m_sdlDrawer->renderRectColor((iDrawX + 1), (iDrawY + 1), (iDrawXEnd - 1)-(iDrawX + 1), (iDrawYEnd - 1)-(iDrawY + 1), selectFadingColor);
+                m_sdlDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, selectFadingColor);
             }
         }
 
@@ -318,14 +318,14 @@ void cBuildingListDrawer::drawList(cBuildingList *list, bool shouldDrawStructure
         // draw rectangle when mouse hovers over icon
         auto m_mouse = m_interface->getMouse();
         if (isOverItemCoordinates_Boolean(m_mouse->getX(), m_mouse->getY(), iDrawX, iDrawY)) {
-            m_renderDrawer->renderRectColor((iDrawX + 1), (iDrawY + 1), (iDrawXEnd - 1)-(iDrawX + 1), (iDrawYEnd - 1)-(iDrawY + 1), selectFadingColor);
-            m_renderDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, selectFadingColor);
+            m_sdlDrawer->renderRectColor((iDrawX + 1), (iDrawY + 1), (iDrawXEnd - 1)-(iDrawX + 1), (iDrawYEnd - 1)-(iDrawY + 1), selectFadingColor);
+            m_sdlDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, selectFadingColor);
         }
         else {
             Color color = list->getFlashingColor();
             if (item->isFlashing()) {
-                m_renderDrawer->renderRectColor((iDrawX + 1), (iDrawY + 1), (iDrawXEnd - 1)-(iDrawX + 1), (iDrawYEnd - 1)-(iDrawY + 1), color);
-                m_renderDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, color);
+                m_sdlDrawer->renderRectColor((iDrawX + 1), (iDrawY + 1), (iDrawXEnd - 1)-(iDrawX + 1), (iDrawYEnd - 1)-(iDrawY + 1), color);
+                m_sdlDrawer->renderRectColor(iDrawX, iDrawY, iDrawXEnd-iDrawX, iDrawYEnd-iDrawY, color);
             }
         }
 
@@ -369,9 +369,9 @@ void cBuildingListDrawer::drawStructureSize(int structureId, int x, int y)
         iTile = GRID_3X3;
     }
 
-    m_renderDrawer->renderRectFillColor(x + 43, y + 20,19,19,0,0,0,192);
-    m_renderDrawer->renderSprite(m_gfxinter->getTexture(GRID_0X0), x + 43, y + 20);
-    m_renderDrawer->renderSprite(m_gfxinter->getTexture(iTile), x + 43, y + 20);
+    m_sdlDrawer->renderRectFillColor(x + 43, y + 20,19,19,0,0,0,192);
+    m_sdlDrawer->renderSprite(m_gfxinter->getTexture(GRID_0X0), x + 43, y + 20);
+    m_sdlDrawer->renderSprite(m_gfxinter->getTexture(iTile), x + 43, y + 20);
 }
 
 bool cBuildingListDrawer::isOverItemCoordinates_Boolean(int x, int y, int drawX, int drawY)

--- a/src/drawers/cBuildingListDrawer.h
+++ b/src/drawers/cBuildingListDrawer.h
@@ -40,7 +40,7 @@ private:
     cTextDrawer* m_gameTextDrawer;
     cTextDrawer* m_smallTextDrawer;
     Graphics* m_gfxinter;
-    SDLDrawer* m_renderDrawer;
+    SDLDrawer* m_sdlDrawer;
 
     cPlayer *m_player;
     cInfoContext* m_infos = nullptr;

--- a/src/drawers/cMapDrawer.cpp
+++ b/src/drawers/cMapDrawer.cpp
@@ -22,7 +22,7 @@ cMapDrawer::cMapDrawer(GameContext *ctx, cMap *map, cPlayer *player, cMapCamera 
     m_player(player),
     m_camera(camera),
     m_ctx(ctx),
-    m_renderDrawer(ctx->getSDLDrawer()),
+    m_sdlDrawer(ctx->getSDLDrawer()),
     m_gfxdata(ctx->getGraphicsContext()->gfxdata.get()),
     m_drawWithoutShroudTiles(false),
     m_drawGrid(false)
@@ -70,7 +70,7 @@ void cMapDrawer::drawShroud()
                     // do nothing
                 }
                 else {
-                    m_renderDrawer->renderRectFillColor(fDrawX, fDrawY, tileWidth, tileHeight,0, 0, 0,128);
+                    m_sdlDrawer->renderRectFillColor(fDrawX, fDrawY, tileWidth, tileHeight,0, 0, 0,128);
                 }
             }
             else {
@@ -80,7 +80,7 @@ void cMapDrawer::drawShroud()
                     if (tile > -1) {
                         const cRectangle src_pos = {tile * 32, 0, 32, 32};
                         cRectangle dest_pos = {iDrawX, iDrawY, iTileWidth, iTileHeight};
-                        m_renderDrawer->renderStrechSprite(m_gfxdata->getTexture(SHROUD), src_pos, dest_pos);
+                        m_sdlDrawer->renderStrechSprite(m_gfxdata->getTexture(SHROUD), src_pos, dest_pos);
                     }
                 }
                 else {
@@ -89,7 +89,7 @@ void cMapDrawer::drawShroud()
                     // tile 0 of shroud is entirely black... (effectively the same as drawing a rect here)
                     const cRectangle src_pos = {0, 0, 32, 32};
                     cRectangle dest_pos = {iDrawX, iDrawY, iTileWidth, iTileHeight};
-                    m_renderDrawer->renderStrechSprite(m_gfxdata->getTexture(SHROUD), src_pos, dest_pos);
+                    m_sdlDrawer->renderStrechSprite(m_gfxdata->getTexture(SHROUD), src_pos, dest_pos);
                 }
             }
         }
@@ -148,13 +148,13 @@ void cMapDrawer::drawTerrain()
             // Draw terrain
             if (cell->type < TERRAIN_BLOOM || cell->type > TERRAIN_WALL) {
                 // somehow, invalid type
-                m_renderDrawer->renderRectFillColor(iDrawX, iDrawY, iTileWidth, iTileHeight, 245,245,245,255);
+                m_sdlDrawer->renderRectFillColor(iDrawX, iDrawY, iTileWidth, iTileHeight, 245,245,245,255);
             }
             else {
                 // valid type
                 const cRectangle src_pos = {cell->tile * 32, 0,32, 32};
                 cRectangle dest_pos = {iDrawX, iDrawY, iTileWidth, iTileHeight};
-                m_renderDrawer->renderStrechSprite(m_gfxdata->getTexture(cell->type), src_pos, dest_pos);
+                m_sdlDrawer->renderStrechSprite(m_gfxdata->getTexture(cell->type), src_pos, dest_pos);
             }
 
             // draw Smudge if necessary
@@ -162,7 +162,7 @@ void cMapDrawer::drawTerrain()
                 cell->smudgetype.transform([&](const auto &smudgeType) {
                     const cRectangle src_pos = {cell->smudgetile * 32, static_cast<int>(smudgeType) * 32,32, 32};
                     cRectangle dest_pos = {iDrawX, iDrawY, iTileWidth, iTileHeight};
-                    m_renderDrawer->renderStrechSprite(m_gfxdata->getTexture(SMUDGE), src_pos, dest_pos);
+                    m_sdlDrawer->renderStrechSprite(m_gfxdata->getTexture(SMUDGE), src_pos, dest_pos);
                     return std::monostate{}; // needed with GCC15, with GCC16 not needed to return anything.
                 });
             }
@@ -176,12 +176,12 @@ void cMapDrawer::drawTerrain()
                     int mcY = m_mapGeometry->getCellY(mouseCell);
 
                     if (mcX == cellX && mcY == cellY) {
-                        m_renderDrawer->renderRectFillColor(iDrawX, iDrawY, iTileWidth, iTileHeight,255, 255, 0,96);
+                        m_sdlDrawer->renderRectFillColor(iDrawX, iDrawY, iTileWidth, iTileHeight,255, 255, 0,96);
                     }
                 }
 
                 if (m_drawGrid) {
-                    m_renderDrawer->renderRectColor(iDrawX, iDrawY, iTileWidth, iTileHeight, Color{128, 128, 128,255});
+                    m_sdlDrawer->renderRectColor(iDrawX, iDrawY, iTileWidth, iTileHeight, Color{128, 128, 128,255});
                 }
             }
 
@@ -249,7 +249,7 @@ void cMapDrawer::drawCellAsColoredTile(float tileWidth, float tileHeight, int iC
     }
 
     if (bDraw) {
-        m_renderDrawer->renderRectColor(fDrawX, fDrawY, tileWidth, tileHeight, iClr);
+        m_sdlDrawer->renderRectColor(fDrawX, fDrawY, tileWidth, tileHeight, iClr);
     }
 }
 

--- a/src/drawers/cMapDrawer.h
+++ b/src/drawers/cMapDrawer.h
@@ -41,7 +41,7 @@ private:
     cPlayer *m_player = nullptr;
     cMapCamera *m_camera = nullptr;
     GameContext *m_ctx = nullptr;
-    SDLDrawer* m_renderDrawer = nullptr;
+    SDLDrawer* m_sdlDrawer = nullptr;
     Graphics *m_gfxdata = nullptr;
 
     bool m_drawWithoutShroudTiles;

--- a/src/drawers/cMessageDrawer.cpp
+++ b/src/drawers/cMessageDrawer.cpp
@@ -21,7 +21,7 @@ cMessageDrawer::cMessageDrawer(GameContext* ctx) :
     m_state(messages::eMessageDrawerState::COMBAT),
     m_fadeState(messages::eMessageDrawerFadingState::FADE_IN),
     m_textDrawer(ctx->getTextContext()->getGameTextDrawer()),
-    m_renderDrawer(ctx->getSDLDrawer()),
+    m_sdlDrawer(ctx->getSDLDrawer()),
     m_ctx(ctx),
     m_gfxinter(ctx->getGraphicsContext()->gfxinter.get())
 {
@@ -40,11 +40,11 @@ cMessageDrawer::~cMessageDrawer()
 void cMessageDrawer::draw()
 {
     if (m_state == messages::eMessageDrawerState::COMBAT) {
-        m_renderDrawer->renderFromSurface(m_bmpBar, m_position.x, m_position.y);
+        m_sdlDrawer->renderFromSurface(m_bmpBar, m_position.x, m_position.y);
     }
 
     if (m_alpha > -1) {
-        m_renderDrawer->renderFromSurface(m_bmpBar, m_position.x, m_position.y, m_alpha);
+        m_sdlDrawer->renderFromSurface(m_bmpBar, m_position.x, m_position.y, m_alpha);
         // draw message
         m_textDrawer->drawText(m_position.x+13, m_position.y+6, Color{0, 0, 0,Uint8(m_alpha)}, m_message, false);
     }

--- a/src/drawers/cMessageDrawer.h
+++ b/src/drawers/cMessageDrawer.h
@@ -65,7 +65,7 @@ private:
     messages::eMessageDrawerState m_state;
     messages::eMessageDrawerFadingState m_fadeState;
     cTextDrawer* m_textDrawer=nullptr;
-    SDLDrawer* m_renderDrawer=nullptr;
+    SDLDrawer* m_sdlDrawer=nullptr;
     GameContext* m_ctx;
     Graphics* m_gfxinter;
 

--- a/src/drawers/cMiniMapDrawer.cpp
+++ b/src/drawers/cMiniMapDrawer.cpp
@@ -36,7 +36,7 @@ cMiniMapDrawer::cMiniMapDrawer(GameContext *ctx, cMap *map, cPlayer *player, cMa
     m_mapCamera(mapCamera),
     m_ctx(ctx),
     m_gfxinter(ctx->getGraphicsContext()->gfxinter.get()),
-    m_renderDrawer(ctx->getSDLDrawer()),
+    m_sdlDrawer(ctx->getSDLDrawer()),
     m_status(eMinimapStatus::NOTAVAILABLE),
     m_iStaticFrame(STAT14),
     m_iTrans(0)
@@ -67,7 +67,7 @@ cMiniMapDrawer::cMiniMapDrawer(GameContext *ctx, cMap *map, cPlayer *player, cMa
     m_RectFullMinimap = cRectangle(topLeftX, topLeftY, cSideBar::WidthOfMinimap, cSideBar::HeightOfMinimap);
     //std::cout << "Minimap top left corner: (" << m_RectMinimap.getX() << ", " << m_RectMinimap.getY() << ", " << m_RectMinimap.getWidth() << ", " << m_RectMinimap.getHeight() << ")" << std::endl;
     //std::cout << "RectFullMinimap: (" << m_RectFullMinimap.getX() << ", " << m_RectFullMinimap.getY() << ", " << m_RectFullMinimap.getWidth() << ", " << m_RectFullMinimap.getHeight() << ")" << std::endl;
-    m_mipMapTex = m_renderDrawer->createRenderTargetTexture(getMapWidthInPixels(), getMapHeightInPixels());
+    m_mipMapTex = m_sdlDrawer->createRenderTargetTexture(getMapWidthInPixels(), getMapHeightInPixels());
 }
 
 cMiniMapDrawer::~cMiniMapDrawer()
@@ -94,7 +94,7 @@ void cMiniMapDrawer::draw()
         return;
     }
 
-    m_renderDrawer->renderRectFillColor(m_RectFullMinimap, Color::Black);
+    m_sdlDrawer->renderRectFillColor(m_RectFullMinimap, Color::Black);
 
     if (m_status == eMinimapStatus::POWERUP || m_status == eMinimapStatus::RENDERMAP || m_status == eMinimapStatus::POWERDOWN) {
         drawTerrain();
@@ -105,7 +105,7 @@ void cMiniMapDrawer::draw()
         cleanDrawTerrain();
         drawUnitsAndStructures(true);
     }
-    m_renderDrawer->renderStrechFullSprite(m_mipMapTex, m_RectMinimap);
+    m_sdlDrawer->renderStrechFullSprite(m_mipMapTex, m_RectMinimap);
 
     drawStaticFrame();
     drawViewPortRectangle();
@@ -118,7 +118,7 @@ void cMiniMapDrawer::drawStaticFrame()
     if (m_status == eMinimapStatus::LOWPOWER) return;
 
     if (m_status == eMinimapStatus::POWERDOWN) {
-        m_renderDrawer->renderStrechFullSprite(m_gfxinter->getTexture(m_iStaticFrame), m_RectFullMinimap);
+        m_sdlDrawer->renderStrechFullSprite(m_gfxinter->getTexture(m_iStaticFrame), m_RectFullMinimap);
         return;
     }
 
@@ -132,7 +132,7 @@ void cMiniMapDrawer::drawStaticFrame()
 
     // non-stat01 frames are drawn transparent
     if (m_iStaticFrame != STAT01) {
-        m_renderDrawer->renderStrechFullSprite(m_gfxinter->getTexture(m_iStaticFrame), m_RectFullMinimap,m_iTrans);
+        m_sdlDrawer->renderStrechFullSprite(m_gfxinter->getTexture(m_iStaticFrame), m_RectFullMinimap,m_iTrans);
     }
 }
 
@@ -236,7 +236,7 @@ void cMiniMapDrawer::onNotifyMouseEvent(const s_MouseEvent &event)
 
 void cMiniMapDrawer::drawTerrain()
 {
-    m_renderDrawer->beginDrawingToTexture(m_mipMapTex);
+    m_sdlDrawer->beginDrawingToTexture(m_mipMapTex);
     Color iColor = Color{0, 0, 0,255};
 
     for (int x = 0; x < (m_map->getWidth()); x++) {
@@ -255,10 +255,10 @@ void cMiniMapDrawer::drawTerrain()
                 iColor = Color{0, 0, 0,255};
             }
 
-            m_renderDrawer->renderDot(x, y, iColor, 1);
+            m_sdlDrawer->renderDot(x, y, iColor, 1);
         }
     }
-    m_renderDrawer->endDrawingToTexture();
+    m_sdlDrawer->endDrawingToTexture();
 }
 
 void cMiniMapDrawer::drawViewPortRectangle()
@@ -295,7 +295,7 @@ void cMiniMapDrawer::drawViewPortRectangle()
     if (startY + minimapHeight > m_RectFullMinimap.getEndY()) {
         minimapHeight = m_RectFullMinimap.getEndY() - startY;
     }
-    m_renderDrawer->renderRectColor(startX, startY, minimapWidth, minimapHeight, Color{255, 255, 255,255});
+    m_sdlDrawer->renderRectColor(startX, startY, minimapWidth, minimapHeight, Color{255, 255, 255,255});
 }
 
 /**
@@ -304,7 +304,7 @@ void cMiniMapDrawer::drawViewPortRectangle()
  * @param playerOnly (if false, draws all other players than player)
  */
 void cMiniMapDrawer::drawUnitsAndStructures(bool playerOnly) const {
-    m_renderDrawer->beginDrawingToTexture(m_mipMapTex);
+    m_sdlDrawer->beginDrawingToTexture(m_mipMapTex);
     const Color black = Color::Black;
     for (int x = 0; x < m_map->getWidth(); x++) {
         for (int y = 0; y < m_map->getHeight(); y++) {
@@ -360,10 +360,10 @@ void cMiniMapDrawer::drawUnitsAndStructures(bool playerOnly) const {
             if (iColor.r == black.r && iColor.g == black.g && iColor.b == black.b) {
                 continue;
             }
-            m_renderDrawer->renderDot(x, y, iColor, 1);
+            m_sdlDrawer->renderDot(x, y, iColor, 1);
         }
     }
-    m_renderDrawer->endDrawingToTexture();
+    m_sdlDrawer->endDrawingToTexture();
 }
 
 Color cMiniMapDrawer::getRGBColorForTerrainType(int terrainType)
@@ -476,9 +476,9 @@ void cMiniMapDrawer::onMousePressedRight(const s_MouseEvent &event)
 }
 
 void cMiniMapDrawer::cleanDrawTerrain() const {
-    m_renderDrawer->beginDrawingToTexture(m_mipMapTex);
-    m_renderDrawer->renderClearToColor(Color::Black);
-    m_renderDrawer->endDrawingToTexture();
+    m_sdlDrawer->beginDrawingToTexture(m_mipMapTex);
+    m_sdlDrawer->renderClearToColor(Color::Black);
+    m_sdlDrawer->endDrawingToTexture();
 }
 
 int cMiniMapDrawer::getMouseCell(int mouseX, int mouseY)

--- a/src/drawers/cMiniMapDrawer.h
+++ b/src/drawers/cMiniMapDrawer.h
@@ -90,7 +90,7 @@ private:
     cRectangle m_RectFullMinimap; // the total space it could take
     Texture *m_mipMapTex;
     Graphics *m_gfxinter;
-    SDLDrawer *m_renderDrawer;
+    SDLDrawer *m_sdlDrawer;
 
     eMinimapStatus m_status;
 

--- a/src/drawers/cOrderDrawer.cpp
+++ b/src/drawers/cOrderDrawer.cpp
@@ -14,13 +14,13 @@
 
 cOrderDrawer::cOrderDrawer(GameContext *ctx, cPlayer *player) :
     m_ctx(ctx),
-    m_renderDrawer(ctx->getSDLDrawer()),
+    m_sdlDrawer(ctx->getSDLDrawer()),
     m_player(player)
 {
     d2tm_assert(player != nullptr);
     d2tm_assert(ctx != nullptr);
     auto *gfxinter = m_ctx->getGraphicsContext()->gfxinter.get();
-    m_buttonBitmap = createPlayerTextureFromIndexedSurfaceWithPalette(m_renderDrawer, player, gfxinter->getSurface(BTN_ORDER), TransparentColorIndex);
+    m_buttonBitmap = createPlayerTextureFromIndexedSurfaceWithPalette(m_sdlDrawer, player, gfxinter->getSurface(BTN_ORDER), TransparentColorIndex);
     int halfOfButton = m_buttonBitmap->w / 2;
     int halfOfSidebar = cSideBar::SidebarWidthWithoutCandyBar / 2;
     int halfOfHeightLeftForButton = 50 / 2; // 50 = height of 1 row icons which is removed for Starport
@@ -41,11 +41,11 @@ void cOrderDrawer::drawOrderButton(cPlayer *thePlayer)
     cOrderProcesser *orderProcesser = thePlayer->getOrderProcesser();
 
     d2tm_assert(orderProcesser);
-    m_renderDrawer->renderSprite(m_buttonBitmap, m_buttonRect.getX(), m_buttonRect.getY());
+    m_sdlDrawer->renderSprite(m_buttonBitmap, m_buttonRect.getX(), m_buttonRect.getY());
 
     bool canOrder = orderProcesser->canPlaceOrder();
     if (!canOrder) {
-        m_renderDrawer->renderRectFillColor(m_buttonRect, Color::Black, 128);
+        m_sdlDrawer->renderRectFillColor(m_buttonRect, Color::Black, 128);
     }
 
     if (m_isMouseOverOrderButton && canOrder) {
@@ -60,8 +60,8 @@ void cOrderDrawer::drawRectangleOrderButton()
     int width = m_buttonRect.getWidth();
     int height = m_buttonRect.getHeight();
     Color color = m_player->getHouseFadingColor();
-    m_renderDrawer->renderRectColor(x, y, width, height, color);
-    m_renderDrawer->renderRectColor(x+1, y+1, width-2, height-2, color);
+    m_sdlDrawer->renderRectColor(x, y, width, height, color);
+    m_sdlDrawer->renderRectColor(x+1, y+1, width-2, height-2, color);
 }
 
 void cOrderDrawer::onMouseAt(const s_MouseEvent &event)

--- a/src/drawers/cOrderDrawer.h
+++ b/src/drawers/cOrderDrawer.h
@@ -32,7 +32,7 @@ private:
 
     bool m_isMouseOverOrderButton;
     GameContext *m_ctx;
-    SDLDrawer *m_renderDrawer;
+    SDLDrawer *m_sdlDrawer;
     cPlayer *m_player;
     cRectangle m_buttonRect;
     Texture *m_buttonBitmap;

--- a/src/drawers/cPlaceItDrawer.cpp
+++ b/src/drawers/cPlaceItDrawer.cpp
@@ -19,7 +19,7 @@
 
 #include "include/cAssert.h"
 
-cPlaceItDrawer::cPlaceItDrawer(GameContext *ctx, cPlayer *thePlayer, cStructureUtils *structureUtils) : m_structureUtils(structureUtils), m_player(thePlayer), m_ctx(ctx), m_renderDrawer(ctx->getSDLDrawer())
+cPlaceItDrawer::cPlaceItDrawer(GameContext *ctx, cPlayer *thePlayer, cStructureUtils *structureUtils) : m_structureUtils(structureUtils), m_player(thePlayer), m_ctx(ctx), m_sdlDrawer(ctx->getSDLDrawer())
 {
     d2tm_assert(thePlayer != nullptr);
     d2tm_assert(ctx != nullptr);
@@ -162,7 +162,7 @@ void cPlaceItDrawer::drawStatusOfStructureAtCell(cBuildingListItem *itemToPlace,
                 float posX = iX * desiredWidth;
                 float posY = iY * desiredHeight;
                 // cRectangle rectangle = cRectangle(posX, posY, desiredWidth, desiredHeight);
-                m_renderDrawer->renderRectFillColor(iDrawX+posX, iDrawY+posY, desiredWidth, desiredHeight,itemToPlaceColor);
+                m_sdlDrawer->renderRectFillColor(iDrawX+posX, iDrawY+posY, desiredWidth, desiredHeight,itemToPlaceColor);
             }
         }
     }
@@ -201,5 +201,5 @@ void cPlaceItDrawer::drawStructureIdAtMousePos(cBuildingListItem *itemToPlace)
     // which cannot be used in this case)
     cRectangle src = { 0, 0, width, height}; // takes first frame
     cRectangle dest= {iDrawX, iDrawY, scaledWidth, scaledHeight};
-    m_renderDrawer->renderStrechSprite(bmp, src, dest,96);
+    m_sdlDrawer->renderStrechSprite(bmp, src, dest,96);
 }

--- a/src/drawers/cPlaceItDrawer.h
+++ b/src/drawers/cPlaceItDrawer.h
@@ -30,7 +30,7 @@ private:
     cStructureUtils* m_structureUtils = nullptr;
     cPlayer *m_player;
     GameContext *m_ctx;
-    SDLDrawer *m_renderDrawer;
+    SDLDrawer *m_sdlDrawer;
     Graphics *m_gfxdata;
     cGameObjectContext* m_objects = nullptr;
     cInfoContext* m_infos = nullptr;

--- a/src/drawers/cSideBarDrawer.cpp
+++ b/src/drawers/cSideBarDrawer.cpp
@@ -20,7 +20,7 @@
 cSideBarDrawer::cSideBarDrawer(GameContext *ctx, cPlayer *player) :
     m_player(player),
     m_gfxinter(ctx->getGraphicsContext()->gfxinter.get()),
-    m_renderDrawer(ctx->getSDLDrawer()),
+    m_sdlDrawer(ctx->getSDLDrawer()),
     m_ctx(ctx),
     m_buildingListDrawer(ctx, player),
     m_sidebar(nullptr),
@@ -36,10 +36,10 @@ cSideBarDrawer::cSideBarDrawer(GameContext *ctx, cPlayer *player) :
     m_candyHorizonBar = createPlayerTextureFromIndexedSurfaceWithPalette(m_ctx->getSDLDrawer(),
         m_player, m_gfxinter->getSurface(HORIZONTAL_CANDYBAR), TransparentColorIndex);
 
-    m_candiBarRenderer = m_renderDrawer->createRenderTargetTexture(cSideBar::SidebarWidth, m_ctx->getGameInterface()->getGameSettings()->getScreenH()-40);
-    m_renderDrawer->beginDrawingToTexture(m_candiBarRenderer);
+    m_candiBarRenderer = m_sdlDrawer->createRenderTargetTexture(cSideBar::SidebarWidth, m_ctx->getGameInterface()->getGameSettings()->getScreenH()-40);
+    m_sdlDrawer->beginDrawingToTexture(m_candiBarRenderer);
     createCandyBar();
-    m_renderDrawer->endDrawingToTexture();
+    m_sdlDrawer->endDrawingToTexture();
 }
 
 cSideBarDrawer::~cSideBarDrawer()
@@ -71,7 +71,7 @@ void cSideBarDrawer::onNotifyKeyboardEvent(const cKeyboardEvent &event)
 void cSideBarDrawer::draw()
 {
     // black out sidebar
-    m_renderDrawer->renderRectFillColor((m_ctx->getGameInterface()->getGameSettings()->getScreenW() - cSideBar::SidebarWidth), 0, cSideBar::SidebarWidth, m_ctx->getGameInterface()->getGameSettings()->getScreenH(), Color{0, 0, 0,255});
+    m_sdlDrawer->renderRectFillColor((m_ctx->getGameInterface()->getGameSettings()->getScreenW() - cSideBar::SidebarWidth), 0, cSideBar::SidebarWidth, m_ctx->getGameInterface()->getGameSettings()->getScreenH(), Color{0, 0, 0,255});
 
     drawCandybar();
 
@@ -114,7 +114,7 @@ void cSideBarDrawer::drawBuildingLists()
 
     for (; drawX < m_ctx->getGameInterface()->getGameSettings()->getScreenW(); drawX += backgroundSprite->w) {
         for (int drawY=startY; drawY < m_ctx->getGameInterface()->getGameSettings()->getScreenH(); drawY += backgroundSprite->h) {
-            m_renderDrawer->renderSprite(backgroundSprite, drawX, drawY);
+            m_sdlDrawer->renderSprite(backgroundSprite, drawX, drawY);
         }
     }
 
@@ -125,8 +125,8 @@ void cSideBarDrawer::drawBuildingLists()
     int iDrawY = m_buildingListDrawer.getDrawY();
 
     Texture *horBar = m_gfxinter->getTexture(BMP_GERALD_SIDEBAR_PIECE);
-    m_renderDrawer->renderSprite(horBar, iDrawX-1, iDrawY-38); // above sublist buttons
-    m_renderDrawer->renderSprite(horBar, iDrawX-1, iDrawY-5); // above normal icons
+    m_sdlDrawer->renderSprite(horBar, iDrawX-1, iDrawY-38); // above sublist buttons
+    m_sdlDrawer->renderSprite(horBar, iDrawX-1, iDrawY-5); // above normal icons
 
     if (selectedListId > -1) {
         selectedList = m_sidebar->getList(selectedListId);
@@ -143,25 +143,25 @@ void cSideBarDrawer::drawBuildingLists()
         int barX = (iDrawX - 1) + (i * 66);
         Color darker = Color{89, 56, 0,255};
         Color veryDark = Color{48, 28, 0,255};
-        m_renderDrawer->renderLine( barX - 1, iDrawY, barX - 1, endY, darker);
-        m_renderDrawer->renderLine( barX, iDrawY, barX, endY, veryDark);
+        m_sdlDrawer->renderLine( barX - 1, iDrawY, barX - 1, endY, darker);
+        m_sdlDrawer->renderLine( barX, iDrawY, barX, endY, veryDark);
 
         // horizontal lines
         for (int j = 1; j < rows; j++) {
             int barY = iDrawY - 1 + (j * 50);
-            m_renderDrawer->renderLine( iDrawX, barY-1, m_ctx->getGameInterface()->getGameSettings()->getScreenW(), barY - 1, darker);
-            m_renderDrawer->renderLine( iDrawX, barY, m_ctx->getGameInterface()->getGameSettings()->getScreenW(), barY, veryDark);
+            m_sdlDrawer->renderLine( iDrawX, barY-1, m_ctx->getGameInterface()->getGameSettings()->getScreenW(), barY - 1, darker);
+            m_sdlDrawer->renderLine( iDrawX, barY, m_ctx->getGameInterface()->getGameSettings()->getScreenW(), barY, veryDark);
         }
     }
 
     if (selectedList && selectedList->getType() == eListType::LIST_STARPORT) {
-        m_renderDrawer->renderRectFillColor(iDrawX, endY, m_ctx->getGameInterface()->getGameSettings()->getScreenW()-iDrawX, m_ctx->getGameInterface()->getGameSettings()->getScreenH()-endY, m_sidebarColor);
-        m_renderDrawer->renderSprite(horBar, iDrawX-1, endY); // just below the last icons
+        m_sdlDrawer->renderRectFillColor(iDrawX, endY, m_ctx->getGameInterface()->getGameSettings()->getScreenW()-iDrawX, m_ctx->getGameInterface()->getGameSettings()->getScreenH()-endY, m_sidebarColor);
+        m_sdlDrawer->renderSprite(horBar, iDrawX-1, endY); // just below the last icons
     }
 
     // vertical lines at the side
-    m_renderDrawer->renderLine( iDrawX - 1, iDrawY-38, iDrawX-1, m_ctx->getGameInterface()->getGameSettings()->getScreenH(), Color{255, 211, 125,255}); // left
-    m_renderDrawer->renderLine( m_ctx->getGameInterface()->getGameSettings()->getScreenW() - 1, iDrawY - 38, m_ctx->getGameInterface()->getGameSettings()->getScreenW() - 1, endY, Color{209, 150, 28,255}); // right
+    m_sdlDrawer->renderLine( iDrawX - 1, iDrawY-38, iDrawX-1, m_ctx->getGameInterface()->getGameSettings()->getScreenH(), Color{255, 211, 125,255}); // left
+    m_sdlDrawer->renderLine( m_ctx->getGameInterface()->getGameSettings()->getScreenW() - 1, iDrawY - 38, m_ctx->getGameInterface()->getGameSettings()->getScreenW() - 1, endY, Color{209, 150, 28,255}); // right
 
     // END drawing icons grid
 
@@ -199,7 +199,7 @@ void cSideBarDrawer::drawCapacities()
 
 void cSideBarDrawer::drawCandybar()
 {
-    m_renderDrawer->renderSprite(m_candiBarRenderer,m_ctx->getGameInterface()->getGameSettings()->getScreenW() - cSideBar::SidebarWidth,40);
+    m_sdlDrawer->renderSprite(m_candiBarRenderer,m_ctx->getGameInterface()->getGameSettings()->getScreenW() - cSideBar::SidebarWidth,40);
 }
 
 void cSideBarDrawer::drawMinimap()
@@ -209,7 +209,7 @@ void cSideBarDrawer::drawMinimap()
     // 128 pixels (each pixel is a cell) + 8 margin
     int heightMinimap = cSideBar::HeightOfMinimap;
     int drawY = cSideBar::TopBarHeight + heightMinimap;
-    m_renderDrawer->renderSprite(sprite, drawX, drawY);
+    m_sdlDrawer->renderSprite(sprite, drawX, drawY);
 
     // 11, 10
     // 78, 60
@@ -223,7 +223,7 @@ void cSideBarDrawer::drawMinimap()
     }
 
     // else, we render the house emblem
-    m_renderDrawer->renderRectFillColor(drawX + 1, cSideBar::TopBarHeight + 1,m_ctx->getGameInterface()->getGameSettings()->getScreenW()-(drawX + 1), drawY-(cSideBar::TopBarHeight + 1),
+    m_sdlDrawer->renderRectFillColor(drawX + 1, cSideBar::TopBarHeight + 1,m_ctx->getGameInterface()->getGameSettings()->getScreenW()-(drawX + 1), drawY-(cSideBar::TopBarHeight + 1),
                                       m_player->getEmblemBackgroundColor());
 
     if (m_player->isHouse(ATREIDES) || m_player->isHouse(HARKONNEN) || m_player->isHouse(ORDOS) || m_player->isHouse(SARDAUKAR)) {
@@ -260,7 +260,7 @@ void cSideBarDrawer::drawMinimap()
 
         cRectangle src = {srcX, srcY, emblemWidth,emblemHeight};
         cRectangle dest = {drawX, drawY, emblemDesiredWidth, emblemDesiredHeight};
-        m_renderDrawer->renderStrechSprite(m_gfxinter->getTexture(bitmapId), src, dest);
+        m_sdlDrawer->renderStrechSprite(m_gfxinter->getTexture(bitmapId), src, dest);
     }
 }
 
@@ -268,34 +268,34 @@ void cSideBarDrawer::createCandyBar()
 {
     int heightInPixels = (m_ctx->getGameInterface()->getGameSettings()->getScreenH() - cSideBar::TopBarHeight);
     // ball first
-    m_renderDrawer->renderSprite(m_candyBarBall, 0,0); // height of ball = 25
-    m_renderDrawer->renderSprite(m_gfxinter->getTexture(BMP_GERALD_CANDYBAR_TOP), 0, 26); // height of top = 10
+    m_sdlDrawer->renderSprite(m_candyBarBall, 0,0); // height of ball = 25
+    m_sdlDrawer->renderSprite(m_gfxinter->getTexture(BMP_GERALD_CANDYBAR_TOP), 0, 26); // height of top = 10
     // now draw pieces untill the end (height of piece is 23 pixels)
     int startY = 26 + 10; // end of ball (26) + height of top m_candybar (=10) , makes 36
     int heightMinimap = cSideBar::HeightOfMinimap;
     // auto tmp = cRectangle{0,0,24, heightMinimap - (6 + 1)};  // (add 1 pixel for room between ball and bar)
     for (int y = startY; y < (heightMinimap); y += 24) {
-        m_renderDrawer->renderSprite(m_candyBarPiece, 0, y);
+        m_sdlDrawer->renderSprite(m_candyBarPiece, 0, y);
     }
     // note: no need to take top bar into account because 'm_candybar' is a separate bitmap so coords start at 0,0
     // ball is 6 pixels higher than horizontal m_candybar
     int ballY = (heightMinimap) - 6;
 
     // draw bottom m_candybar
-    m_renderDrawer->renderSprite(m_gfxinter->getTexture(BMP_GERALD_CANDYBAR_BOTTOM), 0, ballY - 10); // height of bottom = 9
+    m_sdlDrawer->renderSprite(m_gfxinter->getTexture(BMP_GERALD_CANDYBAR_BOTTOM), 0, ballY - 10); // height of bottom = 9
 
     // draw ball
-    m_renderDrawer->renderSprite(m_candyBarBall, 0, ballY); // height of ball = 25
+    m_sdlDrawer->renderSprite(m_candyBarBall, 0, ballY); // height of ball = 25
 
     // draw top m_candybar again
-    m_renderDrawer->renderSprite(m_gfxinter->getTexture(BMP_GERALD_CANDYBAR_TOP), 0, ballY + 26); // height of top = 10
+    m_sdlDrawer->renderSprite(m_gfxinter->getTexture(BMP_GERALD_CANDYBAR_TOP), 0, ballY + 26); // height of top = 10
 
     startY = ballY + 26 + 10;
     for (int y = startY; y < (heightInPixels + 23); y += 24) {
-        m_renderDrawer->renderSprite(m_candyBarPiece, 0, y);
+        m_sdlDrawer->renderSprite(m_candyBarPiece, 0, y);
     }
     // draw bottom
-    m_renderDrawer->renderSprite(m_gfxinter->getTexture(BMP_GERALD_CANDYBAR_BOTTOM), 0, heightInPixels - 10); // height of top = 10
+    m_sdlDrawer->renderSprite(m_gfxinter->getTexture(BMP_GERALD_CANDYBAR_BOTTOM), 0, heightInPixels - 10); // height of top = 10
 }
 
 void cSideBarDrawer::drawPowerUsage() const
@@ -306,7 +306,7 @@ void cSideBarDrawer::drawPowerUsage() const
     int barY = cSideBar::TotalHeightBeforePowerBarStarts + arbitraryMargin;
     int barWidth = (cSideBar::VerticalCandyBarWidth / 3) - 1;
     //cRectangle powerBarRect(barX, barY, barWidth, barTotalHeight);
-    m_renderDrawer->renderRectFillColor(barX, barY, barWidth, barTotalHeight, Color::Black); //renderDrawer->getColor_BLACK());
+    m_sdlDrawer->renderRectFillColor(barX, barY, barWidth, barTotalHeight, Color::Black); //sdlDrawer->getColor_BLACK());
 
     // the maximum power (ie a full bar) is 1 + amount windtraps * power_give (100)
     int maxPowerOutageOfWindtrap = m_infos->getStructureInfo(WINDTRAP).power_give;
@@ -318,7 +318,7 @@ void cSideBarDrawer::drawPowerUsage() const
     if (barHeightToDraw > barTotalHeight) barHeightToDraw = barTotalHeight;
     int powerInY = barY + (barTotalHeight - barHeightToDraw);
 
-    m_renderDrawer->renderRectFillColor(barX, powerInY, barWidth, barY+barTotalHeight-powerInY, Color{0, 232, 0,255});
+    m_sdlDrawer->renderRectFillColor(barX, powerInY, barWidth, barY+barTotalHeight-powerInY, Color{0, 232, 0,255});
 
     barHeightToDraw = barTotalHeight * powerUse;
     if (barHeightToDraw > barTotalHeight) barHeightToDraw = barTotalHeight;
@@ -332,25 +332,25 @@ void cSideBarDrawer::drawPowerUsage() const
     if (g > 255) g = 255;
 
     if (m_player->bEnoughPower()) {
-        m_renderDrawer->renderRectFillColor(barX, powerOutY, barWidth, barY + barTotalHeight-powerOutY, Color{(Uint8)r, (Uint8)g, 32,255});
+        m_sdlDrawer->renderRectFillColor(barX, powerOutY, barWidth, barY + barTotalHeight-powerOutY, Color{(Uint8)r, (Uint8)g, 32,255});
     }
     else {
-        m_renderDrawer->renderRectFillColor(barX, powerOutY, barWidth, barY + barTotalHeight-powerOutY, m_player->getErrorFadingColor());
+        m_sdlDrawer->renderRectFillColor(barX, powerOutY, barWidth, barY + barTotalHeight-powerOutY, m_player->getErrorFadingColor());
     }
 
-    m_renderDrawer->renderLine(barX, powerOutY, barX+barWidth, powerOutY, Color{255, 255, 255,255});
+    m_sdlDrawer->renderLine(barX, powerOutY, barX+barWidth, powerOutY, Color{255, 255, 255,255});
 
-    m_renderDrawer->renderRectColor(barX, barY, barWidth, barTotalHeight, m_sidebarColor);
+    m_sdlDrawer->renderRectColor(barX, barY, barWidth, barTotalHeight, m_sidebarColor);
 
     // draw darker 'sides' at the left and top
     Color darker = Color{89, 56, 0,255};
-    m_renderDrawer->renderLine(barX, barY, barX, barY + barTotalHeight, darker); // left side |
-    m_renderDrawer->renderLine(barX, barY, barX+barWidth, barY, darker); // top side _
+    m_sdlDrawer->renderLine(barX, barY, barX, barY + barTotalHeight, darker); // left side |
+    m_sdlDrawer->renderLine(barX, barY, barX+barWidth, barY, darker); // top side _
     if (m_player->bEnoughPower()) {
-        m_renderDrawer->renderSprite(m_gfxinter->getTexture(ICON_POWER_HIGH),barX-3, barY - 21);
+        m_sdlDrawer->renderSprite(m_gfxinter->getTexture(ICON_POWER_HIGH),barX-3, barY - 21);
     }
     else {
-        m_renderDrawer->renderSprite(m_gfxinter->getTexture(ICON_POWER),barX-3, barY - 21);
+        m_sdlDrawer->renderSprite(m_gfxinter->getTexture(ICON_POWER),barX-3, barY - 21);
     }
 }
 
@@ -361,7 +361,7 @@ void cSideBarDrawer::drawCreditsUsage()
     int barY = cSideBar::TopBarHeight + 48;
     int barWidth = (cSideBar::VerticalCandyBarWidth / 3) - 1;
     // cRectangle powerBarRect(barX, barY, barWidth, barTotalHeight);
-    m_renderDrawer->renderRectFillColor(barX, barY, barWidth, barTotalHeight, 0,0,0,255);
+    m_sdlDrawer->renderRectFillColor(barX, barY, barWidth, barTotalHeight, 0,0,0,255);
 
     // STEFAN: 01/05/2021 -> looks like a lot of this code can be moved to the player class to retrieve max spice capacity
     // and so forth.
@@ -377,7 +377,7 @@ void cSideBarDrawer::drawCreditsUsage()
     if (barHeightToDraw > barTotalHeight) barHeightToDraw = barTotalHeight;
     int powerInY = barY + (barTotalHeight - barHeightToDraw);
 
-    m_renderDrawer->renderRectFillColor(barX, powerInY, barWidth, barY + barTotalHeight - powerInY, Color{0, 232, 0,255});
+    m_sdlDrawer->renderRectFillColor(barX, powerInY, barWidth, barY + barTotalHeight - powerInY, Color{0, 232, 0,255});
 
     barHeightToDraw = barTotalHeight * spiceStored;
     if (barHeightToDraw > barTotalHeight) barHeightToDraw = barTotalHeight;
@@ -392,24 +392,24 @@ void cSideBarDrawer::drawCreditsUsage()
     if (g > 255) g = 255;
 
     if (m_player->bEnoughSpiceCapacityToStoreCredits()) {
-        m_renderDrawer->renderRectFillColor(barX, powerOutY, barWidth, barY + barTotalHeight - powerOutY, (Uint8)r,(Uint8)g, 32,255);
+        m_sdlDrawer->renderRectFillColor(barX, powerOutY, barWidth, barY + barTotalHeight - powerOutY, (Uint8)r,(Uint8)g, 32,255);
     }
     else {
-        m_renderDrawer->renderRectFillColor(barX, powerOutY, barWidth, barY + barTotalHeight - powerOutY, m_player->getErrorFadingColor());
+        m_sdlDrawer->renderRectFillColor(barX, powerOutY, barWidth, barY + barTotalHeight - powerOutY, m_player->getErrorFadingColor());
     }
 
-    m_renderDrawer->renderLine( barX, powerOutY, barX+barWidth, powerOutY, Color{255, 255, 255,255});
+    m_sdlDrawer->renderLine( barX, powerOutY, barX+barWidth, powerOutY, Color{255, 255, 255,255});
 
     // draw darker 'sides' at the left and top
     Color darker = Color{89, 56, 0,255};
-    m_renderDrawer->renderLine( barX, barY, barX, barY + barTotalHeight, darker); // left side |
-    m_renderDrawer->renderLine( barX, barY, barX+barWidth, barY, darker); // top side _
+    m_sdlDrawer->renderLine( barX, barY, barX, barY + barTotalHeight, darker); // left side |
+    m_sdlDrawer->renderLine( barX, barY, barX+barWidth, barY, darker); // top side _
 
     if (spiceCapacityRatio>0.95) {
-        m_renderDrawer->renderSprite(m_gfxinter->getTexture(ICON_SOLARIS_FULL), barX-5, barY-20);
+        m_sdlDrawer->renderSprite(m_gfxinter->getTexture(ICON_SOLARIS_FULL), barX-5, barY-20);
     } else  if (spiceCapacityRatio<0.05) {
-        m_renderDrawer->renderSprite(m_gfxinter->getTexture(ICON_SOLARIS_LOW), barX-5, barY-20);
+        m_sdlDrawer->renderSprite(m_gfxinter->getTexture(ICON_SOLARIS_LOW), barX-5, barY-20);
     } else {
-        m_renderDrawer->renderSprite(m_gfxinter->getTexture(ICON_SOLARIS), barX-5, barY-20);
+        m_sdlDrawer->renderSprite(m_gfxinter->getTexture(ICON_SOLARIS), barX-5, barY-20);
     }
 }

--- a/src/drawers/cSideBarDrawer.h
+++ b/src/drawers/cSideBarDrawer.h
@@ -43,7 +43,7 @@ protected:
 private:
     cPlayer *m_player;
     Graphics *m_gfxinter;
-    SDLDrawer* m_renderDrawer;
+    SDLDrawer* m_sdlDrawer;
     GameContext* m_ctx = nullptr;
     cInfoContext* m_infos = nullptr;
     cBuildingListDrawer m_buildingListDrawer;

--- a/src/drawers/cStructureDrawer.cpp
+++ b/src/drawers/cStructureDrawer.cpp
@@ -27,7 +27,7 @@
 #include "include/cAssert.h"
 
 cStructureDrawer::cStructureDrawer(GameContext *ctx, cPlayer *player, cStructureUtils *structureUtils) :
-    m_renderDrawer(ctx->getSDLDrawer()),
+    m_sdlDrawer(ctx->getSDLDrawer()),
     m_textDrawer(ctx->getTextContext()->getBeneTextDrawer()),
     m_gfxinter(ctx->getGraphicsContext()->gfxinter.get()),
     m_gfxdata(ctx->getGraphicsContext()->gfxdata.get()),
@@ -36,7 +36,7 @@ cStructureDrawer::cStructureDrawer(GameContext *ctx, cPlayer *player, cStructure
     m_ctx(ctx)
 {
     d2tm_assert(ctx != nullptr);
-    d2tm_assert(m_renderDrawer != nullptr);
+    d2tm_assert(m_sdlDrawer != nullptr);
     d2tm_assert(m_textDrawer != nullptr);
     d2tm_assert(m_gfxinter != nullptr);
     d2tm_assert(m_gfxdata != nullptr);
@@ -83,7 +83,7 @@ void cStructureDrawer::drawRectangleOfStructure(cAbstractStructure *theStructure
     int width_x = m_mapCamera->factorZoomLevel(width);
     int height_y = m_mapCamera->factorZoomLevel(height);
 
-    m_renderDrawer->renderRectColor(drawX, drawY, width_x, height_y, color.r, color.g, color.b, 96);
+    m_sdlDrawer->renderRectColor(drawX, drawY, width_x, height_y, color.r, color.g, color.b, 96);
 }
 
 void cStructureDrawer::drawStructurePrebuildAnimation(cAbstractStructure *structure)
@@ -102,7 +102,7 @@ void cStructureDrawer::drawStructurePrebuildAnimation(cAbstractStructure *struct
 
     // Draw prebuild
     cRectangle dest= {drawX, drawY, scaledWidth, scaledHeight};
-    m_renderDrawer->renderStrechFullSprite(m_gfxdata->getTexture(iDrawPreBuild), dest);
+    m_sdlDrawer->renderStrechFullSprite(m_gfxdata->getTexture(iDrawPreBuild), dest);
 }
 
 void cStructureDrawer::drawStructureAnimation(cAbstractStructure *structure)
@@ -185,7 +185,7 @@ void cStructureDrawer::drawStructureAnimationTurret(cAbstractStructure *structur
             int x2 = m_mapCamera->getWindowXPosition(structure->pos_x() + 16);
             int y2 = m_mapCamera->getWindowYPosition(structure->pos_y() + 16);
 
-            m_renderDrawer->renderLine( x1, y1, x2, y2, Color{255, 255, 255,255});
+            m_sdlDrawer->renderLine( x1, y1, x2, y2, Color{255, 255, 255,255});
 
             int mouseCellX = m_objects->getMapGeometry()->getCellX(pContext->getMouseCell());
             int mouseCellY = m_objects->getMapGeometry()->getCellY(pContext->getMouseCell());
@@ -291,7 +291,7 @@ void cStructureDrawer::renderIconThatStructureIsBeingRepaired(cAbstractStructure
     int scaledWidth = m_mapCamera->factorZoomLevel(iconWidth);
     int scaledHeight = m_mapCamera->factorZoomLevel(iconHeight);
     cRectangle dest = {drawX+offsetXScaled, drawY + offsetYScaled, scaledWidth, scaledHeight};
-    m_renderDrawer->renderStrechFullSprite(m_gfxdata->getTexture(MOUSE_REPAIR), dest);
+    m_sdlDrawer->renderStrechFullSprite(m_gfxdata->getTexture(MOUSE_REPAIR), dest);
 }
 
 void cStructureDrawer::renderIconOfUnitBeingRepaired(cAbstractStructure *structure) const
@@ -322,11 +322,11 @@ void cStructureDrawer::renderIconOfUnitBeingRepaired(cAbstractStructure *structu
     if (r > 255) r = 255;
 
     // bar itself
-    m_renderDrawer->renderRectFillColor(draw_x, draw_y, width_x+1, height_y+1, 0,0,0,255);
-    m_renderDrawer->renderRectFillColor(draw_x, draw_y, (w-1), height_y,r,g,32,255);
+    m_sdlDrawer->renderRectFillColor(draw_x, draw_y, width_x+1, height_y+1, 0,0,0,255);
+    m_sdlDrawer->renderRectFillColor(draw_x, draw_y, (w-1), height_y,r,g,32,255);
 
     // bar around it
-    m_renderDrawer->renderRectColor(draw_x, draw_y, width_x, height_y, Color{255, 255, 255,255});
+    m_sdlDrawer->renderRectColor(draw_x, draw_y, width_x, height_y, Color{255, 255, 255,255});
     int drawX = structure->iDrawX();
     int drawY = structure->iDrawY();
     int offsetX = (structure->getWidthInPixels() - iconWidth) / 2;
@@ -336,7 +336,7 @@ void cStructureDrawer::renderIconOfUnitBeingRepaired(cAbstractStructure *structu
     int scaledWidth = m_mapCamera->factorZoomLevel(iconWidth);
     int scaledHeight = m_mapCamera->factorZoomLevel(iconHeight);
     cRectangle dest = {drawX + offsetXScaled, drawY + offsetYScaled, scaledWidth, scaledHeight};
-    m_renderDrawer->renderStrechFullSprite(m_gfxinter->getTexture(iconId), dest);
+    m_sdlDrawer->renderStrechFullSprite(m_gfxinter->getTexture(iconId), dest);
 }
 
 void cStructureDrawer::drawStructuresForLayer(int layer)
@@ -361,7 +361,7 @@ void cStructureDrawer::drawStructuresForLayer(int layer)
         }
     }
 
-    m_renderDrawer->renderRectFillColor((m_ctx->getGameInterface()->getGameSettings()->getScreenW() - cSideBar::SidebarWidth), 0,
+    m_sdlDrawer->renderRectFillColor((m_ctx->getGameInterface()->getGameSettings()->getScreenW() - cSideBar::SidebarWidth), 0,
                                       cSideBar::SidebarWidth, m_ctx->getGameInterface()->getGameSettings()->getScreenH(), 0, 0, 0,255);
 }
 
@@ -393,9 +393,9 @@ void cStructureDrawer::drawStructureHealthBar(int iStructure)
     if (r > 255) r = 255;
 
     // bar itself
-    m_renderDrawer->renderRectFillColor(draw_x, draw_y, width_x+1, height_y+1, 0,0,0,255);
-    m_renderDrawer->renderRectFillColor(draw_x, draw_y, (w-1), height_y, (Uint8)r,(Uint8)g,32,255);
+    m_sdlDrawer->renderRectFillColor(draw_x, draw_y, width_x+1, height_y+1, 0,0,0,255);
+    m_sdlDrawer->renderRectFillColor(draw_x, draw_y, (w-1), height_y, (Uint8)r,(Uint8)g,32,255);
 
     // bar around it
-    m_renderDrawer->renderRectColor(draw_x, draw_y, width_x, height_y, Color{255, 255, 255,255});
+    m_sdlDrawer->renderRectColor(draw_x, draw_y, width_x, height_y, Color{255, 255, 255,255});
 }

--- a/src/drawers/cStructureDrawer.h
+++ b/src/drawers/cStructureDrawer.h
@@ -37,7 +37,7 @@ protected:
     int determinePreBuildAnimationIndex(cAbstractStructure *structure);
 
 private:
-    SDLDrawer* m_renderDrawer;
+    SDLDrawer* m_sdlDrawer;
     cTextDrawer* m_textDrawer;
     Graphics *m_gfxinter;
     Graphics *m_gfxdata;

--- a/src/game/cGame.h
+++ b/src/game/cGame.h
@@ -230,7 +230,7 @@ private:
     Texture *actualRenderer= nullptr;
     cTextDrawer* m_textDrawer = nullptr;
     cTimeManager* m_timeManager;
-    SDLDrawer *m_renderDrawer = nullptr;
+    SDLDrawer *m_sdlDrawer = nullptr;
 
     std::unique_ptr<cHousesInfo> m_Houses;
     bool m_missionWasWon;               // hack: used for state transitioning :/

--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -436,7 +436,7 @@ void cGame::drawState()
 {
     if (m_cScreenFader->getAction() == eFadeAction::FadeOut) {
         if (screenTexture) {
-            m_renderDrawer->renderSprite(screenTexture,0,0,m_cScreenFader->getAlpha());
+            m_sdlDrawer->renderSprite(screenTexture,0,0,m_cScreenFader->getAlpha());
         }
         return;
     }
@@ -459,8 +459,8 @@ void cGame::drawState()
 */
 void cGame::run()
 {
-    actualRenderer = m_renderDrawer->createRenderTargetTexture(m_gameSettings->m_screenW, m_gameSettings->m_screenH);
-    screenTexture = m_renderDrawer->createRenderTargetTexture(m_gameSettings->m_screenW, m_gameSettings->m_screenH);
+    actualRenderer = m_sdlDrawer->createRenderTargetTexture(m_gameSettings->m_screenW, m_gameSettings->m_screenH);
+    screenTexture = m_sdlDrawer->createRenderTargetTexture(m_gameSettings->m_screenW, m_gameSettings->m_screenH);
     SDL_Event event;
     while (m_gameSettings->m_playing) {
         if (m_focusManager->isGameWindowActive()) {
@@ -507,15 +507,15 @@ void cGame::run()
         m_currentState->update();
         //Logger::print(LOG_INFO , COMP_NONE, "m_currentState", "m_currentState {}", gameStateToString(m_currentState->getType()));
 
-        m_renderDrawer->beginDrawingToTexture(actualRenderer);
-        m_renderDrawer->renderClearToColor();
+        m_sdlDrawer->beginDrawingToTexture(actualRenderer);
+        m_sdlDrawer->renderClearToColor();
         drawState(); // run game state, includes interaction + drawing
         transitionStateIfRequired();
         shakeScreenAndBlitBuffer();
 
-        m_renderDrawer->endDrawingToTexture();
-        m_renderDrawer->renderClearToColor();  // SDL3 persists its intermediate texture between frames; clear before composite
-        m_renderDrawer->renderSprite(actualRenderer, m_screenShake->getX(), m_screenShake->getY());
+        m_sdlDrawer->endDrawingToTexture();
+        m_sdlDrawer->renderClearToColor();  // SDL3 persists its intermediate texture between frames; clear before composite
+        m_sdlDrawer->renderSprite(actualRenderer, m_screenShake->getX(), m_screenShake->getY());
         SDL_RenderPresent(renderer);
         m_timeManager->waitForCPU(); // wait for CPU to catch up, so we don't run too fast
     }
@@ -633,11 +633,11 @@ bool cGame::setupGame()
     // share Graphics to all class what use ctx !
     ctx->setGraphicsContext(context->createGraphicsContext());
     // creation SDLDrawer and send it to GameContext, so it can be used by all classes that have access to GameContext
-    std::unique_ptr<SDLDrawer> renderDrawer = std::make_unique<SDLDrawer>(renderer);
-    m_renderDrawer = renderDrawer.get();
-    ctx->setSDLDrawer(std::move(renderDrawer));
+    std::unique_ptr<SDLDrawer> sdlDrawer = std::make_unique<SDLDrawer>(renderer);
+    m_sdlDrawer = sdlDrawer.get();
+    ctx->setSDLDrawer(std::move(sdlDrawer));
     // share Text to all class what use ctx !
-    ctx->setTextContext(context->createTextContext(m_gameSettings.get(), m_renderDrawer));
+    ctx->setTextContext(context->createTextContext(m_gameSettings.get(), m_sdlDrawer));
     //m_gameObjectsContext->getMap()->setGameContext(ctx.get());
 
     m_textDrawer = ctx->getTextContext()->getGameTextDrawer();
@@ -652,16 +652,16 @@ bool cGame::setupGame()
         m_soundPlayer->setMusicEnabled(false);
     }
 
-    m_notificationArea->setDrawer(m_renderDrawer);
+    m_notificationArea->setDrawer(m_sdlDrawer);
     m_guiConsole = std::make_unique<GuiConsole>(
-        m_renderDrawer,
+        m_sdlDrawer,
         m_textDrawer,
         m_notificationArea.get(),
         m_gameSettings->getScreenW(),
         m_gameSettings->getScreenH());
 
     auto previewMaps = m_gameObjectsContext->getPreviewMaps();
-    previewMaps->setRenderDrawer(m_renderDrawer); // inject render drawer into cPreviewMaps that is part of game objects context, so it can be used to create textures for map previews
+    previewMaps->setSDLDrawer(m_sdlDrawer); // inject render drawer into cPreviewMaps that is part of game objects context, so it can be used to create textures for map previews
     previewMaps->loadSkirmishMaps(); // load skirmish maps, so they are ready when we need them in the skirmish setup state
 
     // do it here, because it depends on fonts to be loaded
@@ -725,7 +725,7 @@ bool cGame::setupGame()
     m_mouse->setMouseObserver(this);
     m_keyboard->setKeyboardObserver(this);
 
-    // I need m_renderDrawer to create cPreviewMaps
+    // I need m_sdlDrawer to create cPreviewMaps
     // m_PreviewMaps = std::make_shared<cPreviewMaps>();
 
     // m_gameObjectsContext->getMap()->setGameContext(ctx.get());
@@ -1630,16 +1630,16 @@ void cGame::initiateFadingOut()
 {
     m_cScreenFader->startFadeOut();
 
-    m_renderDrawer->beginDrawingToTexture(screenTexture);
+    m_sdlDrawer->beginDrawingToTexture(screenTexture);
     SDL_RenderTexture(renderer, actualRenderer->tex.get(), nullptr, nullptr);
-    m_renderDrawer->endDrawingToTexture();
+    m_sdlDrawer->endDrawingToTexture();
 }
 
 void cGame::takeBackGroundScreen()
 {
-    m_renderDrawer->beginDrawingToTexture(screenTexture);
+    m_sdlDrawer->beginDrawingToTexture(screenTexture);
     SDL_RenderTexture(renderer, actualRenderer->tex.get(), nullptr, nullptr);
-    m_renderDrawer->endDrawingToTexture();
+    m_sdlDrawer->endDrawingToTexture();
 }
 
 s_DataCampaign* cGame::getDataCampaign() const

--- a/src/gameobjects/map/cPreviewMaps.cpp
+++ b/src/gameobjects/map/cPreviewMaps.cpp
@@ -49,9 +49,9 @@ int cPreviewMaps::getMapCount() const
     return static_cast<int>(m_PreviewMap.size()-1); // -1 because the first map is reserved for the random map, which is not a real skirmish map
 }
 
-void cPreviewMaps::setRenderDrawer(SDLDrawer *renderDrawer)
+void cPreviewMaps::setSDLDrawer(SDLDrawer *sdlDrawer)
 {
-    m_renderDrawer = renderDrawer;
+    m_sdlDrawer = sdlDrawer;
 }
 
 void cPreviewMaps::destroy()
@@ -142,7 +142,7 @@ void cPreviewMaps::loadSkirmish(const std::string &filename)
     if (previewMap->terrain == nullptr) {
         previewMap->terrain = SDL_CreateSurface(previewMap->width, previewMap->height, SDL_PIXELFORMAT_RGBA32);
     }
-    m_renderDrawer->FillWithColor(previewMap->terrain, Color::Black);
+    m_sdlDrawer->FillWithColor(previewMap->terrain, Color::Black);
 
     for (int iY = 0; iY < maxHeight; iY++) {
         const char *mapLine = vecmap[iY].c_str();
@@ -191,7 +191,7 @@ void cPreviewMaps::loadSkirmish(const std::string &filename)
             }
 
             previewMap->terrainType[iCll] = terrainType;
-            m_renderDrawer->setPixel(previewMap->terrain, 1 + iX, 1 + iY, iColor);
+            m_sdlDrawer->setPixel(previewMap->terrain, 1 + iX, 1 + iY, iColor);
         }
     }
 
@@ -201,11 +201,11 @@ void cPreviewMaps::loadSkirmish(const std::string &filename)
         if (startCell > -1) {
             int x = mapGeom.getCellX(startCell);
             int y = mapGeom.getCellY(startCell);
-            m_renderDrawer->setPixel(previewMap->terrain, 1 + x, 1 + y, Color::White);
+            m_sdlDrawer->setPixel(previewMap->terrain, 1 + x, 1 + y, Color::White);
         }
     }
     if (previewMap->terrain!= nullptr){
-        SDL_Texture* out = SDL_CreateTextureFromSurface(m_renderDrawer->getRenderer(), previewMap->terrain);
+        SDL_Texture* out = SDL_CreateTextureFromSurface(m_sdlDrawer->getRenderer(), previewMap->terrain);
         if (out == nullptr) {
             Logger::error(COMP_SDL2, "cPreviewMaps", "Error creating texture from surface: {}", SDL_GetError());
             return;

--- a/src/gameobjects/map/cPreviewMaps.h
+++ b/src/gameobjects/map/cPreviewMaps.h
@@ -29,7 +29,7 @@ class cPreviewMaps {
 public:
     cPreviewMaps();
 
-    void setRenderDrawer(SDLDrawer *renderDrawer);
+    void setSDLDrawer(SDLDrawer *sdlDrawer);
 
     ~cPreviewMaps() = default;
 
@@ -52,5 +52,5 @@ private:
     std::unique_ptr<s_PreviewMap> m_emptyMap;
 
     std::vector<std::unique_ptr<s_PreviewMap>> m_PreviewMap;
-    SDLDrawer * m_renderDrawer = nullptr;
+    SDLDrawer * m_sdlDrawer = nullptr;
 };

--- a/src/gameobjects/mentat/AbstractMentat.cpp
+++ b/src/gameobjects/mentat/AbstractMentat.cpp
@@ -40,7 +40,7 @@ AbstractMentat::AbstractMentat(GameContext* ctx, bool canMissionSelect)
     m_gameInterface = ctx->getGameInterface();
     gfxmentat = ctx->getGraphicsContext()->gfxmentat.get();
     m_textDrawer = ctx->getTextContext()->getBeneTextDrawer();
-    m_renderDrawer = ctx->getSDLDrawer();
+    m_sdlDrawer = ctx->getSDLDrawer();
     iMentatSentence = -1;
 
     TIMER_Speaking = -1;
@@ -77,7 +77,7 @@ AbstractMentat::AbstractMentat(GameContext* ctx, bool canMissionSelect)
             .withRect(toMissionSelectRect)
             .withLabel("Mission select")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .onClick([this] {
@@ -262,17 +262,17 @@ void AbstractMentat::thinkMouth()  // MOUTH
 
 void AbstractMentat::draw()
 {
-    m_renderDrawer->renderClearToColor(Color{7,7,15,255});
-    m_renderDrawer->renderRectColor(offsetX-1, offsetY-1, 641, 481, Color{64, 64,89,255});
-    m_renderDrawer->renderRectColor(offsetX-2, offsetY-2, 642, 482, Color{40,40,60,255});
-    m_renderDrawer->renderRectColor(offsetX-3, offsetY-3, 643, 483, Color{0,0,0,255});
+    m_sdlDrawer->renderClearToColor(Color{7,7,15,255});
+    m_sdlDrawer->renderRectColor(offsetX-1, offsetY-1, 641, 481, Color{64, 64,89,255});
+    m_sdlDrawer->renderRectColor(offsetX-2, offsetY-2, 642, 482, Color{40,40,60,255});
+    m_sdlDrawer->renderRectColor(offsetX-3, offsetY-3, 643, 483, Color{0,0,0,255});
 
     // movie
     draw_movie();
 
     Texture *tmp = getBackgroundBitmap();
     cRectangle dest = {offsetX, offsetY, MENTAT_SCREEN_W, MENTAT_SCREEN_H};
-    m_renderDrawer->renderStrechFullSprite(tmp, dest);
+    m_sdlDrawer->renderStrechFullSprite(tmp, dest);
 
     draw_eyes();
     draw_mouth();
@@ -317,7 +317,7 @@ void AbstractMentat::draw_movie()
     // drawing only, circulating is done in think function
     Texture *tmp = gfxmovie->getTexture(iMovieFrame);
     cRectangle dest = {movieTopleftX, movieTopleftY,tmp->w, tmp->h};
-    m_renderDrawer->renderStrechFullSprite(tmp, dest);
+    m_sdlDrawer->renderStrechFullSprite(tmp, dest);
 }
 
 void AbstractMentat::initSentences()
@@ -338,7 +338,7 @@ void AbstractMentat::loadScene(const std::string &scene)
     char filename[255];
     snprintf(filename, sizeof(filename), "data/scenes/sdl_%s.dat", scene.c_str());
 
-    gfxmovie = std::make_shared<Graphics>(m_renderDrawer->getRenderer(),filename);
+    gfxmovie = std::make_shared<Graphics>(m_sdlDrawer->getRenderer(),filename);
 
     TIMER_movie = 0;
     iMovieFrame=0;

--- a/src/gameobjects/mentat/AbstractMentat.h
+++ b/src/gameobjects/mentat/AbstractMentat.h
@@ -104,7 +104,7 @@ protected:
 
     eMentatState state;
     cTextDrawer* m_textDrawer = nullptr;
-    SDLDrawer* m_renderDrawer;
+    SDLDrawer* m_sdlDrawer;
 
     cRectangle *leftButton;
     cRectangle *rightButton;

--- a/src/gameobjects/mentat/AtreidesMentat.cpp
+++ b/src/gameobjects/mentat/AtreidesMentat.cpp
@@ -20,7 +20,7 @@ AtreidesMentat::AtreidesMentat(GameContext* ctx, bool allowMissionSelect) : Abst
             .withRect(*leftButton)        
             .withLabel("Repeat")
             .withTexture(gfxmentat->getTexture(BTN_REPEAT))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
             .onClick([this]() {this->resetSpeak();})
             .build();
@@ -29,7 +29,7 @@ AtreidesMentat::AtreidesMentat(GameContext* ctx, bool allowMissionSelect) : Abst
             .withRect(*rightButton)        
             .withLabel("Yes")
             .withTexture(gfxmentat->getTexture(BTN_YES))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
             .onClick([this]() {
                 Logger::info(COMP_GAME, "AtreidesMentat", "changing state from mentat");
@@ -55,10 +55,10 @@ void AtreidesMentat::draw_other()
 
 void AtreidesMentat::draw_eyes()
 {
-    m_renderDrawer->renderSprite(gfxmentat->getTexture(ATR_EYES01+ iMentatEyes),  offsetX + 80, offsetY + 241);
+    m_sdlDrawer->renderSprite(gfxmentat->getTexture(ATR_EYES01+ iMentatEyes),  offsetX + 80, offsetY + 241);
 }
 
 void AtreidesMentat::draw_mouth()
 {
-    m_renderDrawer->renderSprite(gfxmentat->getTexture(ATR_MOUTH01+ iMentatMouth),  offsetX + 80, offsetY + 273);
+    m_sdlDrawer->renderSprite(gfxmentat->getTexture(ATR_MOUTH01+ iMentatMouth),  offsetX + 80, offsetY + 273);
 }

--- a/src/gameobjects/mentat/BeneMentat.cpp
+++ b/src/gameobjects/mentat/BeneMentat.cpp
@@ -28,7 +28,7 @@ BeneMentat::BeneMentat(GameContext* ctx, s_DataCampaign* dataCampaign) : Abstrac
             .withRect(*leftButton)
             .withLabel("No")
             .withTexture(gfxmentat->getTexture(BTN_NO))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
             .onClick([this]() { this->onNoButtonPressed(); })
             .build();
@@ -37,7 +37,7 @@ BeneMentat::BeneMentat(GameContext* ctx, s_DataCampaign* dataCampaign) : Abstrac
             .withRect(*rightButton)
             .withLabel("Yes")
             .withTexture(gfxmentat->getTexture(BTN_YES))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
             .onClick([this]() { this->onYesButtonPressed(); })
             .build();
@@ -89,12 +89,12 @@ void BeneMentat::draw_other()
 
 void BeneMentat::draw_eyes()
 {
-    m_renderDrawer->renderSprite(gfxmentat->getTexture(BEN_EYES01+ iMentatEyes), offsetX + 128, offsetY + 240);
+    m_sdlDrawer->renderSprite(gfxmentat->getTexture(BEN_EYES01+ iMentatEyes), offsetX + 128, offsetY + 240);
 }
 
 void BeneMentat::draw_mouth()
 {
-    m_renderDrawer->renderSprite(gfxmentat->getTexture(BEN_MOUTH01+ iMentatMouth), offsetX + 112, offsetY + 272);
+    m_sdlDrawer->renderSprite(gfxmentat->getTexture(BEN_MOUTH01+ iMentatMouth), offsetX + 112, offsetY + 272);
 }
 
 void BeneMentat::onNotifyKeyboardEvent(const cKeyboardEvent &event)

--- a/src/gameobjects/mentat/HarkonnenMentat.cpp
+++ b/src/gameobjects/mentat/HarkonnenMentat.cpp
@@ -19,7 +19,7 @@ HarkonnenMentat::HarkonnenMentat(GameContext* ctx, bool allowMissionSelect) : Ab
             .withRect(*leftButton)        
             .withLabel("Repeat")
             .withTexture(gfxmentat->getTexture(BTN_REPEAT))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
             .onClick([this]() {this->resetSpeak();})
             .build();
@@ -28,7 +28,7 @@ HarkonnenMentat::HarkonnenMentat(GameContext* ctx, bool allowMissionSelect) : Ab
             .withRect(*rightButton)        
             .withLabel("Yes")
             .withTexture(gfxmentat->getTexture(BTN_YES))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
             .onClick([this]() {
                 Logger::info(COMP_GAME, "HarkonnenMentat", "changing state from mentat"); 
@@ -53,10 +53,10 @@ void HarkonnenMentat::draw_other()
 
 void HarkonnenMentat::draw_eyes()
 {
-    m_renderDrawer->renderSprite(gfxmentat->getTexture(HAR_EYES01+ iMentatEyes), offsetX + 64, offsetY + 256);
+    m_sdlDrawer->renderSprite(gfxmentat->getTexture(HAR_EYES01+ iMentatEyes), offsetX + 64, offsetY + 256);
 }
 
 void HarkonnenMentat::draw_mouth()
 {
-    m_renderDrawer->renderSprite(gfxmentat->getTexture(HAR_MOUTH01+ iMentatMouth), offsetX + 64, offsetY + 288);
+    m_sdlDrawer->renderSprite(gfxmentat->getTexture(HAR_MOUTH01+ iMentatMouth), offsetX + 64, offsetY + 288);
 }

--- a/src/gameobjects/mentat/OrdosMentat.cpp
+++ b/src/gameobjects/mentat/OrdosMentat.cpp
@@ -18,7 +18,7 @@ OrdosMentat::OrdosMentat(GameContext* ctx, bool allowMissionSelect) : AbstractMe
             .withRect(*leftButton)        
             .withLabel("Repeat")
             .withTexture(gfxmentat->getTexture(BTN_REPEAT))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
             .onClick([this]() {this->resetSpeak();})
             .build();
@@ -27,7 +27,7 @@ OrdosMentat::OrdosMentat(GameContext* ctx, bool allowMissionSelect) : AbstractMe
             .withRect(*rightButton)        
             .withLabel("Yes")
             .withTexture(gfxmentat->getTexture(BTN_YES))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
             .onClick([this]() {
                 Logger::info(COMP_GAME, "OrdosMentat", "changing state from mentat"); 
@@ -52,10 +52,10 @@ void OrdosMentat::draw_other()
 
 void OrdosMentat::draw_eyes()
 {
-    m_renderDrawer->renderSprite(gfxmentat->getTexture(ORD_EYES01+ iMentatEyes), offsetX + 32, offsetY + 240);
+    m_sdlDrawer->renderSprite(gfxmentat->getTexture(ORD_EYES01+ iMentatEyes), offsetX + 32, offsetY + 240);
 }
 
 void OrdosMentat::draw_mouth()
 {
-    m_renderDrawer->renderSprite(gfxmentat->getTexture(ORD_MOUTH01+ iMentatMouth), offsetX + 31, offsetY + 270);
+    m_sdlDrawer->renderSprite(gfxmentat->getTexture(ORD_MOUTH01+ iMentatMouth), offsetX + 31, offsetY + 270);
 }

--- a/src/gameobjects/mentat/SardaukarMentat.cpp
+++ b/src/gameobjects/mentat/SardaukarMentat.cpp
@@ -19,7 +19,7 @@ SardaukarMentat::SardaukarMentat(GameContext* ctx, bool allowMissionSelect) : Ab
             .withRect(*leftButton)        
             .withLabel("Repeat")
             .withTexture(gfxmentat->getTexture(BTN_REPEAT))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
             .onClick([this]() {this->resetSpeak();})
             .build();
@@ -28,7 +28,7 @@ SardaukarMentat::SardaukarMentat(GameContext* ctx, bool allowMissionSelect) : Ab
             .withRect(*rightButton)        
             .withLabel("Yes")
             .withTexture(gfxmentat->getTexture(BTN_YES))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::WITH_TEXTURE)
             .onClick([this]() {
                 Logger::info(COMP_NONE, "cYesButtonCommand::changeStateFromMentat", "called");
@@ -53,10 +53,10 @@ void SardaukarMentat::draw_other()
 
 void SardaukarMentat::draw_eyes()
 {
-    //m_renderDrawer->renderSprite(gfxmentat->getTexture(ORD_EYES01+ iMentatEyes), offsetX + 32, offsetY + 240);
+    //m_sdlDrawer->renderSprite(gfxmentat->getTexture(ORD_EYES01+ iMentatEyes), offsetX + 32, offsetY + 240);
 }
 
 void SardaukarMentat::draw_mouth()
 {
-    //m_renderDrawer->renderSprite(gfxmentat->getTexture(ORD_MOUTH01+ iMentatMouth), offsetX + 31, offsetY + 270);
+    //m_sdlDrawer->renderSprite(gfxmentat->getTexture(ORD_MOUTH01+ iMentatMouth), offsetX + 31, offsetY + 270);
 }

--- a/src/gameobjects/projectiles/bullet.cpp
+++ b/src/gameobjects/projectiles/bullet.cpp
@@ -151,7 +151,7 @@ void cBullet::draw()
 
     // Whenever this bullet is a shimmer, draw a shimmer and leave
     if (iType == BULLET_SHIMMER) {
-        //@Mira renderDrawer->shimmer(bmp_screen, mapCamera->factorZoomLevel(16), x, y, mapCamera->factorZoomLevel(4));
+        //@Mira sdlDrawer->shimmer(bmp_screen, mapCamera->factorZoomLevel(16), x, y, mapCamera->factorZoomLevel(4));
         return;
     }
 

--- a/src/gamestates/cChooseHouseState.cpp
+++ b/src/gamestates/cChooseHouseState.cpp
@@ -75,15 +75,15 @@ void cChooseHouseState::thinkFast()
 void cChooseHouseState::draw() const
 {
     // Render the planet Dune a bit downward
-    m_renderDrawer->renderSprite(bmp_Dune, coords_Dune.x, coords_Dune.y);
+    m_sdlDrawer->renderSprite(bmp_Dune, coords_Dune.x, coords_Dune.y);
 
     // HOUSES
-    m_renderDrawer->renderSprite(bmp_SelectYourHouseTitle, coords_SelectYourHouseTitle.x, coords_SelectYourHouseTitle.y);
+    m_sdlDrawer->renderSprite(bmp_SelectYourHouseTitle, coords_SelectYourHouseTitle.x, coords_SelectYourHouseTitle.y);
 
-    m_renderDrawer->renderSprite(bmp_HouseAtreides, houseAtreides.getX(), houseAtreides.getY());
-    m_renderDrawer->renderSprite(bmp_HouseOrdos, houseOrdos.getX(), houseOrdos.getY());
-    m_renderDrawer->renderSprite(bmp_HouseHarkonnen, houseHarkonnen.getX(),houseOrdos.getY());
-    m_renderDrawer->renderSprite(bmp_HouseSardaukar, houseSardaukar.getX(), houseSardaukar.getY());
+    m_sdlDrawer->renderSprite(bmp_HouseAtreides, houseAtreides.getX(), houseAtreides.getY());
+    m_sdlDrawer->renderSprite(bmp_HouseOrdos, houseOrdos.getX(), houseOrdos.getY());
+    m_sdlDrawer->renderSprite(bmp_HouseHarkonnen, houseHarkonnen.getX(),houseOrdos.getY());
+    m_sdlDrawer->renderSprite(bmp_HouseSardaukar, houseSardaukar.getX(), houseSardaukar.getY());
 
     // BACK (bottom right
     // TODO: Use actual cGuiButton

--- a/src/gamestates/cCreditsState.cpp
+++ b/src/gamestates/cCreditsState.cpp
@@ -50,7 +50,7 @@ cCreditsState::cCreditsState(sGameServices* services) :
             .withRect(backButtonRect)
             .withLabel("Back")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .onClick([this]() {
@@ -397,12 +397,12 @@ void cCreditsState::thinkFast()
 
 void cCreditsState::draw() const
 {
-    m_renderDrawer->renderSprite(m_duneBmp, m_duneCoordinates.x, m_duneCoordinates.y);
+    m_sdlDrawer->renderSprite(m_duneBmp, m_duneCoordinates.x, m_duneCoordinates.y);
 
     int halfScreen = m_settings->getScreenW() / 2;
 
     // draw crawler
-    m_renderDrawer->renderSprite(m_titleBmp, m_titleX, m_crawlerY);
+    m_sdlDrawer->renderSprite(m_titleBmp, m_titleX, m_crawlerY);
     int textCrawlY = m_crawlerY + m_titleHeight;
     for (auto &line : m_lines) {
         if (line.name.empty()) {

--- a/src/gamestates/cEditorState.cpp
+++ b/src/gamestates/cEditorState.cpp
@@ -60,10 +60,10 @@ cEditorState::cEditorState(sGameServices* services)
     const cRectangle &modifRect = cRectangle(m_settings->getScreenW()-heightBarSize, heightBarSize, heightBarSize, m_settings->getScreenH()-heightBarSize);
     mapSizeArea = cRectangle(0,heightBarSize,m_settings->getScreenW()-heightBarSize,m_settings->getScreenH()-heightBarSize);
     m_editorCam = std::make_unique<cEditorCam>(mapSizeArea);
-    m_selectBar = std::make_unique<GuiBar>(m_renderDrawer, selectRect,GuiBarPlacement::HORIZONTAL,heightButtonSize);
-    m_topologyBar = std::make_unique<GuiBar>(m_renderDrawer, modifRect,GuiBarPlacement::VERTICAL, heightButtonSize);
-    m_startCellBar = std::make_unique<GuiBar>(m_renderDrawer, modifRect,GuiBarPlacement::VERTICAL, heightButtonSize);
-    m_symmetricBar = std::make_unique<GuiBar>(m_renderDrawer, modifRect,GuiBarPlacement::VERTICAL, heightButtonSize);
+    m_selectBar = std::make_unique<GuiBar>(m_sdlDrawer, selectRect,GuiBarPlacement::HORIZONTAL,heightButtonSize);
+    m_topologyBar = std::make_unique<GuiBar>(m_sdlDrawer, modifRect,GuiBarPlacement::VERTICAL, heightButtonSize);
+    m_startCellBar = std::make_unique<GuiBar>(m_sdlDrawer, modifRect,GuiBarPlacement::VERTICAL, heightButtonSize);
+    m_symmetricBar = std::make_unique<GuiBar>(m_sdlDrawer, modifRect,GuiBarPlacement::VERTICAL, heightButtonSize);
 
     m_selectBar->setTheme(cGuiThemeBuilder().light().build());
     m_selectBar->beginPlacement(heightBarSize);
@@ -93,7 +93,7 @@ void cEditorState::populateSelectBar()
     auto guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(STONELAYER))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 setCurrentBar(m_topologyBar.get());
             })
@@ -105,7 +105,7 @@ void cEditorState::populateSelectBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(STARTPOSITION))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 setCurrentBar(m_startCellBar.get());
             })
@@ -116,7 +116,7 @@ void cEditorState::populateSelectBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(FLIPHORZ))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 setCurrentBar(m_symmetricBar.get());
             })
@@ -129,7 +129,7 @@ void cEditorState::populateSelectBar()
     auto guiIcon = GuiButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(SAVEICON))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::WITH_STRETCHED_TEXTURE)
             .onClick([this]() {
                 saveMap();
@@ -146,7 +146,7 @@ void cEditorState::populateTopologyBar()
     auto guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(TERRAN_HILL))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 idTerrainToMapModif = TERRAIN_HILL;
             })
@@ -157,7 +157,7 @@ void cEditorState::populateTopologyBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(TERRAN_MOUNTAIN))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 idTerrainToMapModif = TERRAIN_MOUNTAIN;
             })
@@ -168,7 +168,7 @@ void cEditorState::populateTopologyBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(TERRAN_ROCK))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 idTerrainToMapModif = TERRAIN_ROCK;
             })
@@ -179,7 +179,7 @@ void cEditorState::populateTopologyBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(TERRAN_SAND))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 idTerrainToMapModif = TERRAIN_SAND;
             })
@@ -191,7 +191,7 @@ void cEditorState::populateTopologyBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(TERRAN_SPICE))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 idTerrainToMapModif = TERRAIN_SPICE;
             })
@@ -202,7 +202,7 @@ void cEditorState::populateTopologyBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(TERRAN_SPICEHILL))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 idTerrainToMapModif = TERRAIN_SPICEHILL;
             })
@@ -212,7 +212,7 @@ void cEditorState::populateTopologyBar()
 
     auto cursorSizeButton = GuiValueButtonBuilder()
             .withRect(cRectangle(0, 0, heightButtonSize, heightButtonSize))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTextDrawer(m_textDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .withLabel("size")
@@ -234,7 +234,7 @@ void cEditorState::populateStartCellBar()
     auto guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(STARTPOSITION1))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 idStartCellPlayer = 0;
             })
@@ -246,7 +246,7 @@ void cEditorState::populateStartCellBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(STARTPOSITION2))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 idStartCellPlayer = 1;
             })
@@ -257,7 +257,7 @@ void cEditorState::populateStartCellBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(STARTPOSITION3))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 idStartCellPlayer = 2;
             })
@@ -268,7 +268,7 @@ void cEditorState::populateStartCellBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(STARTPOSITION4))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 idStartCellPlayer = 3;
             })
@@ -279,7 +279,7 @@ void cEditorState::populateStartCellBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(STARTPOSITION5))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 idStartCellPlayer = 4;
             })
@@ -295,7 +295,7 @@ void cEditorState::populateSymmetricBar()
     auto guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(FLIPHORZLR))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 // std::cout << "FLIPHORZLR" << std::endl;
                 modifySymmetricArea(Direction::right);
@@ -307,7 +307,7 @@ void cEditorState::populateSymmetricBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(FLIPHORZRL))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 // std::cout << "FLIPHORZRL" << std::endl;
                 modifySymmetricArea(Direction::left);
@@ -319,7 +319,7 @@ void cEditorState::populateSymmetricBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(FLIPVERTBT))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 // std::cout << "FLIPVERTBT" << std::endl;
                 modifySymmetricArea(Direction::top);
@@ -331,7 +331,7 @@ void cEditorState::populateSymmetricBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(FLIPVERTTB))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 // std::cout << "FLIPVERTTB" << std::endl;
                 modifySymmetricArea(Direction::bottom);
@@ -343,7 +343,7 @@ void cEditorState::populateSymmetricBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(FLIPDIAGBL))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 modifySymmetricArea(Direction::bottomLeft);
             })
@@ -354,7 +354,7 @@ void cEditorState::populateSymmetricBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(FLIPDIAGBR))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 modifySymmetricArea(Direction::bottomRight);
             })
@@ -365,7 +365,7 @@ void cEditorState::populateSymmetricBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(FLIPDIAGTL))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 modifySymmetricArea(Direction::topLeft);
             })
@@ -376,7 +376,7 @@ void cEditorState::populateSymmetricBar()
     guiButton = GuiStateButtonBuilder()
             .withRect(rectGui)
             .withTexture(m_gfxeditor->getTexture(FLIPDIAGTR))
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onClick([this]() {
                 modifySymmetricArea(Direction::topRight);
             })
@@ -684,22 +684,22 @@ void cEditorState::drawMap() const
             switch (tileID)
             {
             case TERRAIN_SPICE:
-                m_renderDrawer->renderStrechSprite(m_gfxdata->getTexture(TERRAIN_SPICE), srcRect, destRect);
+                m_sdlDrawer->renderStrechSprite(m_gfxdata->getTexture(TERRAIN_SPICE), srcRect, destRect);
                 break;
             case TERRAIN_SAND:
-                m_renderDrawer->renderStrechSprite(m_gfxdata->getTexture(TERRAIN_SAND), srcRect, destRect);
+                m_sdlDrawer->renderStrechSprite(m_gfxdata->getTexture(TERRAIN_SAND), srcRect, destRect);
                 break;
             case TERRAIN_MOUNTAIN:
-                m_renderDrawer->renderStrechSprite(m_gfxdata->getTexture(TERRAIN_MOUNTAIN), srcRect, destRect);
+                m_sdlDrawer->renderStrechSprite(m_gfxdata->getTexture(TERRAIN_MOUNTAIN), srcRect, destRect);
                 break;
             case TERRAIN_ROCK:
-                m_renderDrawer->renderStrechSprite(m_gfxdata->getTexture(TERRAIN_ROCK), srcRect, destRect);
+                m_sdlDrawer->renderStrechSprite(m_gfxdata->getTexture(TERRAIN_ROCK), srcRect, destRect);
                 break;
             case TERRAIN_SPICEHILL:
-                m_renderDrawer->renderStrechSprite(m_gfxdata->getTexture(TERRAIN_SPICEHILL), srcRect, destRect);
+                m_sdlDrawer->renderStrechSprite(m_gfxdata->getTexture(TERRAIN_SPICEHILL), srcRect, destRect);
                 break;  
             case TERRAIN_HILL:
-                m_renderDrawer->renderStrechSprite(m_gfxdata->getTexture(TERRAIN_HILL), srcRect, destRect);
+                m_sdlDrawer->renderStrechSprite(m_gfxdata->getTexture(TERRAIN_HILL), srcRect, destRect);
                 break;            
             default:
                 break;
@@ -753,8 +753,8 @@ void cEditorState::drawHoveredCellHighlight() const
     const int highlightHeight = (highlightEndTileY - highlightStartTileY + 1) * tileLenSize;
 
     cRectangle cellRect(cellScreenX, cellScreenY, highlightWidth, highlightHeight);
-    m_renderDrawer->renderRectFillColor(cellRect, editorHoveredCellFillColor, editorHoveredCellFillColor.a);
-    m_renderDrawer->renderRectColor(cellRect, editorHoveredCellBorderColor, editorHoveredCellBorderColor.a);
+    m_sdlDrawer->renderRectFillColor(cellRect, editorHoveredCellFillColor, editorHoveredCellFillColor.a);
+    m_sdlDrawer->renderRectColor(cellRect, editorHoveredCellBorderColor, editorHoveredCellBorderColor.a);
 }
 
 void cEditorState::drawSelectionRectangle() const
@@ -772,8 +772,8 @@ void cEditorState::drawSelectionRectangle() const
     const int highlightHeight = (m_selectionEndTileY - m_selectionStartTileY + 1) * tileLenSize;
 
     cRectangle selectionRect(cellScreenX, cellScreenY, highlightWidth, highlightHeight);
-    m_renderDrawer->renderRectFillColor(selectionRect, editorSelectionFillColor, editorSelectionFillColor.a);
-    m_renderDrawer->renderRectColor(selectionRect, editorSelectionBorderColor, editorSelectionBorderColor.a);
+    m_sdlDrawer->renderRectFillColor(selectionRect, editorSelectionFillColor, editorSelectionFillColor.a);
+    m_sdlDrawer->renderRectColor(selectionRect, editorSelectionBorderColor, editorSelectionBorderColor.a);
 }
 
 void cEditorState::drawPastePreviewGhost() const
@@ -805,8 +805,8 @@ void cEditorState::drawPastePreviewGhost() const
     const int ghostHeight = heightInTiles * tileLenSize;
 
     cRectangle ghostRect(cellScreenX, cellScreenY, ghostWidth, ghostHeight);
-    m_renderDrawer->renderRectFillColor(ghostRect, editorPasteGhostFillColor, editorPasteGhostFillColor.a);
-    m_renderDrawer->renderRectColor(ghostRect, editorPasteGhostBorderColor, editorPasteGhostBorderColor.a);
+    m_sdlDrawer->renderRectFillColor(ghostRect, editorPasteGhostFillColor, editorPasteGhostFillColor.a);
+    m_sdlDrawer->renderRectColor(ghostRect, editorPasteGhostBorderColor, editorPasteGhostBorderColor.a);
 }
 
 bool cEditorState::tryGetTileFromMouseCoords(const cPoint &coords, int &tileX, int &tileY) const
@@ -1020,7 +1020,7 @@ void cEditorState::drawGrid() const
         if (lineX < gridLeft || lineX > gridRight) {
             continue;
         }
-        m_renderDrawer->renderLine(lineX, gridTop, lineX, gridBottom, editorGridColor);
+        m_sdlDrawer->renderLine(lineX, gridTop, lineX, gridBottom, editorGridColor);
     }
 
     for (int j = startY; j <= static_cast<int>(endY); j++) {
@@ -1028,7 +1028,7 @@ void cEditorState::drawGrid() const
         if (lineY < gridTop || lineY > gridBottom) {
             continue;
         }
-        m_renderDrawer->renderLine(gridLeft, lineY, gridRight, lineY, editorGridColor);
+        m_sdlDrawer->renderLine(gridLeft, lineY, gridRight, lineY, editorGridColor);
     }
 }
 
@@ -1063,12 +1063,12 @@ void cEditorState::drawAxes() const
 
     const int middleX = (static_cast<int>(m_mapData->getCols()) * tileLenSize) / 2 - cameraX;
     if (middleX >= gridLeft && middleX <= gridRight) {
-        m_renderDrawer->renderLine(middleX, gridTop, middleX, gridBottom, editorCenterLineColor);
+        m_sdlDrawer->renderLine(middleX, gridTop, middleX, gridBottom, editorCenterLineColor);
     }
 
     const int middleY = heightBarSize + (static_cast<int>(m_mapData->getRows()) * tileLenSize) / 2 - cameraY;
     if (middleY >= gridTop && middleY <= gridBottom) {
-        m_renderDrawer->renderLine(gridLeft, middleY, gridRight, middleY, editorCenterLineColor);
+        m_sdlDrawer->renderLine(gridLeft, middleY, gridRight, middleY, editorCenterLineColor);
     }
 }
 
@@ -1330,7 +1330,7 @@ void cEditorState::drawStartCells() const
             // Display if onscreen
             if (x + tileLenSize > 0 && x < m_settings->getScreenW() &&y + tileLenSize > heightBarSize && y < m_settings->getScreenH()) {
                 destRect = cRectangle(x, y, tileLenSize, tileLenSize);
-                m_renderDrawer->renderStrechSprite(m_gfxeditor->getTexture(STARTPOSITION1+i), srcRect, destRect);
+                m_sdlDrawer->renderStrechSprite(m_gfxeditor->getTexture(STARTPOSITION1+i), srcRect, destRect);
             }
         }
     }

--- a/src/gamestates/cGamePlaying.cpp
+++ b/src/gamestates/cGamePlaying.cpp
@@ -225,7 +225,7 @@ void cGamePlaying::drawTrackingOverlays() const
     const cRectangle* battlefield = m_interface->getMapViewport();
     m_textDrawer->drawTextCentered(label, battlefield->getX(), battlefield->getWidth(), cSideBar::TopBarHeight + 10, fadingYellow);
 
-    m_renderDrawer->setClippingFor(battlefield->getX(), battlefield->getY(),
+    m_sdlDrawer->setClippingFor(battlefield->getX(), battlefield->getY(),
                                    battlefield->getX() + battlefield->getWidth(),
                                    battlefield->getY() + battlefield->getHeight());
 
@@ -235,10 +235,10 @@ void cGamePlaying::drawTrackingOverlays() const
         cRectangle box(u->draw_x(), u->draw_y(),
                        static_cast<int>(m_mapCamera->factorZoomLevel(u->getBmpWidth())),
                        static_cast<int>(m_mapCamera->factorZoomLevel(u->getBmpHeight())));
-        m_renderDrawer->renderRectColor(box, Color::Yellow, alpha);
+        m_sdlDrawer->renderRectColor(box, Color::Yellow, alpha);
     }
 
-    m_renderDrawer->resetClippingFor();
+    m_sdlDrawer->resetClippingFor();
 }
 
 void cGamePlaying::draw() const
@@ -394,13 +394,13 @@ void cGamePlaying::drawCombatMouse() const
 {
     auto m_mouse = m_interface->getMouse();
     if (m_mouse->isBoxSelecting()) {
-        m_renderDrawer->renderRectColor(m_mouse->getBoxSelectRectangle(), m_interface->getColorFadeSelectedLimited(Color::White, 0.5f));
+        m_sdlDrawer->renderRectColor(m_mouse->getBoxSelectRectangle(), m_interface->getColorFadeSelectedLimited(Color::White, 0.5f));
     }
 
     if (m_mouse->isMapScrolling()) {
         cPoint startPoint = m_mouse->getDragLineStartPoint();
         cPoint endPoint = m_mouse->getDragLineEndPoint();
-        m_renderDrawer->renderLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y, m_interface->getColorFadeSelectedLimited(Color::White, 0.5f));
+        m_sdlDrawer->renderLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y, m_interface->getColorFadeSelectedLimited(Color::White, 0.5f));
     }
     m_mouse->draw();
 

--- a/src/gamestates/cGameState.cpp
+++ b/src/gamestates/cGameState.cpp
@@ -6,7 +6,7 @@
 
 cGameState::cGameState(sGameServices* services) :
     m_ctx(services->ctx),
-    m_renderDrawer(m_ctx->getSDLDrawer())
+    m_sdlDrawer(m_ctx->getSDLDrawer())
 {
     d2tm_assert(m_ctx != nullptr);
 }

--- a/src/gamestates/cGameState.h
+++ b/src/gamestates/cGameState.h
@@ -66,7 +66,7 @@ public:
 
 protected:
     GameContext* m_ctx=nullptr;
-    SDLDrawer* m_renderDrawer=nullptr;
+    SDLDrawer* m_sdlDrawer=nullptr;
 private:
 
 };

--- a/src/gamestates/cMainMenuState.cpp
+++ b/src/gamestates/cMainMenuState.cpp
@@ -60,7 +60,7 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
             .withRect(creditsRect)        
             .withLabel("CREDITS")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .onClick([this]() {
@@ -83,7 +83,7 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
     buttonWidth = mainMenuWidth - 8;
 
     const cRectangle &window = cRectangle(mainMenuFrameX, mainMenuFrameY, mainMenuWidth, mainMenuHeight);
-    gui_window = std::make_unique<GuiWindow>(m_renderDrawer, window, m_textDrawer);
+    gui_window = std::make_unique<GuiWindow>(m_sdlDrawer, window, m_textDrawer);
     gui_window->setTheme(cGuiThemeBuilder().light().build());
 
     const cRectangle &campaign = cRectangle(buttonsX, playY, buttonWidth, buttonHeight);
@@ -91,7 +91,7 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
             .withRect(campaign)        
             .withLabel("Campaign")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .onClick([this]() {
@@ -106,7 +106,7 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
             .withRect(skirmish)        
             .withLabel("Skirmish")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .onClick([this]() {
@@ -123,7 +123,7 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
             .withRect(multiplayer)        
             .withLabel("Multiplayer")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().inactive().build())
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .onClick([this](){m_interface->initiateFadingOut();})
@@ -137,7 +137,7 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
             .withRect(load)        
             .withLabel("Load")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().inactive().build())
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .onClick([this](){m_interface->initiateFadingOut();})
@@ -151,7 +151,7 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
             .withRect(editors)        
             .withLabel("New Map Editor")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .onClick([this](){m_interface->setTransitionToWithFadingOut(GAME_NEW_MAP_EDITOR);})
@@ -165,7 +165,7 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
             .withRect(options)        
             .withLabel("Options")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .onClick([this](){m_interface->setNextStateToTransitionTo(GAME_OPTIONS);})
@@ -179,7 +179,7 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
             .withRect(hof)        
             .withLabel("Hall of Fame")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().inactive().build())
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .onClick([this](){m_interface->initiateFadingOut();})
@@ -193,7 +193,7 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
             .withRect(exit)        
             .withLabel("Exit")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .onClick([this]() {
@@ -204,14 +204,14 @@ cMainMenuState::cMainMenuState(sGameServices* services) :
 
     // prepare to drawing in cache texture
     if (m_settings->isDebugMode()) {
-        backGroundDebug = m_renderDrawer->createRenderTargetTexture(m_settings->getScreenW(), m_settings->getScreenH());
-        m_renderDrawer->beginDrawingToTexture(backGroundDebug);
+        backGroundDebug = m_sdlDrawer->createRenderTargetTexture(m_settings->getScreenW(), m_settings->getScreenH());
+        m_sdlDrawer->beginDrawingToTexture(backGroundDebug);
         for (int x = 0; x < m_settings->getScreenW(); x += 60) {
             for (int y = 0; y < m_settings->getScreenH(); y += 20) {
                 m_textDrawer->drawText(x, y, Color{48, 48, 48,255}, "DEBUG");
             }
         }
-        m_renderDrawer->endDrawingToTexture();
+        m_sdlDrawer->endDrawingToTexture();
     }
 }
 
@@ -230,10 +230,10 @@ void cMainMenuState::thinkFast()
 void cMainMenuState::draw() const
 {
     if (m_settings->isDebugMode()) {
-        m_renderDrawer->renderSprite(backGroundDebug,0,0);
+        m_sdlDrawer->renderSprite(backGroundDebug,0,0);
     }
 
-    m_renderDrawer->renderSprite(bmp_D2TM_Title, logoX, logoY);
+    m_sdlDrawer->renderSprite(bmp_D2TM_Title, logoX, logoY);
 
     gui_window->draw();
     gui_btn_credits->draw();

--- a/src/gamestates/cNewmapEditorState.cpp
+++ b/src/gamestates/cNewmapEditorState.cpp
@@ -43,7 +43,7 @@ void cNewMapEditorState::constructWindow()
     int buttonWidth = mainMenuWidth - 8;
 
     const cRectangle &window = cRectangle(mainMenuFrameX, mainMenuFrameY, mainMenuWidth, mainMenuHeight);
-    m_guiWindow = std::make_unique<GuiWindow>(m_renderDrawer, window, m_textDrawer);
+    m_guiWindow = std::make_unique<GuiWindow>(m_sdlDrawer, window, m_textDrawer);
     m_guiWindow->setTheme(cGuiThemeBuilder().light().build());
 
     // Title
@@ -58,14 +58,14 @@ void cNewMapEditorState::constructWindow()
     auto gui_NameLabel = GuiLabelBuilder()
         .withLabel("Name your new map:")
         .withTextDrawer(m_textDrawer)
-        .withRenderer(m_renderDrawer)
+        .withRenderer(m_sdlDrawer)
         .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
         .withTextAlign(GuiTextAlignHorizontal::LEFT)
         .withRect(nameRect)
         .build();
     m_guiWindow->addGuiObject(std::move(gui_NameLabel));
 
-    auto inputName = std::make_unique<GuiTextInput>( m_renderDrawer,
+    auto inputName = std::make_unique<GuiTextInput>( m_sdlDrawer,
         m_guiWindow->getRelativeRect(labelX+200, labelY-2, 200, m_textDrawer->getFontHeight() + 4),
         m_textDrawer);
     inputName->setTheme(cGuiThemeBuilder().light().build()); 
@@ -77,14 +77,14 @@ void cNewMapEditorState::constructWindow()
     auto gui_authorLabel = GuiLabelBuilder()
         .withLabel("Name of author:")
         .withTextDrawer(m_textDrawer)
-        .withRenderer(m_renderDrawer)
+        .withRenderer(m_sdlDrawer)
         .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
         .withTextAlign(GuiTextAlignHorizontal::LEFT)
         .withRect(authorRect)
         .build();
     m_guiWindow->addGuiObject(std::move(gui_authorLabel));
     
-    auto inputAuthor = std::make_unique<GuiTextInput>(m_renderDrawer, 
+    auto inputAuthor = std::make_unique<GuiTextInput>(m_sdlDrawer, 
         m_guiWindow->getRelativeRect(labelX+200, labelY+betweenY-2, 200, m_textDrawer->getFontHeight() + 4),
         m_textDrawer);
     inputAuthor->setTheme(cGuiThemeBuilder().light().build());
@@ -96,14 +96,14 @@ void cNewMapEditorState::constructWindow()
     auto gui_descriptionLabel = GuiLabelBuilder()
         .withLabel("Description:")
         .withTextDrawer(m_textDrawer)
-        .withRenderer(m_renderDrawer)
+        .withRenderer(m_sdlDrawer)
         .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
         .withTextAlign(GuiTextAlignHorizontal::LEFT)
         .withRect(descriptionRect)
         .build();
     m_guiWindow->addGuiObject(std::move(gui_descriptionLabel));
 
-    auto inputDescription = std::make_unique<GuiTextInput>( m_renderDrawer,
+    auto inputDescription = std::make_unique<GuiTextInput>( m_sdlDrawer,
         m_guiWindow->getRelativeRect(labelX+200, labelY+betweenY*2-2, 200, m_textDrawer->getFontHeight() + 4),
         m_textDrawer);
     inputDescription->setTheme(cGuiThemeBuilder().light().build());
@@ -115,7 +115,7 @@ void cNewMapEditorState::constructWindow()
     auto gui_widthLabel = GuiLabelBuilder()
         .withLabel("Width size:")
         .withTextDrawer(m_textDrawer)
-        .withRenderer(m_renderDrawer)
+        .withRenderer(m_sdlDrawer)
         .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
         .withTextAlign(GuiTextAlignHorizontal::LEFT)
         .withRect(widthRect)
@@ -126,7 +126,7 @@ void cNewMapEditorState::constructWindow()
         .withRect( m_guiWindow->getRelativeRect(labelX+200, labelY+betweenY*3, 50, buttonHeight) )
         .withValues( m_sizesMap )
         .withTextDrawer( m_textDrawer )
-        .withRenderer(m_renderDrawer)
+        .withRenderer(m_sdlDrawer)
         .withTheme(cGuiThemeBuilder().light().build())
         .build();
     m_cycleWidth = cycleWidth.get();
@@ -137,7 +137,7 @@ void cNewMapEditorState::constructWindow()
     auto gui_heightLabel = GuiLabelBuilder()
         .withLabel("Height size:")
         .withTextDrawer(m_textDrawer)
-        .withRenderer(m_renderDrawer)
+        .withRenderer(m_sdlDrawer)
         .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
         .withTextAlign(GuiTextAlignHorizontal::LEFT)
         .withRect(heightRect)
@@ -148,7 +148,7 @@ void cNewMapEditorState::constructWindow()
         .withRect( m_guiWindow->getRelativeRect(labelX+200, labelY+betweenY*4, 50, buttonHeight) )
         .withValues( m_sizesMap )
         .withTextDrawer( m_textDrawer )
-        .withRenderer(m_renderDrawer)
+        .withRenderer(m_sdlDrawer)
         .withTheme( cGuiThemeBuilder().light().build() )
         .build();
     m_cycleHeight = cycleHeight.get();
@@ -162,7 +162,7 @@ void cNewMapEditorState::constructWindow()
         .withRect(quitRect)        
         .withLabel("Return to menu")
         .withTextDrawer(m_textDrawer)
-        .withRenderer(m_renderDrawer)
+        .withRenderer(m_sdlDrawer)
         .withTextAlign(GuiTextAlignHorizontal::CENTER)
         .withTheme(cGuiThemeBuilder().light().build())
         .onClick([this]() {
@@ -179,7 +179,7 @@ void cNewMapEditorState::constructWindow()
         .withRect(backRect)        
         .withLabel("Create map !")
         .withTextDrawer(m_textDrawer)
-        .withRenderer(m_renderDrawer)
+        .withRenderer(m_sdlDrawer)
         .withTheme(cGuiThemeBuilder().light().build())
         .onClick([this](){
             this->constructEmptyMap();

--- a/src/gamestates/cOptionsState.cpp
+++ b/src/gamestates/cOptionsState.cpp
@@ -44,7 +44,7 @@ void cOptionsState::constructWindow(int prevState)
     int buttonWidth = mainMenuWidth - 8;
 
     const cRectangle &window = cRectangle(mainMenuFrameX, mainMenuFrameY, mainMenuWidth, mainMenuHeight);
-    m_guiWindow = std::make_unique<GuiWindow>(m_renderDrawer, window, m_textDrawer);
+    m_guiWindow = std::make_unique<GuiWindow>(m_sdlDrawer, window, m_textDrawer);
     m_guiWindow->setTheme(cGuiThemeBuilder().light().build());
     cSoundPlayer* soundPlayer = m_ctx->getSoundPlayer();
 
@@ -59,7 +59,7 @@ void cOptionsState::constructWindow(int prevState)
             .withRect(toMainMenuRect)        
             .withLabel("Back to main menu")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .onClick([this]() {
                 m_interface->setTransitionToWithFadingOut(GAME_MENU);
@@ -72,7 +72,7 @@ void cOptionsState::constructWindow(int prevState)
         auto gui_cheatLabel = GuiLabelBuilder()
                 .withLabel("Cheat mode enabled")
                 .withTextDrawer(m_textDrawer)
-                .withRenderer(m_renderDrawer)
+                .withRenderer(m_sdlDrawer)
                 .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
                 .withTheme(cGuiThemeBuilder().light().withTextColor(Color::Yellow).build())
                 .withRect(cheatRect)
@@ -88,7 +88,7 @@ void cOptionsState::constructWindow(int prevState)
             .withRect(quitRect)        
             .withLabel("Quit game")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .onClick([this]() {
                 m_settings->setPlaying(false);
@@ -105,7 +105,7 @@ void cOptionsState::constructWindow(int prevState)
             .withRect(backRect)        
             .withLabel("Back")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .onClick([this,prevState](){
                 m_interface->setNextStateToTransitionTo(prevState);
@@ -123,7 +123,7 @@ void cOptionsState::constructWindow(int prevState)
             .withRect(toMissionSelectRect)        
             .withLabel("Mission select")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .onClick([this]() {
                 m_interface->setNextStateToTransitionTo(GAME_MISSIONSELECT);
@@ -135,7 +135,7 @@ void cOptionsState::constructWindow(int prevState)
     auto gui_MusicLabel = GuiLabelBuilder()
             .withLabel("Music")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .withRect(musicRect)
             .build();
@@ -144,7 +144,7 @@ void cOptionsState::constructWindow(int prevState)
     const cRectangle &musicCheckRect = m_guiWindow->getRelativeRect(5+75, 5+buttonHeight, buttonHeight, buttonHeight);
     auto gui_MusicCheckLabel = GuiCheckBoxBuilder()
             .withRect(musicCheckRect)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onCheck([soundPlayer]() {
                 soundPlayer->setMusicEnabled(true);
             })
@@ -159,7 +159,7 @@ void cOptionsState::constructWindow(int prevState)
     auto gui_MusicVolumeLabel = GuiLabelBuilder()
             .withLabel("Volume")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .withRect(musicVolumeRect)
             .build();
@@ -168,7 +168,7 @@ void cOptionsState::constructWindow(int prevState)
     const cRectangle &btn_musicVolumeRect = m_guiWindow->getRelativeRect(5+buttonWidth/4 + 50*2, 5+buttonHeight, buttonHeight*5, buttonHeight);
     auto gui_sld_musicVolumeRect = GuiSliderBuilder()
             .withRect(btn_musicVolumeRect)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withMinValue(0)
             .withMaxValue(10)
             .withInitialValue(soundPlayer->getMusicVolume())
@@ -182,7 +182,7 @@ void cOptionsState::constructWindow(int prevState)
     auto gui_SoundLabel = GuiLabelBuilder()
             .withLabel("Sound")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .withRect(soundRect)
             .build();
@@ -191,7 +191,7 @@ void cOptionsState::constructWindow(int prevState)
     const cRectangle &soundCheckRect = m_guiWindow->getRelativeRect(5+75, (5+buttonHeight)*2, buttonHeight, buttonHeight);
     auto gui_SoundCheckLabel = GuiCheckBoxBuilder()
             .withRect(soundCheckRect)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .onCheck([soundPlayer]() {
                 soundPlayer->setSoundEnabled(true);
             })
@@ -206,7 +206,7 @@ void cOptionsState::constructWindow(int prevState)
     auto gui_SoundVolumeLabel = GuiLabelBuilder()
             .withLabel("Volume")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .withRect(soundVolumeRect)
             .build();
@@ -215,7 +215,7 @@ void cOptionsState::constructWindow(int prevState)
     const cRectangle &btn_soundVolumeRect = m_guiWindow->getRelativeRect(5+buttonWidth/4 + 50*2, (5+buttonHeight)*2, buttonHeight*5, buttonHeight);
     auto gui_sld_soundVolumeRect = GuiSliderBuilder()
             .withRect(btn_soundVolumeRect)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withMinValue(0)
             .withMaxValue(10)
             .withInitialValue(soundPlayer->getSoundVolume())
@@ -229,7 +229,7 @@ void cOptionsState::constructWindow(int prevState)
     auto gui_DifficultyLabel = GuiLabelBuilder()
             .withLabel("Speed")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .withRect(speedRect)
             .build();
@@ -240,7 +240,7 @@ void cOptionsState::constructWindow(int prevState)
     int convertedForSlider = 2 - timeManager->getGlobalSpeed() + 10;
     auto gui_sld_speedRect = GuiSliderBuilder()
             .withRect(sld_speedRect)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withMinValue(2)
             .withMaxValue(10)
             .withInitialValue(convertedForSlider)
@@ -265,7 +265,7 @@ void cOptionsState::thinkFast()
 void cOptionsState::draw() const
 {
     if (m_backgroundTexture) {
-        m_renderDrawer->renderSprite(m_backgroundTexture,0,0);
+        m_sdlDrawer->renderSprite(m_backgroundTexture,0,0);
     }
     m_guiWindow->draw();
 

--- a/src/gamestates/cSelectMissionState.cpp
+++ b/src/gamestates/cSelectMissionState.cpp
@@ -29,7 +29,7 @@ cSelectMissionState::cSelectMissionState(sGameServices* services, int prevState)
     int buttonWidth = mainMenuWidth - 8;
 
     const cRectangle &window = cRectangle(mainMenuFrameX, mainMenuFrameY, mainMenuWidth, mainMenuHeight);
-    gui_window = std::make_unique<GuiWindow>(m_renderDrawer, window, m_textDrawer);
+    gui_window = std::make_unique<GuiWindow>(m_sdlDrawer, window, m_textDrawer);
     gui_window->setTheme(cGuiThemeBuilder().light().build());
 
     // Title
@@ -46,7 +46,7 @@ cSelectMissionState::cSelectMissionState(sGameServices* services, int prevState)
             .withRect(rect)        
             .withLabel(std::format("Mission {}", i))
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)    
+            .withRenderer(m_sdlDrawer)    
             .withTheme(cGuiThemeBuilder().light().build())
             .onClick([this,i]() {
                 m_interface->jumpToSelectYourNextConquestMission(i);
@@ -66,7 +66,7 @@ cSelectMissionState::cSelectMissionState(sGameServices* services, int prevState)
             .withRect(backRect)        
             .withLabel("Back")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)    
+            .withRenderer(m_sdlDrawer)    
             .withTheme(cGuiThemeBuilder().light().build())
             .onClick([this,prevState]() {
                 m_interface->setNextStateToTransitionTo(prevState);

--- a/src/gamestates/cSelectYourNextConquestState.cpp
+++ b/src/gamestates/cSelectYourNextConquestState.cpp
@@ -94,7 +94,7 @@ cSelectYourNextConquestState::cSelectYourNextConquestState(sGameServices* servic
             .withLabel("Mission select")
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(cGuiThemeBuilder().light().build())
             .onClick([this]() {
                 m_interface->setNextStateToTransitionTo(GAME_MISSIONSELECT);})
@@ -281,7 +281,7 @@ void cSelectYourNextConquestState::draw() const
 
 
     // Draw this last
-    m_renderDrawer->renderSprite(m_gfxworld->getTexture(BMP_NEXTCONQ), offsetX, offsetY); // title "Select your next Conquest"
+    m_sdlDrawer->renderSprite(m_gfxworld->getTexture(BMP_NEXTCONQ), offsetX, offsetY); // title "Select your next Conquest"
     drawLogoInFourCorners(iHouse);
     m_drawManager->drawMessageBar();
 
@@ -309,10 +309,10 @@ void cSelectYourNextConquestState::drawLogoInFourCorners(int iHouse) const
 
         // Draw 4 times the logo (in each corner)
     if (iLogo > -1) {
-        m_renderDrawer->renderSprite(m_gfxworld->getTexture(iLogo), offsetX, offsetY);
-        m_renderDrawer->renderSprite(m_gfxworld->getTexture(iLogo), offsetX + (640) - 64, offsetY);
-        m_renderDrawer->renderSprite(m_gfxworld->getTexture(iLogo), offsetX, offsetY + (480) - 64);
-        m_renderDrawer->renderSprite(m_gfxworld->getTexture(iLogo), offsetX + (640) - 64, offsetY + (480) - 64);
+        m_sdlDrawer->renderSprite(m_gfxworld->getTexture(iLogo), offsetX, offsetY);
+        m_sdlDrawer->renderSprite(m_gfxworld->getTexture(iLogo), offsetX + (640) - 64, offsetY);
+        m_sdlDrawer->renderSprite(m_gfxworld->getTexture(iLogo), offsetX, offsetY + (480) - 64);
+        m_sdlDrawer->renderSprite(m_gfxworld->getTexture(iLogo), offsetX + (640) - 64, offsetY + (480) - 64);
     }
 }
 
@@ -320,26 +320,26 @@ void cSelectYourNextConquestState::drawStateIntroduction() const
 {
     if (regionSceneState == SCENE_THREE_HOUSES_COME_FOR_DUNE) {
         // draw dune planet (being faded in)
-        m_renderDrawer->renderSprite(m_gfxinter->getTexture(BMP_GAME_DUNE),offsetX, offsetY + 12,iRegionSceneAlpha);
+        m_sdlDrawer->renderSprite(m_gfxinter->getTexture(BMP_GAME_DUNE),offsetX, offsetY + 12,iRegionSceneAlpha);
     }
     else if (regionSceneState == SCENE_TO_TAKE_CONTROL_OF_THE_LAND) {
-        m_renderDrawer->renderSprite(m_gfxinter->getTexture(BMP_GAME_DUNE), offsetX, offsetY + 12); // dune is opaque
-        m_renderDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE), offsetX + 16, offsetY + 73, iRegionSceneAlpha);
+        m_sdlDrawer->renderSprite(m_gfxinter->getTexture(BMP_GAME_DUNE), offsetX, offsetY + 12); // dune is opaque
+        m_sdlDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE), offsetX + 16, offsetY + 73, iRegionSceneAlpha);
     }
     else if (regionSceneState == SCENE_THAT_HAS_BECOME_DIVIDED) {
         // now the world map is opaque
-        m_renderDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE), offsetX + 16, offsetY + 73);
-        m_renderDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE_REGIONS), offsetX + 16, offsetY + 73,iRegionSceneAlpha);
+        m_sdlDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE), offsetX + 16, offsetY + 73);
+        m_sdlDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE_REGIONS), offsetX + 16, offsetY + 73,iRegionSceneAlpha);
     }
     else if (regionSceneState == SCENE_SELECT_YOUR_NEXT_CONQUEST) {
-        m_renderDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE_REGIONS), offsetX + 16, offsetY + 73);
+        m_sdlDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE_REGIONS), offsetX + 16, offsetY + 73);
     }
 }
 
 void cSelectYourNextConquestState::drawStateConquerRegions() const   // draw dune first
 {
-    m_renderDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE), offsetX + 16, offsetY + 73);
-    m_renderDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE_REGIONS), offsetX + 16, offsetY + 73);
+    m_sdlDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE), offsetX + 16, offsetY + 73);
+    m_sdlDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE_REGIONS), offsetX + 16, offsetY + 73);
 
     // draw here stuff
     for (int i = 0; i < 27; i++) {
@@ -354,8 +354,8 @@ void cSelectYourNextConquestState::drawStateConquerRegions() const   // draw dun
 
 void cSelectYourNextConquestState::drawStateSelectYourNextConquest() const
 {
-    m_renderDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE), offsetX + 16, offsetY + 73);
-    m_renderDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE_REGIONS), offsetX + 16, offsetY + 73);
+    m_sdlDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE), offsetX + 16, offsetY + 73);
+    m_sdlDrawer->renderSprite(m_gfxworld->getTexture(WORLD_DUNE_REGIONS), offsetX + 16, offsetY + 73);
 
     cRegion *pRegion = getRegionMouseIsOver();
     if (pRegion && pRegion->bSelectable) {
@@ -528,10 +528,10 @@ void cSelectYourNextConquestState::drawRegion(cRegion &regionPiece) const
     int regionY = offsetY + regionPiece.y;
 
     if (regionPiece.iAlpha >= 255) {
-        m_renderDrawer->renderSprite(regionPiece.bmpColor, regionX, regionY);
+        m_sdlDrawer->renderSprite(regionPiece.bmpColor, regionX, regionY);
     }
     else {
-        m_renderDrawer->renderSprite(regionPiece.bmpColor, regionX, regionY,regionPiece.iAlpha);
+        m_sdlDrawer->renderSprite(regionPiece.bmpColor, regionX, regionY,regionPiece.iAlpha);
     }
 }
 // End of function

--- a/src/gamestates/cSetupSkirmishState.cpp
+++ b/src/gamestates/cSetupSkirmishState.cpp
@@ -191,7 +191,7 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
         .withRect(nextMaps)
         .withLabel("Next")
         .withTextDrawer(m_textDrawer)
-        .withRenderer(m_renderDrawer)
+        .withRenderer(m_sdlDrawer)
         .withTheme(theme)
         .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
         .onClick(nextFunction)
@@ -201,7 +201,7 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
             .withRect(previousMaps)
             .withLabel("Previous")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(theme)
             .withKind(GuiRenderKind::TRANSPARENT_WITHOUT_BORDER)
             .onClick(previousFunction)
@@ -254,7 +254,7 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
             .withRect(backButtonRect)
             .withLabel("Back")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(theme)
             .withKind(GuiRenderKind::OPAQUE_WITH_BORDER)
             .onClick([this]() {
@@ -273,7 +273,7 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
             .withRect(startButtonRect)
             .withLabel("Start")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(theme)
             .withKind(GuiRenderKind::OPAQUE_WITH_BORDER)
             .onClick([this]() {
@@ -290,7 +290,7 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
             .withRect(surpriseMeButtonRect)
             .withLabel("Surprise me")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(theme)
             .withKind(GuiRenderKind::OPAQUE_WITH_BORDER)
             .onClick([this]() { surpriseMe(); })
@@ -306,7 +306,7 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
             .withRect(newMapButtonRect)
             .withLabel("New Map")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(theme)
             .withKind(GuiRenderKind::OPAQUE_WITH_BORDER)
             .onClick([this]() {
@@ -320,7 +320,7 @@ cSetupSkirmishState::cSetupSkirmishState(sGameServices* services, cPreviewMaps* 
             .withRect(modifyButtonRect)
             .withLabel("Modify")
             .withTextDrawer(m_textDrawer)
-            .withRenderer(m_renderDrawer)
+            .withRenderer(m_sdlDrawer)
             .withTheme(theme)
             .withKind(GuiRenderKind::OPAQUE_WITH_BORDER)
             .onClick([this]() {
@@ -340,20 +340,20 @@ cSetupSkirmishState::~cSetupSkirmishState()
 bool cSetupSkirmishState::guiDrawFrame(int x, int y, int width, int height) const
 {
     cRectangle rect = cRectangle(x, y, width, height);
-    m_renderDrawer->gui_DrawRect(rect, colorLightBackground, colorDarkishBorder, colorOtherBorder);
+    m_sdlDrawer->gui_DrawRect(rect, colorLightBackground, colorDarkishBorder, colorOtherBorder);
     return mouse_within_rect(m_mouse, x, y, width, height);
 }
 
 bool cSetupSkirmishState::guiDrawFramePressed(int x1, int y1, int width, int height) const
 {
-    m_renderDrawer->renderRectFillColor(x1, y1, width, height, colorLightBackground);
-    m_renderDrawer->renderRectColor(x1, y1, width, height, colorOtherBorder);
+    m_sdlDrawer->renderRectFillColor(x1, y1, width, height, colorLightBackground);
+    m_sdlDrawer->renderRectColor(x1, y1, width, height, colorOtherBorder);
 
     int endX = (x1+width)-1;
     int endY = (y1+height)-1;
     // lines to darken the right sides
-    m_renderDrawer->renderLine(endX, y1, endX, endY, colorDarkishBorder);
-    m_renderDrawer->renderLine(x1, endY, endX, endY, colorDarkishBorder);
+    m_sdlDrawer->renderLine(endX, y1, endX, endY, colorDarkishBorder);
+    m_sdlDrawer->renderLine(x1, endY, endX, endY, colorDarkishBorder);
 
     return mouse_within_rect(m_mouse, x1, y1, width, height);
 }
@@ -365,29 +365,29 @@ void cSetupSkirmishState::thinkFast()
 void cSetupSkirmishState::draw() const
 {
     // Draw top-bar / title-bar
-    m_renderDrawer->gui_DrawRect(topBar, colorLightBackground, colorDarkishBorder, colorOtherBorder);
+    m_sdlDrawer->gui_DrawRect(topBar, colorLightBackground, colorDarkishBorder, colorOtherBorder);
     m_textDrawer->drawTextCentered("Skirmish", 4);
 
     // Draw Players/House/Credits/Units/Team rectangle
-    m_renderDrawer->gui_DrawRect(playerTitleBar, colorDarkishBackground, Color::White, Color::White);
+    m_sdlDrawer->gui_DrawRect(playerTitleBar, colorDarkishBackground, Color::White, Color::White);
     // Draw rectangle for the actual players (beneath playerTitleBar)
-    m_renderDrawer->gui_DrawRect(playerList, colorDarkishBackground, Color::White, Color::White);
+    m_sdlDrawer->gui_DrawRect(playerList, colorDarkishBackground, Color::White, Color::White);
 
     // Draw top-right rectangle for "Startpoints"
-    m_renderDrawer->gui_DrawRect(topRightBox, colorLightBackground, colorDarkishBorder, colorOtherBorder);
+    m_sdlDrawer->gui_DrawRect(topRightBox, colorLightBackground, colorDarkishBorder, colorOtherBorder);
 
     // Draw "Maps" (yellow title), rectangle
-    m_renderDrawer->gui_DrawRect(mapListTitle, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);
+    m_sdlDrawer->gui_DrawRect(mapListTitle, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);
     m_textDrawer->drawTextCentered("Maps", mapListTitle.getX(), mapListTitle.getWidth(), mapListTitle.getY() + 4, Color::Yellow);
 
     // Draw "Preview" bar + title (right to "Maps")
-    m_renderDrawer->gui_DrawRect(previewMapTitle, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);    //renderDrawer->gui_DrawRect(previewMap, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);      
+    m_sdlDrawer->gui_DrawRect(previewMapTitle, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);    //sdlDrawer->gui_DrawRect(previewMap, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);      
     m_textDrawer->drawTextCentered("Preview", previewMapTitle.getX(), previewMapTitle.getWidth(), previewMapTitle.getY() + 4, Color::Yellow);
 
     // Draw the right bar where we render the map selected + any information
-    m_renderDrawer->gui_DrawRect(previewMap, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);
+    m_sdlDrawer->gui_DrawRect(previewMap, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);
 
-    m_renderDrawer->gui_DrawRect(selectArea, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);
+    m_sdlDrawer->gui_DrawRect(selectArea, colorDarkishBackground, colorDarkishBorder, colorDarkishBorder);
     ///////
     /// DRAW PREVIEW MAP
     //////
@@ -450,7 +450,7 @@ void cSetupSkirmishState::draw() const
     }
 
     cRectangle bottomBarRect = cRectangle(-1, screen_y - topBarHeight, screen_x + 2, topBarHeight + 2);
-    m_renderDrawer->gui_DrawRect(bottomBarRect, colorLightBackground, colorDarkishBorder, colorOtherBorder);
+    m_sdlDrawer->gui_DrawRect(bottomBarRect, colorLightBackground, colorDarkishBorder, colorOtherBorder);
 
     // For now in draw function
     startButton->setEnabled(iSkirmishMap > -1);
@@ -556,7 +556,7 @@ void cSetupSkirmishState::drawPreviewMapAndMore(const cRectangle &previewMapRect
                                          previewMapRect.getHeight() * selectedMap->previewTex->w / selectedMap->previewTex->h, previewMapRect.getHeight());
 
                     }
-                    m_renderDrawer->renderStrechFullSprite(selectedMap->previewTex, dst);
+                    m_sdlDrawer->renderStrechFullSprite(selectedMap->previewTex, dst);
                 }
             }
         }
@@ -564,9 +564,9 @@ void cSetupSkirmishState::drawPreviewMapAndMore(const cRectangle &previewMapRect
             // render the 'random generated skirmish map'
             cRectangle dst = cRectangle(previewMapRect.getX(), previewMapRect.getY(),previewMapRect.getWidth(), previewMapRect.getWidth());            // when mouse is hovering, draw it, else do not
             if (previewMapRect.isPointWithin(m_mouse->getX(), m_mouse->getY())) {
-                    m_renderDrawer->renderStrechFullSprite(selectedMap->previewTex, dst);
+                    m_sdlDrawer->renderStrechFullSprite(selectedMap->previewTex, dst);
             } else {
-                m_renderDrawer->renderStrechFullSprite(m_gfxinter->getTexture(BMP_UNKNOWNMAP), dst);
+                m_sdlDrawer->renderStrechFullSprite(m_gfxinter->getTexture(BMP_UNKNOWNMAP), dst);
             }
         }
         m_textDrawer->drawText(previewMapRect.getX() + 4, previewMapRect.getY() + previewMapRect.getHeight() + 16,
@@ -1290,7 +1290,7 @@ void cSetupSkirmishState::generateRandomMap()
     randomMap->validMap = true;
     randomMap->author = "D2TM";
 
-    SDL_Texture* out = SDL_CreateTextureFromSurface(m_renderDrawer->getRenderer(), randomMap->terrain);
+    SDL_Texture* out = SDL_CreateTextureFromSurface(m_sdlDrawer->getRenderer(), randomMap->terrain);
     if (out == nullptr) {
         Logger::error(COMP_SDL2, "cSetupSkirmishState", "Error creating texture from surface: {}", SDL_GetError());
         return;
@@ -1337,7 +1337,7 @@ void cSetupSkirmishState::drawMapList(const cRectangle &selectMapArea) const
             textColor = bHover ? colorDarkerYellow : Color::Yellow;
             // RENDERS (AGAIN)!
             guiDrawFramePressed(iDrawX, iDrawY, mapItemButtonWidth, mapItemButtonHeight);
-            m_renderDrawer->renderRectColor(iDrawX - 2, iDrawY - 2, mapItemButtonWidth + 4, mapItemButtonHeight + 4, Color::Yellow);
+            m_sdlDrawer->renderRectColor(iDrawX - 2, iDrawY - 2, mapItemButtonWidth + 4, mapItemButtonHeight + 4, Color::Yellow);
         }
 
         // In case invalid map, render as not-selectable
@@ -1368,7 +1368,7 @@ void cSetupSkirmishState::drawMapList(const cRectangle &selectMapArea) const
 
         // Render preview map on tile
         cRectangle dest = cRectangle(iDrawX + 4, iDrawY + 20, mapItemButtonWidth - 8, mapItemButtonHeight - 24);
-        m_renderDrawer->renderStrechFullSprite(tex, dest);
+        m_sdlDrawer->renderStrechFullSprite(tex, dest);
 
         // Determine next tile coordinates, and if needed wrap to next row
         iDrawX += mapItemButtonWidth + 15;

--- a/src/gamestates/cWinLoseState.cpp
+++ b/src/gamestates/cWinLoseState.cpp
@@ -44,11 +44,11 @@ void cWinLoseState::thinkFast()
 void cWinLoseState::draw() const
 {
     if (m_backgroundTexture)
-        m_renderDrawer->renderSprite(m_backgroundTexture,0,0);
+        m_sdlDrawer->renderSprite(m_backgroundTexture,0,0);
 
     int posW = (m_settings->getScreenW()-m_tex->w)/2;
     int posH = (m_settings->getScreenH()-m_tex->h)/2;
-    m_renderDrawer->renderSprite(m_tex,posW, posH);
+    m_sdlDrawer->renderSprite(m_tex,posW, posH);
 
     m_interface->drawCursor();
 }

--- a/src/gui/GuiButton.cpp
+++ b/src/gui/GuiButton.cpp
@@ -29,40 +29,40 @@ void GuiButton::draw() const
 {
     switch (m_renderKind) {
         case OPAQUE_WITHOUT_BORDER:
-            m_renderDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_theme.fillColor);
+            m_sdlDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_theme.fillColor);
             drawText();
             break;
         case TRANSPARENT_WITHOUT_BORDER:
             drawText();
             break;
         case OPAQUE_WITH_BORDER:
-            m_renderDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_enabled ? m_theme.fillColor : m_theme.disabledFillColor);
+            m_sdlDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_enabled ? m_theme.fillColor : m_theme.disabledFillColor);
             if (m_pressed) {
-                m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.borderDark, m_theme.borderLight);
+                m_sdlDrawer->gui_DrawRectBorder(m_rect, m_theme.borderDark, m_theme.borderLight);
             }
             else {
                 if (m_enabled) {
-                    m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.borderLight, m_theme.borderDark);
+                    m_sdlDrawer->gui_DrawRectBorder(m_rect, m_theme.borderLight, m_theme.borderDark);
                 } else {
-                    m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.disabledBorderLight, m_theme.disabledBorderDark);
+                    m_sdlDrawer->gui_DrawRectBorder(m_rect, m_theme.disabledBorderLight, m_theme.disabledBorderDark);
                 }
             }
             drawText();
             break;
         case TRANSPARENT_WITH_BORDER:
             if (m_pressed) {
-                m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.borderDark, m_theme.borderLight);
+                m_sdlDrawer->gui_DrawRectBorder(m_rect, m_theme.borderDark, m_theme.borderLight);
             }
             else {
-                m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.borderLight, m_theme.borderDark);
+                m_sdlDrawer->gui_DrawRectBorder(m_rect, m_theme.borderLight, m_theme.borderDark);
             }
             drawText();
             break;
         case WITH_TEXTURE:
-            m_renderDrawer->renderSprite(m_tex, m_rect.getX(),m_rect.getY());
+            m_sdlDrawer->renderSprite(m_tex, m_rect.getX(),m_rect.getY());
             break;
         case WITH_STRETCHED_TEXTURE:
-            m_renderDrawer->renderStrechFullSprite(m_tex, m_rect, 255);
+            m_sdlDrawer->renderStrechFullSprite(m_tex, m_rect, 255);
             break;
     }
 }

--- a/src/gui/GuiCheckBox.cpp
+++ b/src/gui/GuiCheckBox.cpp
@@ -25,14 +25,14 @@ void GuiCheckBox::draw() const
 {
     switch (m_renderKind) {
         case OPAQUE_WITHOUT_BORDER:
-            m_renderDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_theme.fillColor);
+            m_sdlDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_theme.fillColor);
             drawBox();
             break;
         case TRANSPARENT_WITHOUT_BORDER:
             drawBox();
             break;
         case OPAQUE_WITH_BORDER:
-            m_renderDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_theme.fillColor);
+            m_sdlDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_theme.fillColor);
             drawBox();
             break;
         case TRANSPARENT_WITH_BORDER:
@@ -47,14 +47,14 @@ void GuiCheckBox::draw() const
 }
 
 void GuiCheckBox::renderChecked() const {
-    m_renderDrawer->renderLine(
+    m_sdlDrawer->renderLine(
         m_rect.getX() + 2,
         m_rect.getY() + 3,
         m_rect.getX() + (m_rect.getWidth() - 3),
         m_rect.getY() + (m_rect.getHeight()- 2),
         m_theme.textColorShadow
     );
-    m_renderDrawer->renderLine(
+    m_sdlDrawer->renderLine(
         m_rect.getX() + 2,
         m_rect.getY() + (m_rect.getHeight()-2),
         m_rect.getX() + (m_rect.getWidth()-3),
@@ -62,14 +62,14 @@ void GuiCheckBox::renderChecked() const {
         m_theme.textColorShadow
     );
 
-    m_renderDrawer->renderLine(
+    m_sdlDrawer->renderLine(
         m_rect.getX() + 2,
         m_rect.getY() + 2,
         m_rect.getX() + (m_rect.getWidth() - 3),
         m_rect.getY() + (m_rect.getHeight()- 3),
         m_theme.textColor
     );
-    m_renderDrawer->renderLine(
+    m_sdlDrawer->renderLine(
         m_rect.getX() + 2,
         m_rect.getY() + (m_rect.getHeight()-3),
         m_rect.getX() + (m_rect.getWidth()-3),

--- a/src/gui/GuiConsole.cpp
+++ b/src/gui/GuiConsole.cpp
@@ -8,7 +8,7 @@
 
 #include <algorithm>
 
-GuiConsole::GuiConsole(SDLDrawer* renderDrawer,
+GuiConsole::GuiConsole(SDLDrawer* sdlDrawer,
                        cTextDrawer* textDrawer,
                        cNotificationArea* notificationArea,
                        int screenWidth,
@@ -20,13 +20,13 @@ GuiConsole::GuiConsole(SDLDrawer* renderDrawer,
     const int x = 8;
     const int y = screenHeight - height - 10;
 
-    m_window = std::make_unique<GuiWindow>(renderDrawer, cRectangle(x, y, width, height), textDrawer);
+    m_window = std::make_unique<GuiWindow>(sdlDrawer, cRectangle(x, y, width, height), textDrawer);
     m_messageParser = std::make_unique<GuiConsoleMessageParser>(notificationArea);
 
     auto input = GuiTextInputBuilder()
         .withRect(m_window->getRelativeRect(8, 6, width - 16, inputHeight))
         .withTextDrawer(textDrawer)
-        .withRenderer(renderDrawer)
+        .withRenderer(sdlDrawer)
         .withTheme(cGuiThemeBuilder().light().build())
         .onEnter([this](const std::string& text) {
             submit(text);

--- a/src/gui/GuiConsole.h
+++ b/src/gui/GuiConsole.h
@@ -14,7 +14,7 @@ struct s_MouseEvent;
 
 class GuiConsole {
 public:
-    GuiConsole(SDLDrawer* renderDrawer,
+    GuiConsole(SDLDrawer* sdlDrawer,
                cTextDrawer* textDrawer,
                cNotificationArea* notificationArea,
                int screenWidth,

--- a/src/gui/GuiLabel.cpp
+++ b/src/gui/GuiLabel.cpp
@@ -25,14 +25,14 @@ void GuiLabel::draw() const
         return;
     switch (m_renderKind) {
         case OPAQUE_WITHOUT_BORDER:
-            m_renderDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_theme.fillColor);
+            m_sdlDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_theme.fillColor);
             drawText();
             break;
         case TRANSPARENT_WITHOUT_BORDER:
             drawText();
             break;
         case OPAQUE_WITH_BORDER:
-            m_renderDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_theme.fillColor);
+            m_sdlDrawer->renderRectFillColor(m_rect.getX(), m_rect.getY(), m_rect.getWidth(), m_rect.getHeight(), m_theme.fillColor);
             drawRectBorder(m_theme.borderLight, m_theme.borderDark);
             drawText();
             break;
@@ -41,10 +41,10 @@ void GuiLabel::draw() const
             drawText();
             break;
         case WITH_TEXTURE:
-            m_renderDrawer->renderSprite(m_tex, m_rect.getX(),m_rect.getY());
+            m_sdlDrawer->renderSprite(m_tex, m_rect.getX(),m_rect.getY());
             break;
         case WITH_STRETCHED_TEXTURE:
-            m_renderDrawer->renderStrechFullSprite(m_tex, m_rect, 255);
+            m_sdlDrawer->renderStrechFullSprite(m_tex, m_rect, 255);
             break;
     }
 }

--- a/src/gui/GuiObject.cpp
+++ b/src/gui/GuiObject.cpp
@@ -5,7 +5,7 @@
 
 
 GuiObject::GuiObject(SDLDrawer* drawer, const cRectangle &rect) : 
-    m_rect(rect), m_renderDrawer(drawer)
+    m_rect(rect), m_sdlDrawer(drawer)
 {
     d2tm_assert(drawer != nullptr);
 }
@@ -32,13 +32,13 @@ void GuiObject::drawRectBorder(Color borderRect, Color borderBottomRight) const
     int width = m_rect.getWidth();
     int height = m_rect.getHeight();
     //std::cout <<":" << x1 << " " << y1 << " " << width << " " << height << std::endl;
-    m_renderDrawer->renderRectColor(m_rect,borderRect);
-    m_renderDrawer->renderLine(x1+width, y1, x1+width, y1+height,borderBottomRight);
-    m_renderDrawer->renderLine(x1, y1+height, x1+width, y1+height, borderBottomRight);
+    m_sdlDrawer->renderRectColor(m_rect,borderRect);
+    m_sdlDrawer->renderLine(x1+width, y1, x1+width, y1+height,borderBottomRight);
+    m_sdlDrawer->renderLine(x1, y1+height, x1+width, y1+height, borderBottomRight);
 }
 
 void GuiObject::drawRectFillBorder(const GuiTheme& theme) const
 {
-    m_renderDrawer->renderRectFillColor(m_rect, theme.fillColor);
+    m_sdlDrawer->renderRectFillColor(m_rect, theme.fillColor);
     drawRectBorder(theme.borderLight, theme.borderDark);
 }

--- a/src/gui/GuiObject.h
+++ b/src/gui/GuiObject.h
@@ -36,7 +36,7 @@ protected:
     // any gui object has a position and size. Hence its always a 'rect'.
     cRectangle m_rect;
     GuiTheme m_theme;
-    SDLDrawer* m_renderDrawer = nullptr;
+    SDLDrawer* m_sdlDrawer = nullptr;
     void drawRectBorder(Color borderRect, Color borderBottomRight) const;
     void drawRectFillBorder(const GuiTheme& theme) const;
 };

--- a/src/gui/GuiSlider.cpp
+++ b/src/gui/GuiSlider.cpp
@@ -21,7 +21,7 @@ void GuiSlider::draw() const {
 }
 
 void GuiSlider::drawTrack() const {
-    m_renderDrawer->renderRectFillColor(m_rect, m_theme.fillColor);
+    m_sdlDrawer->renderRectFillColor(m_rect, m_theme.fillColor);
     drawRectBorder(m_theme.borderLight, m_theme.borderDark);
 }
 
@@ -32,8 +32,8 @@ void GuiSlider::drawKnob() const {
     int knobY = m_rect.getY();
 
     cRectangle knobRect(knobX, knobY, GUI_KNOB_WIDTH, m_rect.getHeight());
-    m_renderDrawer->renderRectFillColor(knobRect, m_theme.borderDark);
-    m_renderDrawer->gui_DrawRectBorder(knobRect, m_theme.borderLight, m_theme.borderDark);
+    m_sdlDrawer->renderRectFillColor(knobRect, m_theme.borderDark);
+    m_sdlDrawer->gui_DrawRectBorder(knobRect, m_theme.borderLight, m_theme.borderDark);
 }
 
 void GuiSlider::setValue(int value) {

--- a/src/gui/GuiStateButton.cpp
+++ b/src/gui/GuiStateButton.cpp
@@ -50,7 +50,7 @@ void GuiStateButton::changeState(GuiState newState)
 
 void GuiStateButton::draw() const 
 {
-    m_renderDrawer->renderStrechSprite(m_tex, *m_currentRectState, m_rect);
+    m_sdlDrawer->renderStrechSprite(m_tex, *m_currentRectState, m_rect);
 }
 
 void GuiStateButton::onNotifyMouseEvent(const s_MouseEvent &event)

--- a/src/gui/GuiTextInput.cpp
+++ b/src/gui/GuiTextInput.cpp
@@ -36,10 +36,10 @@ GuiTextInput::GuiTextInput(SDLDrawer* drawer,const cRectangle& rect, cTextDrawer
 
 void GuiTextInput::draw() const
 {
-    m_renderDrawer->renderRectFillColor(m_rect, m_theme.background);
+    m_sdlDrawer->renderRectFillColor(m_rect, m_theme.background);
     if (m_focused) {
         cRectangle focusRect(m_rect.getX() - 3, m_rect.getY() - 3, m_rect.getWidth() + 6, m_rect.getHeight() + 6);
-        m_renderDrawer->renderRectColor(focusRect, m_theme.textColorHover);
+        m_sdlDrawer->renderRectColor(focusRect, m_theme.textColorHover);
     }
     // Affiche un curseur si focus
     m_writer->drawText(m_rect.getX() + kHorizontalPadding, m_rect.getY() + 4, m_theme.textColor, getFittedDisplayText());

--- a/src/gui/GuiValueButton.cpp
+++ b/src/gui/GuiValueButton.cpp
@@ -53,11 +53,11 @@ void GuiValueButton::onNotifyKeyboardEvent(const cKeyboardEvent &)
 
 void GuiValueButton::draw() const
 {
-    m_renderDrawer->renderRectFillColor(m_rect, m_theme.fillColor);
+    m_sdlDrawer->renderRectFillColor(m_rect, m_theme.fillColor);
     if (m_pressed) {
-        m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.borderDark, m_theme.borderLight);
+        m_sdlDrawer->gui_DrawRectBorder(m_rect, m_theme.borderDark, m_theme.borderLight);
     } else {
-        m_renderDrawer->gui_DrawRectBorder(m_rect, m_theme.borderLight, m_theme.borderDark);
+        m_sdlDrawer->gui_DrawRectBorder(m_rect, m_theme.borderLight, m_theme.borderDark);
     }
 
     if (m_textDrawer != nullptr) {
@@ -69,7 +69,7 @@ void GuiValueButton::draw() const
             const cRectangle bottomRect(m_rect.getX(), m_rect.getY() + topHeight, m_rect.getWidth(), bottomHeight);
 
             if (m_texture != nullptr) {
-                m_renderDrawer->renderStrechFullSprite(m_texture, topRect);
+                m_sdlDrawer->renderStrechFullSprite(m_texture, topRect);
             } else {
                 m_textDrawer->drawTextCenteredInBox(m_label, topRect, textColor);
             }

--- a/src/managers/cDrawManager.cpp
+++ b/src/managers/cDrawManager.cpp
@@ -33,7 +33,7 @@ cDrawManager::cDrawManager(GameContext *ctx, cPlayer *thePlayer, sGameServices *
     m_player(thePlayer),
     m_ctx(ctx),
     m_textDrawer(ctx->getTextContext()->getGameTextDrawer()),
-    m_renderDrawer(ctx->getSDLDrawer()),
+    m_sdlDrawer(ctx->getSDLDrawer()),
     m_gfxinter(ctx->getGraphicsContext()->gfxinter.get()),
     m_gfxdata(ctx->getGraphicsContext()->gfxdata.get()),
     m_gameInterface(ctx->getGameInterface()),
@@ -46,7 +46,7 @@ cDrawManager::cDrawManager(GameContext *ctx, cPlayer *thePlayer, sGameServices *
     d2tm_assert(m_player!=nullptr);
     d2tm_assert(ctx != nullptr);
     d2tm_assert(m_textDrawer != nullptr);
-    d2tm_assert(m_renderDrawer != nullptr);
+    d2tm_assert(m_sdlDrawer != nullptr);
     d2tm_assert(m_gfxdata != nullptr);
     d2tm_assert(m_gfxinter != nullptr);
     d2tm_assert(m_gameInterface != nullptr);
@@ -94,7 +94,7 @@ cDrawManager::~cDrawManager()
 void cDrawManager::drawCombatState()
 {
     // MAP
-    m_renderDrawer->setClippingFor(0, cSideBar::TopBarHeight, m_mapCamera->getWindowWidth(), m_gameSettings->getScreenH());
+    m_sdlDrawer->setClippingFor(0, cSideBar::TopBarHeight, m_mapCamera->getWindowWidth(), m_gameSettings->getScreenH());
     m_mapDrawer->drawTerrain();
 
     m_structureDrawer->drawStructuresFirstLayer();
@@ -118,16 +118,16 @@ void cDrawManager::drawCombatState()
 
     drawRallyPoint();
 
-    m_renderDrawer->resetClippingFor();
+    m_sdlDrawer->resetClippingFor();
 
     // GUI
     drawSidebar();
 
     drawOptionBar();
 
-    m_renderDrawer->setClippingFor(0, cSideBar::TopBarHeight, m_mapCamera->getWindowWidth(), m_mapCamera->getWindowHeight() + cSideBar::TopBarHeight);
+    m_sdlDrawer->setClippingFor(0, cSideBar::TopBarHeight, m_mapCamera->getWindowWidth(), m_mapCamera->getWindowHeight() + cSideBar::TopBarHeight);
     drawStructurePlacing();
-    m_renderDrawer->resetClippingFor();
+    m_sdlDrawer->resetClippingFor();
 
     drawTopBarBackground();
     drawCredits();
@@ -135,7 +135,7 @@ void cDrawManager::drawCombatState()
     // THE MESSAGE
     drawMessage();
 
-    m_renderDrawer->resetClippingFor();
+    m_sdlDrawer->resetClippingFor();
 
     if (m_gameSettings->isDrawUsages()) {
         drawDebugInfoUsages();
@@ -204,7 +204,7 @@ void cDrawManager::drawRallyPoint()
     int rallyPointWidthScaled = m_mapCamera->factorZoomLevel(mouseMoveBitmap->w);
     int rallyPointHeightScaled = m_mapCamera->factorZoomLevel(mouseMoveBitmap->h);
     cRectangle dest = {drawX, drawY, rallyPointWidthScaled, rallyPointHeightScaled};
-    m_renderDrawer->renderStrechFullSprite(m_gfxdata->getTexture(MOUSE_MOVE), dest);
+    m_sdlDrawer->renderStrechFullSprite(m_gfxdata->getTexture(MOUSE_MOVE), dest);
 
     int startX = theStructure->iDrawX() + m_mapCamera->factorZoomLevel(theStructure->getWidthInPixels() / 2);
     int startY = theStructure->iDrawY() + m_mapCamera->factorZoomLevel(theStructure->getHeightInPixels() / 2);
@@ -216,15 +216,15 @@ void cDrawManager::drawRallyPoint()
     int endX = drawX;
     int endY = drawY;
 
-    m_renderDrawer->renderLine( startX, startY, endX, endY, m_objects->getPlayer(HUMAN)->getMinimapColor());
+    m_sdlDrawer->renderLine( startX, startY, endX, endY, m_objects->getPlayer(HUMAN)->getMinimapColor());
 }
 
 void cDrawManager::drawSidebar()
 {
-    m_renderDrawer->setClippingFor(m_gameSettings->getScreenW() - cSideBar::SidebarWidth, 0, m_gameSettings->getScreenW(), m_gameSettings->getScreenH());
+    m_sdlDrawer->setClippingFor(m_gameSettings->getScreenW() - cSideBar::SidebarWidth, 0, m_gameSettings->getScreenW(), m_gameSettings->getScreenH());
     m_sidebarDrawer->draw();
     m_miniMapDrawer->draw();
-    m_renderDrawer->resetClippingFor();
+    m_sdlDrawer->resetClippingFor();
 }
 
 /**
@@ -268,10 +268,10 @@ void cDrawManager::drawTopBarBackground()
 {
     Texture *topbarPiece = m_gfxinter->getTexture(BMP_TOPBAR_BACKGROUND);
     for (int x = 0; x < m_gameSettings->getScreenW(); x+= topbarPiece->w) {
-        m_renderDrawer->renderSprite(topbarPiece, x, 0);
+        m_sdlDrawer->renderSprite(topbarPiece, x, 0);
     }
 
-    m_renderDrawer->renderSprite(m_btnOptions, 1, 0);
+    m_sdlDrawer->renderSprite(m_btnOptions, 1, 0);
 
     //HACK HACK: for now do it like this, instead of using an actual GUI object here
     cRectangle optionsRect = cRectangle(0,0, 162, 30);
@@ -294,11 +294,11 @@ void cDrawManager::setPlayerToDraw(cPlayer *playerToDraw)
 void cDrawManager::drawOptionBar()
 {
     // upper bar
-    m_renderDrawer->renderRectFillColor(0, 0, m_gameSettings->getScreenW(), cSideBar::TopBarHeight, Color{0, 0, 0,255});
-    m_renderDrawer->renderRectFillColor(0,m_gameSettings->getScreenW(), 40,32, Color{214,149,20,255});
+    m_sdlDrawer->renderRectFillColor(0, 0, m_gameSettings->getScreenW(), cSideBar::TopBarHeight, Color{0, 0, 0,255});
+    m_sdlDrawer->renderRectFillColor(0,m_gameSettings->getScreenW(), 40,32, Color{214,149,20,255});
 
     for (int w = 0; w < (m_gameSettings->getScreenW() + 800); w += 789) {
-        m_renderDrawer->renderSprite(m_gfxinter->getTexture(BMP_GERALD_TOP_BAR), w, 31);
+        m_sdlDrawer->renderSprite(m_gfxinter->getTexture(BMP_GERALD_TOP_BAR), w, 31);
     }
 }
 

--- a/src/managers/cDrawManager.h
+++ b/src/managers/cDrawManager.h
@@ -130,7 +130,7 @@ private:
     cPlayer *m_player = nullptr;
     GameContext *m_ctx = nullptr;
     cTextDrawer *m_textDrawer = nullptr;
-    SDLDrawer* m_renderDrawer = nullptr;
+    SDLDrawer* m_sdlDrawer = nullptr;
     Graphics* m_gfxinter = nullptr;
     Graphics* m_gfxdata = nullptr;
     cMouseDrawer* m_mouseDrawer = nullptr;


### PR DESCRIPTION
Fixes #986

The member/parameter name renderDrawer didn't match its type SDLDrawer, unlike the existing getSDLDrawer()/setSDLDrawer()/m_SDLDrawer naming already used in GameContext. This was flagged as a follow-up in PR #967 but not addressed there.

Renamed throughout: m_renderDrawer -> m_sdlDrawer, renderDrawer -> sdlDrawer, setRenderDrawer -> setSDLDrawer.

Pure rename, no behavior change.

## Test plan
- [x] ./rebuildmacos.sh builds clean, all 56 unit tests pass
- [x] ./create_release.sh packages successfully