### PR TITLE
Deviator ignores orders to attack structures

### DIFF
--- a/src/context/cInfoContextCreator.cpp
+++ b/src/context/cInfoContextCreator.cpp
@@ -147,6 +147,7 @@ void cInfoContextCreator::initUnits(cUnitInfos& unitInfos)
         // attack related
         unitInfo.canAttackAirUnits = false;
         unitInfo.canAttackUnits = false;
+        unitInfo.canDamageStructures = true;
 
         // capturing / damage upon entering structure related
         unitInfo.canEnterAndDamageStructure = false;
@@ -312,6 +313,7 @@ void cInfoContextCreator::initUnits(cUnitInfos& unitInfos)
     unitInfos[DEVIATOR].smokeHpFactor = 0.5f;
     unitInfos[DEVIATOR].canGuard = true;
     unitInfos[DEVIATOR].canAttackUnits = true;
+    unitInfos[DEVIATOR].canDamageStructures = false; // gas warhead only deviates units, does no structural damage
     strcpy(unitInfos[DEVIATOR].name, "Deviator");
     unitInfos[DEVIATOR].configured = true;
 

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -921,6 +921,11 @@ void cUnit::attackStructure(int targetStructure)
 {
     log(std::format("attackStructure() : target is [{}]", targetStructure));
 
+    if (isType(DEVIATOR)) {
+        log("attackStructure() : Deviator cannot damage structures, ignoring order.");
+        return;
+    }
+
     cAbstractStructure *target = m_objects->getStructure(targetStructure);
     if (target == nullptr || !target->isValid()) {
         log(std::format("attackStructure() : target is [{}] Invalid target.", targetStructure));

--- a/src/gameobjects/units/cUnit.cpp
+++ b/src/gameobjects/units/cUnit.cpp
@@ -921,8 +921,8 @@ void cUnit::attackStructure(int targetStructure)
 {
     log(std::format("attackStructure() : target is [{}]", targetStructure));
 
-    if (isType(DEVIATOR)) {
-        log("attackStructure() : Deviator cannot damage structures, ignoring order.");
+    if (!canDamageStructures()) {
+        log("attackStructure() : unit cannot damage structures, ignoring order.");
         return;
     }
 

--- a/src/gameobjects/units/cUnit.h
+++ b/src/gameobjects/units/cUnit.h
@@ -346,6 +346,14 @@ public:
         return getUnitInfo().canAttackAirUnits;
     }
 
+    /**
+     * Can this unit's weapon damage structures? (the Deviator cannot)
+     * @return
+     */
+    bool canDamageStructures() const {
+        return getUnitInfo().canDamageStructures;
+    }
+
     bool isInfantryUnit() const;
     bool isWheelUnit() const;
     bool isTankUnit() const;

--- a/src/gameobjects/units/cUnitInfos.h
+++ b/src/gameobjects/units/cUnitInfos.h
@@ -73,6 +73,7 @@ struct s_UnitInfo {
     // attack related
     bool canAttackAirUnits;   // ie for rocket typed units
     bool canAttackUnits;   // a unit used for attacking other units? (ie, mvc or harvester is no)
+    bool canDamageStructures; // can this unit's weapon harm structures? (the Deviator cannot)
     bool canEnterAndDamageStructure;  // can this unit enter a structure and damage it? (and eventually capture?)
     bool attackIsEnterStructure;      // unit attacks by entering a structure (eg saboteur)
     float damageOnEnterStructure;     // the damage inflicted to a structure when entered


### PR DESCRIPTION
Fixes #1089

Deviators do no damage to structures. Previously, giving a group attack order against a structure would still send Deviators chasing after it, causing them to path in front of the group's more destructive units instead of staying at the back where they belong.

cUnit::attackStructure() now ignores the order entirely for Deviators, so the unit stays put and doesn't move toward the target.

## Test plan
- [x] ./rebuildmacos.sh builds clean, all 56 unit tests pass
- [x] ./create_release.sh packages successfully