### PR TITLE
Structure placement adjacent to enemy structures blocked

### DIFF
--- a/.claude/review.md
+++ b/.claude/review.md
@@ -12,6 +12,20 @@ General principles (see `CLAUDE.md` for the full version):
   abstraction, configurability, or error handling for impossible states.
 - Match surrounding style rather than imposing a different one.
 
+## Review output format
+
+Keep the posted review short. A maintainer should read it in under a minute.
+
+- One summary comment. Target under 120 words.
+- Structure: a one-line verdict, then a list of issues found. Nothing else.
+- Each issue: `file:line` — what is wrong — suggested fix. One or two sentences.
+- If nothing needs changing, say so in one line and stop.
+- Do not narrate your process. No "Checked:" / "Verified:" list, no progress
+  recap, no enumeration of what looked fine. The value is the problems found.
+- Do not restate the PR description or commit messages back to the author.
+- Inline line comments are for concrete defects only — not observations,
+  confirmations, or praise.
+
 ## Memory safety & resource management
 
 - New/`delete` balanced; ownership of every heap allocation is clear and

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,8 +54,11 @@ jobs:
             - Consistency with existing code style and structures in this codebase
             - Any changes that could break the build or existing CI
 
-            Leave inline comments on specific lines where relevant, and a short
-            summary comment overall. Be direct about problems, but don't nitpick
-            pure style preferences that don't affect correctness or readability.
+            Post one summary comment following the "Review output format"
+            section of .claude/review.md: a one-line verdict plus a list of
+            issues found, nothing else. Do not narrate your process or recap
+            what you checked. Leave inline comments only for concrete defects on
+            specific lines. Be direct about problems, but don't nitpick pure
+            style preferences that don't affect correctness or readability.
           claude_args: |
             --max-turns 30

--- a/src/controls/mousestates/cMousePlaceState.cpp
+++ b/src/controls/mousestates/cMousePlaceState.cpp
@@ -114,7 +114,7 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
                 if (idOfStructureAtCell > -1) {
                     int iID = idOfStructureAtCell;
 
-                    if (m_context->getObjects()->getStructures()[iID]->getOwner() == HUMAN) {
+                    if (m_context->getObjects()->getStructures()[iID]->getOwner() == m_player->getId()) {
                         bWithinBuildDistance = true; // connection!
                         break;
                     }

--- a/src/controls/mousestates/cMousePlaceState.cpp
+++ b/src/controls/mousestates/cMousePlaceState.cpp
@@ -120,6 +120,10 @@ bool cMousePlaceState::mayPlaceIt(cBuildingListItem *itemToPlace, int mouseCell)
                     }
 
                     // TODO: Allow placement nearby allies?
+
+                    // structure owned by someone else: its foundation slab must not
+                    // count as a build anchor, so skip the wall/slab check for this cell
+                    continue;
                 }
 
                 if (m_context->getObjects()->getMap()->getCellType(iCll) == TERRAIN_WALL ||

--- a/src/drawers/cPlaceItDrawer.cpp
+++ b/src/drawers/cPlaceItDrawer.cpp
@@ -90,7 +90,7 @@ void cPlaceItDrawer::drawStatusOfStructureAtCell(cBuildingListItem *itemToPlace,
                 if (idOfStructureAtCell > -1) {
                     int iID = idOfStructureAtCell;
 
-                    if (m_objects->getStructures()[iID]->getOwner() == HUMAN) {
+                    if (m_objects->getStructures()[iID]->getOwner() == m_player->getId()) {
                         bWithinBuildDistance = true; // connection!
                         break;
                     }

--- a/src/drawers/cPlaceItDrawer.cpp
+++ b/src/drawers/cPlaceItDrawer.cpp
@@ -96,6 +96,10 @@ void cPlaceItDrawer::drawStatusOfStructureAtCell(cBuildingListItem *itemToPlace,
                     }
 
                     // TODO: Allow placement nearby allies?
+
+                    // structure owned by someone else: its foundation slab must not
+                    // count as a build anchor, so skip the wall/slab check for this cell
+                    continue;
                 }
 
                 if (m_objects->getMap()->getCellType(iCll) == TERRAIN_WALL ||


### PR DESCRIPTION
Fixes #989

The build-distance adjacency check compared the adjacent structure's owner against the HUMAN constant (player id 0) instead of the player who is actually placing the structure. This let AI/other players treat player 0's structures as their own for adjacency purposes, and meant the check wasn't actually tied to "is this my own structure" the way it was intended to be.

Both the placement gate (cMousePlaceState::mayPlaceIt) and its duplicated visual preview logic (cPlaceItDrawer::drawStatusOfStructureAtCell) now compare against the placing player's own id.

## Follow-up: enemy foundation slab

Retesting showed placement adjacent to an enemy structure was still allowed. After the owner check rejects a non-owned structure, execution fell through to the wall/slab check for that same cell. Since every structure sits on a TERRAIN_SLAB foundation, an enemy structure next to the hover still satisfied the build-distance check via its own slab.

Fixed by skipping the wall/slab check for cells occupied by a structure that isn't the placing player's. Player-placed slabs and walls still work as build anchors, so building away from structures via slabs is unchanged.

## Test plan
- [x] ./rebuildmacos.sh builds clean, all 56 unit tests pass
- [x] ./create_release.sh packages successfully
- [x] Manual: cannot place a structure adjacent to an enemy structure
- [x] Manual: can still place adjacent to own structures / own slabs