### PR TITLE
Pull requests get an automated Claude Code review

### DIFF
--- a/.claude/review.md
+++ b/.claude/review.md
@@ -1,0 +1,98 @@
+# Code Review Checklist — D2TM
+
+Primary review guide for pull requests to Dune II - The Maker, a C++23 / SDL2
+real-time strategy game engine. Work through the relevant sections below. Skip
+sections that a diff clearly does not touch.
+
+General principles (see `CLAUDE.md` for the full version):
+
+- Every changed line should trace to the stated purpose of the PR. Flag
+  unrelated refactors, reformatting, or "drive-by improvements".
+- Prefer the smallest change that solves the problem. Flag speculative
+  abstraction, configurability, or error handling for impossible states.
+- Match surrounding style rather than imposing a different one.
+
+## Memory safety & resource management
+
+- New/`delete` balanced; ownership of every heap allocation is clear and
+  documented by where it lives (which class/pool owns it).
+- No dangling pointers or references kept across frames: `cUnit`, `cAbstractStructure`,
+  `bullet`, `cParticle` live in pooled arrays and slots get reused. Hold IDs, not
+  pointers, across `thinkNormal`/`thinkSlow` boundaries.
+- Array/pool indices are bounds-checked before use (unit id, structure id, cell
+  index). Watch for `-1` / invalid-id sentinels being used as indices.
+- SDL resources (`SDL_Surface`, `SDL_Texture`, `SDL_Renderer`, fonts, chunks) are
+  freed on every path, including early returns and error paths.
+- No use-after-free when an object destroys itself during iteration (e.g. a unit
+  dying inside a loop over all units). Iteration handles removal safely.
+- Containers: no iterator invalidation after insert/erase; no reference to a
+  vector element retained across a growth.
+
+## Ownership & lifetime
+
+- Prefer references or `const&` for non-owning access. Raw owning pointers only
+  where the existing pool pattern requires it.
+- No new global mutable state. The `game` / `global_renderDrawer` / `gfxdata`
+  globals are legacy and being removed — do not add to them. Pass `GameContext*`
+  or the specific dependency instead.
+- Object cleanup goes through the existing lifecycle hooks (unit `die()`,
+  structure removal, `cGame` teardown), not ad-hoc deletes scattered in callers.
+
+## Game-loop performance
+
+- Know which tick the code runs on: `thinkFast()` (~5ms), `thinkNormal()`
+  (~100ms), `thinkSlow()` (~1000ms). Expensive work (path search, full-map
+  scans, allocations) belongs on the slowest tick that still meets the need.
+- No per-frame heap allocation in `thinkFast()` or in draw code. Reuse buffers.
+- No O(map) or O(units^2) scans added to a fast path without justification.
+- Rendering: draw only what is on-screen (respect `cMapCamera` viewport).
+  No redundant texture creation per frame; cache where the codebase already does.
+- Logging (`logbook`, `Log.h`) is not called in tight per-cell / per-unit loops.
+
+## Pathfinding & AI correctness
+
+- Path requests handle "no path found" and target-occupied cases without
+  spinning (unit re-requesting a path every tick).
+- Cell occupancy is updated consistently: a unit leaving/entering a cell updates
+  `cCell` unit/structure ids so pathfinding and collision stay correct.
+- `cPlayerBrain` missions have a terminating condition; no state that can loop
+  forever (e.g. mission never completes, never fails).
+- Player index assumptions hold: 0 = human, 1–6 = AI. No off-by-one over
+  `MAX_PLAYERS`. Neutral/sandworm handled where relevant.
+- Fog-of-war / discovered state is respected: AI should not act on information a
+  human player in the same position could not have.
+- Random-dependent logic is seeded consistently and does not diverge between
+  otherwise identical runs where determinism is expected.
+
+## Map, units, structures
+
+- Cell coordinate math: `iCell = y * mapWidth + x`. Check for boundary wrap
+  (reading x-1 on column 0, etc.) and for `mapWidth` vs hardcoded 32/64/128.
+- Structure footprints (multi-cell) fully occupy and fully release their cells.
+- Unit/structure removal clears all back-references (selection, group, cell id,
+  rally point, repair/refine targets).
+- INI-driven data (`cUnitInfos`, `cStructureInfos`, ...) is read through the
+  info tables, not hardcoded. New tunables get a `game.ini` entry.
+
+## Build stability & CI
+
+- Compiles with the project toolchain (C++23, gcc-15 on macOS per `CLAUDE.md`).
+  No reliance on compiler extensions or platform-specific headers without guards.
+- New source files are added to `CMakeLists.txt`.
+- No new external dependency without discussion; SDL2 + SDL2_image/ttf/mixer is
+  the sanctioned set.
+- Does not break `build_pr.yml` / `build_master.yml`. Cross-platform paths use
+  the existing helpers, not hardcoded separators.
+- If a key binding changed: `keys.md` and `resources/bin/settings.ini` are both
+  updated (see `.claude/rules/key-bindings.md`).
+- Public/gameplay-facing behavior changes are reflected in docs where the repo
+  already documents them (`CONTEXT.md`, `docs/adr/`).
+
+## Style conventions (do not nitpick beyond these)
+
+- `m_camelCase` members, `camelCase()` functions, `s_` structs, `e` enums,
+  `c`-prefixed class files.
+- `if`/`else` bodies always multi-line braced; never one-liners.
+- Compare `std::optional<T>` directly to `T`; no needless dereference.
+- `cAbstractStructure` id via `getStructureId()`, never `.id` / `.getId()`.
+- Comments explain *why* when non-obvious; no placeholder or narration comments.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,56 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude-review:
+    # Run automatically on every PR push, OR when someone comments "@claude" on a PR/issue
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Only used for the automatic pull_request trigger; ignored when
+          # someone explicitly invokes @claude with their own instructions.
+          prompt: |
+            Before reviewing, read and follow the guidelines in .claude/review.md
+            at the root of this repository — treat it as the primary review
+            checklist. Also respect any conventions defined in CLAUDE.md and
+            elsewhere under .claude/ (coding standards, allowed patterns, etc.);
+            those take precedence over your own defaults if they conflict.
+
+            Then review this pull request to the Dune II - The Maker (D2TM)
+            codebase, a C++ real-time strategy game engine (a Dune II remake).
+
+            If review.md doesn't cover something, fall back to general good
+            judgment on:
+            - Memory safety and resource management (raw pointers, ownership, leaks)
+            - Correctness of game logic changes (units, structures, AI, pathfinding, map/terrain)
+            - Performance implications for the game loop / rendering / update code
+            - Consistency with existing code style and structures in this codebase
+            - Any changes that could break the build or existing CI
+
+            Leave inline comments on specific lines where relevant, and a short
+            summary comment overall. Be direct about problems, but don't nitpick
+            pure style preferences that don't affect correctness or readability.
+          claude_args: |
+            --max-turns 8


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs a Claude Code review on every pull request (opened / synchronize / reopened) and on demand when someone comments `@claude` on a PR or issue.

## Files

- `.github/workflows/claude-code-review.yml` — the workflow. Uses `anthropics/claude-code-action@v1`, authenticated via the `CLAUDE_CODE_OAUTH_TOKEN` repo secret. Capped at `--max-turns 8`.
- `.claude/review.md` — the review checklist the workflow points Claude at as the primary guide: memory safety / resource management, ownership and object lifetime in the pooled `cUnit` / `cAbstractStructure` / `bullet` / `cParticle` arrays, game-loop performance across the `thinkFast` / `thinkNormal` / `thinkSlow` ticks, pathfinding and AI correctness, map/unit/structure invariants, and build/CI stability. It also defers to `CLAUDE.md` and `.claude/rules/` for coding conventions.

## Setup still required

- Add a `CLAUDE_CODE_OAUTH_TOKEN` secret to the repository (the `/install-github-app` flow that normally does this failed locally due to a missing `workflow` scope on the gh token).