### PR TITLE
Claude PR review reliably posts its results

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,6 +29,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Maintain a progress comment on the PR and wire up the GitHub
+          # comment tools so the review is reliably posted back.
+          track_progress: true
+          # Temporary while validating the workflow; remove once reviews land.
+          show_full_output: true
           # Only used for the automatic pull_request trigger; ignored when
           # someone explicitly invokes @claude with their own instructions.
           prompt: |
@@ -53,4 +58,4 @@ jobs:
             summary comment overall. Be direct about problems, but don't nitpick
             pure style preferences that don't affect correctness or readability.
           claude_args: |
-            --max-turns 8
+            --max-turns 30


### PR DESCRIPTION
Follow-up to the Claude Code review workflow (merged in #1432). The first automated run on #1421 finished with `success` but posted no review at all.

## Cause

- `--max-turns 8` was too low. The run used 7 of 8 turns in 23 seconds and stopped before it could post anything. Reading `.claude/review.md`, `CLAUDE.md`, and `.claude/rules/`, fetching the diff, reading the changed files, then posting inline comments plus a summary needs far more than 8 turns.
- Without `track_progress`, the action does not maintain a PR comment or guarantee the GitHub comment tooling is wired up, so a summary only appears if Claude reaches that step on its own.

## Changes

- `--max-turns 8` -> `--max-turns 30`
- `track_progress: true` so the action keeps a progress comment on the PR and sets up the comment tools
- `show_full_output: true` temporarily, so the next run's Claude output is visible in the Actions log for debugging. Remove once reviews are landing.