### PR TITLE
Claude review runs on PR open/ready and on request, not every push

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,15 +2,24 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, ready_for_review]
   issue_comment:
     types: [created]
 
+# One in-flight review per PR; a newer push cancels the older run instead of
+# stacking. Reviews draw from the shared Claude subscription rate limit, so
+# avoiding pile-ups matters.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
-    # Run automatically on every PR push, OR when someone comments "@claude" on a PR/issue
+    # Run automatically when a PR is opened / reopened / marked ready (drafts are
+    # skipped), OR when someone comments "@claude" on a PR/issue. Re-review after
+    # a push is opt-in via an "@claude" comment, to stay within the rate limit.
     if: >
-      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Why

The `claude-review` workflow ran on `pull_request: synchronize`, so every push to any open PR triggered a full review, drafts included. Those reviews authenticate with `CLAUDE_CODE_OAUTH_TOKEN` and draw from the shared Claude subscription rate limit (5-hour window + weekly cap) alongside interactive usage. A rebase-and-force-push loop on a single PR exhausted the 5-hour window and left `claude-review` failing on rate limits.

## Changes

- **Triggers:** `synchronize` replaced with `ready_for_review`. Reviews now run on `opened`, `reopened`, `ready_for_review`, or an `@claude` comment. Re-review after a push is opt-in via `@claude`.
- **Drafts skipped:** `if:` now requires `github.event.pull_request.draft == false`, so draft PRs do not consume budget until marked ready.
- **Concurrency guard:** one in-flight review per PR (`group: claude-review-<number>`, `cancel-in-progress: true`); a newer event cancels the older run instead of stacking.

## Not changed

`track_progress` and `show_full_output` are untouched.