### PR TITLE
Claude review gets git-diff tools and a wider turn budget

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -70,4 +70,5 @@ jobs:
             specific lines. Be direct about problems, but don't nitpick pure
             style preferences that don't affect correctness or readability.
           claude_args: |
-            --max-turns 30
+            --max-turns 45
+            --allowedTools "Bash(git diff:*),Bash(git fetch:*),Bash(git log:*)"


### PR DESCRIPTION
## Why

Run [33098309245](https://github.com/stefanhendriks/Dune-II---The-Maker/actions/runs/33098309245) (review of PR #1417) failed with:

```
Claude reported a successful result after 33 turns, exceeding the configured maximum of 30
Process completed with exit code 1
```

The review itself completed and posted a clean verdict; the job still failed because it overran `--max-turns 30`. It ran long because it tried `git fetch origin master` to get the diff base, which was not in the action's allowed tools, got repeated `This command requires approval` denials, and fell back to reading the changed files one by one to reconstruct the diff.

## Changes

- `--allowedTools "Bash(git diff:*),Bash(git fetch:*),Bash(git log:*)"` so the review can pull the diff in one step instead of reading files individually.
- `--max-turns` 30 -> 45 for headroom on larger PRs.

Follow-up to #1434. `track_progress` is kept as-is (it is the mechanism that posts the review back).