### PR TITLE
Manual build accepts a tag input again by targeting its commit

### DIFF
--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -33,6 +33,9 @@ jobs:
           else
             echo "tag=$INPUT" >> $GITHUB_OUTPUT
           fi
+          # --target must be a branch or commit SHA; a tag name is rejected.
+          # The checkout above resolved inputs.tag, so use the checked-out commit.
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           echo "date=$(date -u +'%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
       - name: Create release
         run: |
@@ -43,7 +46,7 @@ jobs:
               --title "Manual Build - ${DATE}" \
               --notes "Manual build from ${{ inputs.tag }}" \
               --latest=false \
-              --target "${{ inputs.tag }}"
+              --target "${{ steps.resolve.outputs.sha }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -249,6 +252,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Delete manual releases older than 30 days
         run: |
           CUTOFF=$(date -d '30 days ago' --utc +%Y-%m-%dT%H:%M:%SZ)


### PR DESCRIPTION
## Problem

Dispatching `build_manual.yml` with a tag name (e.g. `v0.8.5-rc1`) fails in the `Create release` step:

```
HTTP 422: Validation Failed
Release.target_commitish is invalid
```

`gh release create` is called with `--target "${{ inputs.tag }}"`. `--target` sets `target_commitish`, which GitHub requires to be a branch name or commit SHA. A tag ref is rejected.

## Why it used to work

Before `34454b42` (2026-04-20, "Fix manual build: support SHA input, auto-create tag"), the release was created per-platform with `gh release create "$TAG" ... --latest=false 2>/dev/null || true` and **no `--target`** — so a tag input just attached a release to the existing tag. That commit consolidated release creation into the `Prepare` job and added `--target "${{ inputs.tag }}"` so a raw commit SHA could be auto-tagged. The flag is applied unconditionally, which broke the tag path. Every manual build since then used a SHA input, so it went unnoticed until `v0.8.5-rc1`.

## Fix

- `Prepare` job resolves the checked-out ref to its commit (`git rev-parse HEAD`) and passes that SHA to `--target`. Valid for tag, branch, and SHA inputs alike. When the tag already exists, GitHub ignores `target_commitish` anyway.
- Added a checkout to the `Cleanup` job. `gh release delete --cleanup-tag` shells out to git and failed with `fatal: not a git repository` whenever there was an old `manual-*` release to prune (it has no checkout of its own).