### PR TITLE
Release build maintains the wiki sidebar with a Releases list

### DIFF
--- a/.github/wiki/_Sidebar.header.md
+++ b/.github/wiki/_Sidebar.header.md
@@ -1,0 +1,11 @@
+<!--
+  Fixed part of the wiki sidebar. The release build (build_manual.yml, official
+  mode) copies this to the wiki as _Sidebar.md and appends a "Releases" list
+  built from the v*.md pages. Edit this file to change the non-release links.
+-->
+- [Home](Home)
+- [Controls](Controls)
+- [Settings](Settings)
+- [Startup parameters](Startup-parameters)
+- [FAQ](FAQ)
+- [How to create a release](How-to-create-a-release)

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -99,16 +99,32 @@ jobs:
           > temp_release_notes/${{ inputs.tag }}.md
             ${{ steps.notes.outputs.release-notes }}
           EOF
-      - name: Write changelog to wiki page
+      - name: Publish changelog and sidebar to wiki
         if: ${{ inputs.official }}
-        uses: docker://decathlon/wiki-page-creator-action:2.0.2
         env:
           GH_PAT: ${{ secrets.GH_PAT_D2TM }}
-          ACTION_MAIL: stefan@fundynamic.com
-          ACTION_NAME: stefanhendriks
-          OWNER: stefanhendriks
-          REPO_NAME: Dune-II---The-Maker
-          MD_FOLDER: temp_release_notes
+        run: |
+          set -euo pipefail
+          git clone "https://x-access-token:${GH_PAT}@github.com/${{ github.repository }}.wiki.git" wiki
+          cd wiki
+
+          # changelog page for this release
+          cp "${{ github.workspace }}/temp_release_notes/${{ inputs.tag }}.md" "${{ inputs.tag }}.md"
+
+          # regenerate _Sidebar.md: fixed header + Releases list, newest first
+          cp "${{ github.workspace }}/.github/wiki/_Sidebar.header.md" _Sidebar.md
+          {
+            echo
+            echo "### Releases"
+            ls -1 | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+\.md$' | sed 's/\.md$//' | sort -Vr \
+              | while read -r page; do echo "- [${page}](${page})"; done
+          } >> _Sidebar.md
+
+          git config user.name "stefanhendriks"
+          git config user.email "stefan@fundynamic.com"
+          git add "${{ inputs.tag }}.md" _Sidebar.md
+          git diff --cached --quiet || git commit -m "Release notes for ${{ inputs.tag }}"
+          git push
       - name: Create release
         run: |
           TAG="${{ steps.resolve.outputs.tag }}"


### PR DESCRIPTION
Follow-up to #1438.

## Change

The official release path (`build_manual.yml`, `official` checked) publishes the changelog to the wiki. This swaps the `decathlon/wiki-page-creator-action` Docker action for a plain clone/commit/push that also regenerates `_Sidebar.md`:

- writes `temp_release_notes/<tag>.md` -> wiki page `<tag>` (unchanged behaviour)
- rebuilds `_Sidebar.md` = `.github/wiki/_Sidebar.header.md` (fixed non-release links, version-controlled here) + a `### Releases` list generated from the wiki's `vX.Y.Z.md` pages, `sort -Vr` so newest is first

So every official release adds its own entry to the wiki sidebar. Once `_Sidebar.md` exists, GitHub shows it instead of the auto flat page list; pages not in the header template are still reachable via the wiki "Pages" button.

Non-official (`manual-*`) builds never touch the wiki, so RC runs don't rewrite the sidebar.

## Notes

- To change the non-release sidebar links, edit `.github/wiki/_Sidebar.header.md`.
- I'll seed `_Sidebar.md` on the wiki by hand once this merges, so it's populated before the next official release rather than only appearing at v0.8.5 final.
- `_Sidebar.header.md` must be present in the checked-out release tag; that holds for any tag cut from master after this merges.