### PR TITLE
Bugfix/window letterbox black bars ?

### DIFF
--- a/src/game/cGame_logic.cpp
+++ b/src/game/cGame_logic.cpp
@@ -618,7 +618,7 @@ bool cGame::setupGame()
     }
     Logger::info(COMP_INIT, "Initializing Key Bindings", "Loaded from [KEYS] section");
 
-    m_Screen = std::make_unique<cSDLSystem>(m_gameSettings->m_screenW, m_gameSettings->m_screenH, title);
+    m_Screen = std::make_unique<cSDLSystem>(m_gameSettings->m_screenW, m_gameSettings->m_screenH, title, m_windowed);
     if (!m_windowed) {
         m_Screen->setFullScreenMode();
     }

--- a/src/game/cSDLSystem.cpp
+++ b/src/game/cSDLSystem.cpp
@@ -8,16 +8,23 @@
 #include <format>
 #include <stdexcept>
 
+#include <algorithm>
 #include <array>
 #include "include/cAssert.h"
 #include <optional>
 #include <span>
 #include <vector>
 
+// smallest coordinate space the game UI is laid out for
+static constexpr int MIN_RENDER_WIDTH = 800;
+static constexpr int MIN_RENDER_HEIGHT = 600;
+
 void cSDLSystem::applyFullscreenPresentation()
 {
     int renderW, renderH;
-    SDL_GetCurrentRenderOutputSize(renderer, &renderW, &renderH);
+    // GetRenderOutputSize gives the true screen size; GetCurrentRenderOutputSize would be adjusted
+    // by the logical presentation already in effect, and always report a scale of 1.
+    SDL_GetRenderOutputSize(renderer, &renderW, &renderH);
 
     // Always INTEGER_SCALE: every game pixel maps to the same-sized block on
     // screen (1x, 2x, 3x ...). If the screen is larger than an exact multiple,
@@ -77,15 +84,87 @@ void cSDLSystem::getWindowResolution()
         windowResolution.width = bounds.w;
         windowResolution.height = bounds.h;
     }
+
+    // The area the desktop actually leaves free: the full bounds minus the taskbar, dock or menu
+    // bar. A window asking for more than this gets shrunk by the desktop, and then no longer
+    // matches the render resolution. Fall back to the full bounds when the platform has no notion
+    // of a usable area.
+    usableResolution = windowResolution;
+    SDL_Rect usableBounds = {};
+    if (SDL_GetDisplayUsableBounds(SDL_GetPrimaryDisplay(), &usableBounds)) {
+        Logger::info(COMP_SDL2, "desktop", "Usable bounds : {}x{}", usableBounds.w, usableBounds.h);
+        usableResolution.width = usableBounds.w;
+        usableResolution.height = usableBounds.h;
+    }
+}
+
+/**
+ * Shrink the render resolution until the window fits in the usable desktop area, keeping the
+ * aspect ratio intact. Without this the desktop resizes the window for us, which changes the
+ * aspect ratio and makes SDL letterbox the game with black bars.
+ */
+void cSDLSystem::fitToUsableBounds()
+{
+    if (usableResolution.width < MIN_RENDER_WIDTH || usableResolution.height < MIN_RENDER_HEIGHT) {
+        return; // desktop too small to honour, keep what we have
+    }
+
+    if (renderResolution.width <= usableResolution.width &&
+            renderResolution.height <= usableResolution.height) {
+        return; // already fits
+    }
+
+    int fittedWidth = std::min(renderResolution.width, usableResolution.width);
+    int fittedHeight = renderResolution.height * fittedWidth / renderResolution.width;
+
+    if (fittedHeight > usableResolution.height) {
+        fittedHeight = usableResolution.height;
+        fittedWidth = renderResolution.width * fittedHeight / renderResolution.height;
+    }
+
+    renderResolution.width = std::max(fittedWidth, MIN_RENDER_WIDTH);
+    renderResolution.height = std::max(fittedHeight, MIN_RENDER_HEIGHT);
+}
+
+/**
+ * The desktop can hand us a smaller client area than we asked for (a title bar that has to fit on
+ * screen, a tiled or maximised window). SDL then letterboxes the render resolution inside it,
+ * which shows up as black bars and a wrong aspect ratio. Adopt the size we really got instead:
+ * the game reads Width()/Height() right after this constructor, so the whole UI follows along.
+ */
+void cSDLSystem::syncRenderResolutionToWindow()
+{
+    SDL_SyncWindow(window);
+
+    int outputWidth = 0;
+    int outputHeight = 0;
+    // GetRenderOutputSize, not GetCurrentRenderOutputSize: the latter is adjusted by the logical
+    // presentation, which would just hand back the render resolution we are trying to check.
+    if (!SDL_GetRenderOutputSize(renderer, &outputWidth, &outputHeight)) return;
+
+    if (outputWidth == renderResolution.width && outputHeight == renderResolution.height) return;
+
+    if (outputWidth < MIN_RENDER_WIDTH || outputHeight < MIN_RENDER_HEIGHT) {
+        // below what the UI is laid out for: keep the render resolution and let SDL letterbox
+        Logger::info(COMP_SDL2, "Resolution", "Window is {}x{}, too small to adopt, letterboxing",
+                     outputWidth, outputHeight);
+        return;
+    }
+
+    Logger::info(COMP_SDL2, "Resolution", "Desktop gave us {}x{} instead of {}x{}, adopting it",
+                 outputWidth, outputHeight, renderResolution.width, renderResolution.height);
+
+    renderResolution.width = outputWidth;
+    renderResolution.height = outputHeight;
 }
 
 void cSDLSystem::adaptResolution(int desiredWidth, int desiredHeight)
 {
     Logger::info(COMP_SDL2, "Resolution", "Desired : {}x{}", desiredWidth, desiredHeight);
-    if (desiredWidth<800)
-        desiredWidth = 800;
-    if (desiredHeight<600)
-        desiredHeight = 600;
+    if (desiredWidth<MIN_RENDER_WIDTH)
+        desiredWidth = MIN_RENDER_WIDTH;
+    if (desiredHeight<MIN_RENDER_HEIGHT)
+        desiredHeight = MIN_RENDER_HEIGHT;
 
     int tmpWidth =  windowResolution.width * desiredHeight / windowResolution.height;
     if (tmpWidth > desiredWidth) {
@@ -103,6 +182,8 @@ void cSDLSystem::adaptResolution(int desiredWidth, int desiredHeight)
     // the game at 1:1 or larger integer multiples.
     renderResolution.width = std::min(renderResolution.width, windowResolution.width);
     renderResolution.height = std::min(renderResolution.height, windowResolution.height);
+
+    fitToUsableBounds();
 
     Logger::info(COMP_SDL2, "Resolution", "Adopted : {}x{}", renderResolution.width, renderResolution.height);
 }
@@ -196,5 +277,6 @@ cSDLSystem::cSDLSystem(int desiredWidth, int desiredHeight, const std::string &t
     SDL_SetWindowFullscreen(window, false);
     SDL_SetWindowSize(window, renderResolution.width, renderResolution.height);
     SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+    syncRenderResolutionToWindow();
     SDL_SetRenderLogicalPresentation(renderer, renderResolution.width, renderResolution.height, SDL_LOGICAL_PRESENTATION_LETTERBOX);
 }

--- a/src/game/cSDLSystem.cpp
+++ b/src/game/cSDLSystem.cpp
@@ -26,20 +26,23 @@ void cSDLSystem::applyFullscreenPresentation()
     // by the logical presentation already in effect, and always report a scale of 1.
     SDL_GetRenderOutputSize(renderer, &renderW, &renderH);
 
-    // Always INTEGER_SCALE: every game pixel maps to the same-sized block on
-    // screen (1x, 2x, 3x ...). If the screen is larger than an exact multiple,
-    // the remainder appears as black borders. This avoids fractional scaling
-    // (LETTERBOX at e.g. 1.167x) which produces jagged, uneven pixels even
-    // with nearest-neighbour filtering. renderResolution is already capped to
-    // the logical screen size in adaptResolution, so the scale is always >= 1.
-    int intScale = std::min(renderW / renderResolution.width, renderH / renderResolution.height);
+    // LETTERBOX, not INTEGER_SCALE: fullscreen has to fill the screen. INTEGER_SCALE only allows
+    // whole factors (1x, 2x, 3x ...), so playing at 1280x720 on a 1920x1080 screen is stuck at 1x
+    // and leaves the game as a small rectangle in a black frame - a 1.5x scale is exactly what is
+    // needed there. adaptResolution gives renderResolution the aspect ratio of the display, so
+    // LETTERBOX fills the screen edge to edge instead of adding bars.
+    // The price is that at a fractional scale the game pixels are no longer all the same size
+    // (at 1.5x, one game pixel covers 1 or 2 screen pixels). That is the behaviour players had
+    // before, and it beats losing most of the screen.
+    float scaleToFillScreen = std::min((float)renderW / (float)renderResolution.width,
+                                       (float)renderH / (float)renderResolution.height);
 
-    SDL_SetRenderLogicalPresentation(renderer, renderResolution.width, renderResolution.height, SDL_LOGICAL_PRESENTATION_INTEGER_SCALE);
+    SDL_SetRenderLogicalPresentation(renderer, renderResolution.width, renderResolution.height, SDL_LOGICAL_PRESENTATION_LETTERBOX);
     SDL_RenderClear(renderer);
     SDL_RenderPresent(renderer);
 
     Logger::info(COMP_SDL2, "desktop", "Renderer output size : {}x{}", renderW, renderH);
-    Logger::info(COMP_SDL2, "desktop", "Presentation mode : INTEGER_SCALE (integer scale = {})", intScale);
+    Logger::info(COMP_SDL2, "desktop", "Presentation mode : LETTERBOX (scale = {})", scaleToFillScreen);
     float scale = SDL_GetDisplayContentScale(SDL_GetPrimaryDisplay());
     Logger::info(COMP_SDL2, "DPI", "Display content scale : {}", scale);
 }
@@ -158,7 +161,7 @@ void cSDLSystem::syncRenderResolutionToWindow()
     renderResolution.height = outputHeight;
 }
 
-void cSDLSystem::adaptResolution(int desiredWidth, int desiredHeight)
+void cSDLSystem::adaptResolution(int desiredWidth, int desiredHeight, bool windowed)
 {
     Logger::info(COMP_SDL2, "Resolution", "Desired : {}x{}", desiredWidth, desiredHeight);
     if (desiredWidth<MIN_RENDER_WIDTH)
@@ -183,7 +186,12 @@ void cSDLSystem::adaptResolution(int desiredWidth, int desiredHeight)
     renderResolution.width = std::min(renderResolution.width, windowResolution.width);
     renderResolution.height = std::min(renderResolution.height, windowResolution.height);
 
-    fitToUsableBounds();
+    // Only a real window has to share the desktop with a taskbar and a title bar. In fullscreen the
+    // resolution must stay untouched, otherwise a player asking for the exact size of their screen
+    // would lose the perfect 1:1 scale.
+    if (windowed) {
+        fitToUsableBounds();
+    }
 
     Logger::info(COMP_SDL2, "Resolution", "Adopted : {}x{}", renderResolution.width, renderResolution.height);
 }
@@ -203,7 +211,7 @@ cSDLSystem::~cSDLSystem()
     Logger::info(COMP_SDL2, "SDL shutdown", "Thanks for playing!");
 }
 
-cSDLSystem::cSDLSystem(int desiredWidth, int desiredHeight, const std::string &title)
+cSDLSystem::cSDLSystem(int desiredWidth, int desiredHeight, const std::string &title, bool windowed)
 {
     Logger::info(COMP_SDL2, "cSDLSystem", "=== SDL ===");
 
@@ -234,7 +242,7 @@ cSDLSystem::cSDLSystem(int desiredWidth, int desiredHeight, const std::string &t
     }
 
     this->getWindowResolution();
-    this->adaptResolution(desiredWidth, desiredHeight);
+    this->adaptResolution(desiredWidth, desiredHeight, windowed);
 
     // Disable macOS Spaces fullscreen: SDL3 defaults to Spaces (animated
     // Space transition), which changes the renderer output to logical pixels
@@ -277,6 +285,10 @@ cSDLSystem::cSDLSystem(int desiredWidth, int desiredHeight, const std::string &t
     SDL_SetWindowFullscreen(window, false);
     SDL_SetWindowSize(window, renderResolution.width, renderResolution.height);
     SDL_SetWindowPosition(window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-    syncRenderResolutionToWindow();
+    if (windowed) {
+        // Only when we stay windowed: the caller switches to fullscreen right after this, and the
+        // render resolution must not be pinned to the size of this temporary window.
+        syncRenderResolutionToWindow();
+    }
     SDL_SetRenderLogicalPresentation(renderer, renderResolution.width, renderResolution.height, SDL_LOGICAL_PRESENTATION_LETTERBOX);
 }

--- a/src/game/cSDLSystem.h
+++ b/src/game/cSDLSystem.h
@@ -11,7 +11,7 @@ struct DisplayResolution {
 class cSDLSystem {
 public:
     // Initializes SDL, creates a window and renderer with the given resolution
-    cSDLSystem(int desiredWidth, int desiredHeight, const std::string &title);
+    cSDLSystem(int desiredWidth, int desiredHeight, const std::string &title, bool windowed);
     ~cSDLSystem();
 
     void setFullScreenMode();
@@ -40,7 +40,7 @@ public:
 
 private:
     void getWindowResolution();
-    void adaptResolution(int desiredWidth, int desiredHeight);
+    void adaptResolution(int desiredWidth, int desiredHeight, bool windowed);
     void fitToUsableBounds();
     void syncRenderResolutionToWindow();
     void applyFullscreenPresentation();

--- a/src/game/cSDLSystem.h
+++ b/src/game/cSDLSystem.h
@@ -41,9 +41,12 @@ public:
 private:
     void getWindowResolution();
     void adaptResolution(int desiredWidth, int desiredHeight);
+    void fitToUsableBounds();
+    void syncRenderResolutionToWindow();
     void applyFullscreenPresentation();
     DisplayResolution renderResolution;
     DisplayResolution windowResolution; //display size of screen
+    DisplayResolution usableResolution; //display size minus taskbar/dock/menu bar
     SDL_Window *window = nullptr;
     SDL_Renderer *renderer = nullptr;
 };


### PR DESCRIPTION
Try to fix the issue from kilo525
> "Oh I forgot to ask, how to make it so that lower resolutions still display to the full screen? I used to be able to play 1280x720 fullscreen just fine in the previous version, but when I do it now it doesn't scale to my actual monitor so the game is just a rectangle surrounded by black in the middle of my screen"

## **Goal**

Change SDL3 migration format to original SDL2 LETTERBOX  that were converted to INTEGER_SCALE to be able to zoom in fractional factor

### Changes
- restore letterbox behavior

## Testing Steps
- no test, i didn't have the correct OS
