### PR TITLE
Claude review no longer cancels itself via its own progress comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,11 +6,12 @@ on:
   issue_comment:
     types: [created]
 
-# One in-flight review per PR; a newer push cancels the older run instead of
-# stacking. Reviews draw from the shared Claude subscription rate limit, so
-# avoiding pile-ups matters.
+# One in-flight review per PR per trigger kind; a newer push cancels the older
+# run instead of stacking. The event kind is part of the key so that the
+# progress comment posted by track_progress (an issue_comment event) does not
+# land in the same group as the pull_request review and cancel it.
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Symptom

Every recent PR shows the same pair in the Actions list: the `pull_request` claude-review run is **cancelled** ~1 minute in ("Canceling since a higher priority waiting request for claude-review-<N> exists"), followed by an `issue_comment` run that is **skipped**. The review never posts.

## Cause

The `concurrency` group (added in #1434) was `claude-review-<PR number>`, shared across both triggers with `cancel-in-progress: true`.

1. PR opens -> `pull_request` run starts the review in group `claude-review-1440`.
2. `track_progress: true` makes the action post its "Claude is reviewing this PR…" progress comment.
3. That comment fires `issue_comment: created` -> a new run queues in the **same** group.
4. `cancel-in-progress` kills the running review.
5. The new run hits the `if:` guard (`contains(comment.body, '@claude')`), the progress comment has none -> skipped.

Concurrency is evaluated before the job `if:`, so a run destined to be skipped still grabs the group and cancels the in-flight review.

## Fix

Add `github.event_name` to the group key:

```
group: claude-review-<number>-${{ github.event_name }}
```

`pull_request` and `issue_comment` runs now live in separate groups. Pushes still cancel older pushes; `@claude` comments still cancel older `@claude` comments; the progress comment can't touch the review's group.